### PR TITLE
docs: add CI build badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # rig
 
+![Tests](https://github.com/franklywatson/claude-rig/actions/workflows/test.yml/badge.svg)
+![Coverage Gate](https://github.com/franklywatson/claude-rig/actions/workflows/coverage.yml/badge.svg)
+![Docs Quality](https://github.com/franklywatson/claude-rig/actions/workflows/docs.yml/badge.svg)
+
 Agent harness that enforces tool routing, skill chains, and multi-agent discipline for [Claude Code](https://claude.ai/code).
 
 ## What it does


### PR DESCRIPTION
## Summary
- Add Tests, Coverage Gate, and Docs Quality badge SVGs to top of README

## Test plan
- [x] Markdown lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)