### PR TITLE
docs: expand graphify coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ Rig installs guardrails into a Claude Code project:
   advises on native Read/Grep/Glob when jcodemunch is indexed; blocks `sed -i` and `rtk cat` on code files
 - **Enforcement Pipeline** -- PostToolUse hooks check stale tests, test scope, constitutional rules (real dependencies in stack/E2E tests), and zero-defect status (with pre-existing failure classification)
 - **Skill Chain** -- ordered workflow skills: `brain+` -> `plan+` -> `tdd+` -> `verify+` -> `review+`, plus standalone `investigate` and `savings`
-- **Scout Agent** -- cross-repo indexing agent that builds a typed `CodebaseMap` for context injection, enriched with graphify relationship data (god nodes, module communities, dependency paths) when available
+- **Scout Agent** -- cross-repo indexing agent that builds a typed `CodebaseMap`
+  for context injection, enriched with graphify relationship data (god nodes,
+  module communities, dependency paths) when available
 
 Built from the [agentic-patterns](https://github.com/franklywatson/agentic-patterns) L2-L4 patterns.
 
@@ -22,7 +24,10 @@ Built from the [agentic-patterns](https://github.com/franklywatson/agentic-patte
 - [superpowers](https://github.com/obra/superpowers) -- base skills framework (required; all skill chain skills wrap `superpowers:*` skills)
 - [rtk](https://github.com/franklywatson/rtk) -- token-optimized command proxy (strongly recommended; tool router redirects `grep`/`find`/`cat` through rtk when available)
 - [jcodemunch](https://github.com/franklywatson/jcodemunch) -- indexed code search MCP server (strongly recommended; powers the scout agent and tool router fallback)
-- [graphify](https://github.com/safishamsi/graphify) -- knowledge graph builder (recommended; auto-builds graphs at session start and provides god nodes, module communities, and dependency path queries that complement jcodemunch's symbol search)
+- [graphify](https://github.com/safishamsi/graphify) -- knowledge graph builder
+  (recommended; auto-builds graphs at session start and provides god nodes,
+  module communities, and dependency path queries that complement jcodemunch's
+  symbol search)
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Rig installs guardrails into a Claude Code project:
   advises on native Read/Grep/Glob when jcodemunch is indexed; blocks `sed -i` and `rtk cat` on code files
 - **Enforcement Pipeline** -- PostToolUse hooks check stale tests, test scope, constitutional rules (real dependencies in stack/E2E tests), and zero-defect status (with pre-existing failure classification)
 - **Skill Chain** -- ordered workflow skills: `brain+` -> `plan+` -> `tdd+` -> `verify+` -> `review+`, plus standalone `investigate` and `savings`
-- **Scout Agent** -- cross-repo indexing agent that builds a typed `CodebaseMap` for context injection, enriched with graphify relationship data when available
+- **Scout Agent** -- cross-repo indexing agent that builds a typed `CodebaseMap` for context injection, enriched with graphify relationship data (god nodes, module communities, dependency paths) when available
 
 Built from the [agentic-patterns](https://github.com/franklywatson/agentic-patterns) L2-L4 patterns.
 
@@ -22,7 +22,7 @@ Built from the [agentic-patterns](https://github.com/franklywatson/agentic-patte
 - [superpowers](https://github.com/obra/superpowers) -- base skills framework (required; all skill chain skills wrap `superpowers:*` skills)
 - [rtk](https://github.com/franklywatson/rtk) -- token-optimized command proxy (strongly recommended; tool router redirects `grep`/`find`/`cat` through rtk when available)
 - [jcodemunch](https://github.com/franklywatson/jcodemunch) -- indexed code search MCP server (strongly recommended; powers the scout agent and tool router fallback)
-- [graphify](https://github.com/safishamsi/graphify) -- knowledge graph builder (recommended; powers scout agent's relationship traversal alongside jcodemunch)
+- [graphify](https://github.com/safishamsi/graphify) -- knowledge graph builder (recommended; auto-builds graphs at session start and provides god nodes, module communities, and dependency path queries that complement jcodemunch's symbol search)
 
 ## Quick start
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -267,6 +267,7 @@ structure.
 
 **Graph MCP tools** — session-start emits available graphify MCP tools for the
 agent to use directly:
+
 - `mcp__graphify__query_graph` — relationship queries between symbols
 - `mcp__graphify__god_nodes` — core abstractions ranked by connection density
 - `mcp__graphify__get_community` — module clustering for a specific community

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -250,6 +250,39 @@ Formatted as structured context for the agent
 **Graphify** provides relationship traversal (communities, dependency paths, god nodes).
 They're complementary — jcodemunch answers "what exists?" and graphify answers "how do things connect?".
 
+### Graphify integration
+
+When graphify is installed, the scout agent and session-start hook gain three
+additional capabilities:
+
+**God nodes** — high-degree nodes in the knowledge graph, representing core
+abstractions that many other modules depend on. These surface the most
+architecturally important symbols in the codebase (e.g., a shared config module
+or a base class that many components extend).
+
+**Communities** — clustered groups of related nodes detected by graphify's
+community detection algorithm. Each community represents a logical module or
+subsystem, providing a higher-level view of code organization beyond directory
+structure.
+
+**Graph MCP tools** — session-start emits available graphify MCP tools for the
+agent to use directly:
+- `mcp__graphify__query_graph` — relationship queries between symbols
+- `mcp__graphify__god_nodes` — core abstractions ranked by connection density
+- `mcp__graphify__get_community` — module clustering for a specific community
+- `mcp__graphify__shortest_path` — dependency path between two symbols
+
+**Auto-building:** `ensureGraphBuilt()` automatically runs `graphify update
+<directory>` when no graph exists for a directory. This happens for both the
+main project and external directories referenced during cross-repo indexing.
+If graphify is not installed, the scout agent falls back to jcodemunch-only
+analysis (symbol search without relationship data).
+
+**Confidence levels:** Graph edges carry confidence labels — `EXTRACTED`
+(verified by AST analysis), `INFERRED` (heuristic), `AMBIGUOUS`. Session-start
+reports these percentages (e.g., "90% EXTRACTED, 10% INFERRED") so agents can
+gauge graph reliability.
+
 **Cross-repo support:** `ensureIndexed()` indexes external directories on first
 reference. `ensureGraphBuilt()` auto-builds graphify knowledge graphs for external
 directories (runs `graphify update <dir>` if `<dir>/graphify-out/graph.json` doesn't

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,10 +22,14 @@ Strongly recommended:
   larger projects, increase `max_folder_files` in `~/.code-index/config.jsonc`.
   Rig emits a `[WARNING]` at session start when files are skipped.
 - [graphify](https://github.com/safishamsi/graphify) -- knowledge graph builder.
-  Powers the scout agent's relationship traversal (communities, dependency paths,
-  god nodes) alongside jcodemunch's symbol search. Graphify rebuilds via its own
-  git hooks; rig detects the existing graph. Note: graphify may fail on very
-  large codebases (6000+ files) due to Python AST recursion limits.
+  Powers the scout agent's relationship traversal alongside jcodemunch's symbol
+  search. When installed, rig auto-builds graphs at session start and provides
+  god nodes (core abstractions ranked by connection density), module communities
+  (clustered subsystems), and dependency path queries via MCP tools. Graphify
+  rebuilds via its own git hooks; rig detects the existing graph and auto-builds
+  on first use if needed. Note: graphify may fail on very large codebases
+  (6000+ files) due to Python AST recursion limits during tree-sitter traversal.
+  The scout agent falls back to jcodemunch-only analysis in this case.
 
 ## Install and initialize
 


### PR DESCRIPTION
## Summary
- **README**: Graphify description now mentions god nodes, communities, dependency paths, and auto-building at session start
- **architecture.md**: New "Graphify integration" subsection covering god nodes, communities, MCP tools (`query_graph`, `god_nodes`, `get_community`, `shortest_path`), auto-building behavior, and confidence levels (EXTRACTED/INFERRED/AMBIGUOUS)
- **getting-started.md**: Expanded graphify prerequisite with concrete capabilities, auto-build behavior, and fallback when graphify is unavailable

## Test plan
- [x] `npm run lint` passes (no TypeScript changes)
- [x] Doc link integrity check passes
- [x] Markdown lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)