### PR TITLE
feat: skip rtk rewrite for compound/piped commands

### DIFF
--- a/docs/plans/skip-rtk-rewrite-compound.md
+++ b/docs/plans/skip-rtk-rewrite-compound.md
@@ -4,7 +4,10 @@
 
 ## Problem
 
-When an agent issues a chained command like `ls -la /path/file 2>/dev/null; diff /path/file -`, the PreToolUse hook rewrites it through rtk (e.g., `rtk ls -la ...; diff ...`). This rewritten command is different from the original, requiring user approval because Claude Code treats it as a new command.
+When an agent issues a chained command like `ls -la file; diff file -`, the
+PreToolUse hook rewrites it through rtk (e.g., `rtk ls ...; diff ...`). This
+rewritten command is different from the original, requiring user approval
+because Claude Code treats it as a new command.
 
 ## Solution
 

--- a/docs/plans/skip-rtk-rewrite-compound.md
+++ b/docs/plans/skip-rtk-rewrite-compound.md
@@ -1,5 +1,7 @@
 # Skip rtk Rewrite for Compound/Piped Commands
 
+**Status: COMPLETED** (2026-04-20) — PR #6
+
 ## Problem
 
 When an agent issues a chained command like `ls -la /path/file 2>/dev/null; diff /path/file -`, the PreToolUse hook rewrites it through rtk (e.g., `rtk ls -la ...; diff ...`). This rewritten command is different from the original, requiring user approval because Claude Code treats it as a new command.

--- a/docs/plans/skip-rtk-rewrite-compound.md
+++ b/docs/plans/skip-rtk-rewrite-compound.md
@@ -1,0 +1,75 @@
+# Skip rtk Rewrite for Compound/Piped Commands
+
+## Problem
+
+When an agent issues a chained command like `ls -la /path/file 2>/dev/null; diff /path/file -`, the PreToolUse hook rewrites it through rtk (e.g., `rtk ls -la ...; diff ...`). This rewritten command is different from the original, requiring user approval because Claude Code treats it as a new command.
+
+## Solution
+
+Skip rtk rewriting for compound commands (commands containing `;`, `&&`, `||`, or `|`). Let them pass through as-is. Simple single commands still benefit from rtk token savings.
+
+## Constitutional Rules
+
+- No mocks needed (unit tests with injectable `ExecRewriteFn`)
+- Show test output before claiming done
+- Source + test changes paired
+
+## Mock Policy
+
+Unit tests (mocks ok): `execRewrite` function (injected, standard pattern)
+
+---
+
+### Task 1: Add `isCompoundCommand` helper to intent.ts
+
+**Files:** `src/router/intent.ts`, `tests/router/intent.test.ts`
+**Test strategy:** Unit tests for the helper function — test each operator (`;`, `&&`, `||`, `|`) and negative cases
+**Mock check:** No protected components
+
+- [ ] Step 1: Write failing tests for `isCompoundCommand` in `tests/router/intent.test.ts`
+  - Returns true for `;` separator: `ls file; diff file -`
+  - Returns true for `&&` separator: `git status && git diff`
+  - Returns true for `||` separator: `cmd1 || cmd2`
+  - Returns true for `|` pipe: `cat file | grep pattern`
+  - Returns true for mixed: `cat file | grep foo && ls`
+  - Returns false for simple command: `cat file.ts`
+  - Returns false for `||` inside a string literal: `grep "a||b" file`
+  - Returns false for `&&` inside a string literal: `echo "&&"`
+  - Returns false for redirect `2>/dev/null` (no `|` pipe)
+- [ ] Step 2: Verify tests fail
+- [ ] Step 3: Implement `isCompoundCommand` in `src/router/intent.ts`
+  - Detects `;`, `&&`, `||`, `|` outside of quoted strings
+  - Ignores operators inside single/double quotes and `2>&1` style redirects
+- [ ] Step 4: Verify tests pass
+- [ ] Step 5: Commit
+
+### Task 2: Guard rtk rewrite against compound commands in hook.ts
+
+**Files:** `src/router/hook.ts`, `tests/router/rewrite.test.ts`
+**Test strategy:** Integration tests — verify compound commands pass through without rewrite
+**Mock check:** No protected components (uses injectable `execRewrite`)
+
+- [ ] Step 1: Write failing tests in `tests/router/rewrite.test.ts`
+  - `ls -la /path/file 2>/dev/null; diff /path/file -` returns null (no rewrite, no advise)
+  - `cat file | grep pattern` returns null (no rewrite)
+  - `git status && git diff` returns null (no rewrite)
+  - `grep "TODO" src/ 2>/dev/null || echo "none"` returns null (no rewrite)
+  - Simple `cat file.ts` still gets rtk rewrite (unchanged)
+  - `grep -r "TODO" src/` still gets rtk rewrite (unchanged)
+  - `rg pattern . ; sed -i 's/a/b/g' f` still blocked (file_modify in chain — block fires before rewrite)
+- [ ] Step 2: Verify tests fail
+- [ ] Step 3: Add `isCompoundCommand` guard in `handlePreToolUse` Step 3 (rtk rewrite section)
+  - Import `isCompoundCommand` from intent.ts
+  - Skip `tryRtkRewrite` when command is compound
+- [ ] Step 4: Verify tests pass
+- [ ] Step 5: Commit
+
+### Task 3: Run full test suite and verify no regressions
+
+**Files:** None (verification only)
+**Test strategy:** Full suite run
+**Mock check:** N/A
+
+- [ ] Step 1: Run `npm test` — all 290+ tests pass
+- [ ] Step 2: Run `npm run lint` — no type errors
+- [ ] Step 3: Commit if any adjustments needed

--- a/src/router/hook.ts
+++ b/src/router/hook.ts
@@ -4,6 +4,7 @@ import { SessionCache } from '../session/cache.js';
 import { findMatchingRule, getDefaultRules } from './rules.js';
 import { resolve } from './resolver.js';
 import { tryPythonRewrite } from './python-rewrite.js';
+import { isCompoundCommand } from './intent.js';
 
 export type ExecRewriteFn = (rtkPath: string, args: string[]) => string | null;
 export type ExistsCheckFn = (path: string) => boolean;
@@ -129,9 +130,9 @@ export function handlePreToolUse(
     }
   }
 
-  // Step 3: Transparent rewrite via rtk for Bash commands
+  // Step 3: Transparent rewrite via rtk for Bash commands (skip compound commands)
   if (tool === 'Bash' && typeof args.command === 'string') {
-    if (env.rtkAvailable && env.rtkPath) {
+    if (env.rtkAvailable && env.rtkPath && !isCompoundCommand(args.command)) {
       const rewritten = tryRtkRewrite(args.command, env.rtkPath, resolvedOptions.execRewrite);
       if (rewritten) {
         return { type: 'rewrite', command: rewritten, original: args.command };
@@ -141,6 +142,11 @@ export function handlePreToolUse(
 
   // Step 4: No match = pass through
   if (!match) return null;
+
+  // Step 4b: Compound commands skip advisory (but file_modify still blocks above)
+  if (tool === 'Bash' && typeof args.command === 'string' && isCompoundCommand(args.command)) {
+    return null;
+  }
 
   // Step 5: Enforcement-level blocks and advises
   const resolution = resolve(match, env);

--- a/src/router/intent.ts
+++ b/src/router/intent.ts
@@ -79,6 +79,52 @@ function classifyBashCommand(command: string): IntentType {
   return highest;
 }
 
+/**
+ * Detect shell chaining/piping operators outside of quoted strings.
+ * Matches `;`, `&&`, `||`, and `|` but ignores operators inside
+ * single or double quotes, and ignores redirect tokens like `2>&1`.
+ */
+export function isCompoundCommand(command: string): boolean {
+  let inSingle = false;
+  let inDouble = false;
+  let i = 0;
+
+  while (i < command.length) {
+    const ch = command[i];
+
+    if (ch === '\'' && !inDouble) {
+      inSingle = !inSingle;
+      i++;
+      continue;
+    }
+    if (ch === '"' && !inSingle) {
+      inDouble = !inDouble;
+      i++;
+      continue;
+    }
+
+    if (inSingle || inDouble) {
+      i++;
+      continue;
+    }
+
+    // Check for multi-char operators first
+    if (ch === '&' && command[i + 1] === '&') return true;
+    if (ch === '|' && command[i + 1] === '|') return true;
+
+    // Single-char operators (but | followed by & is 2>&1 redirect, not a pipe)
+    if (ch === ';') return true;
+    if (ch === '|') {
+      // |& is a pipe-and-stderr redirect, still a pipe
+      return true;
+    }
+
+    i++;
+  }
+
+  return false;
+}
+
 export function classifyIntent(tool: string, args: Record<string, unknown>): IntentType {
   // Direct tool mapping
   if (tool === 'Bash' && typeof args.command === 'string') {

--- a/tests/eval/scenarios.ts
+++ b/tests/eval/scenarios.ts
@@ -46,7 +46,6 @@ export const ENV_PRESETS: EnvPreset[] = [
       jcodemunchCwdRepo: 'local/test',
       jcodemunchKnownRepos: ['local/test'],
       graphifyAvailable: true,
-      graphifyGraphPath: 'graphify-out/graph.json',
       graphifyGraphPath: null,
       detectedAt: Date.now(),
     },
@@ -90,7 +89,7 @@ export interface ExpectedOutcome {
 
 export interface EvalScenario {
   id: string;
-  category: 'bash' | 'native' | 'agent' | 'pipe' | 'edge';
+  category: 'bash' | 'native' | 'agent' | 'pipe' | 'edge' | 'python';
   description: string;
   toolCall: { tool: string; args: Record<string, unknown> };
   expected: Record<string, ExpectedOutcome>; // keyed by env preset name
@@ -363,14 +362,14 @@ export const ALL_SCENARIOS: EvalScenario[] = [
   {
     id: 'pipe_cat_grep',
     category: 'pipe',
-    description: 'piped cat | grep — mock rewrites cat (first segment)',
+    description: 'piped cat | grep — compound command passes through without rewrite or advisory',
     toolCall: { tool: 'Bash', args: { command: 'cat file | grep pattern' } },
     expected: {
-      full: { action: 'rewrite', tool: 'rtk read' },
-      rtk_only: { action: 'rewrite', tool: 'rtk read' },
-      jm_only: { action: 'advise', tool: 'jcodemunch' },
-      jm_not_indexed: { action: 'advise', tool: 'Read' },
-      neither: { action: 'advise', tool: 'Read' },
+      full: { action: 'allow' },
+      rtk_only: { action: 'allow' },
+      jm_only: { action: 'allow' },
+      jm_not_indexed: { action: 'allow' },
+      neither: { action: 'allow' },
     },
   },
 

--- a/tests/router/intent.test.ts
+++ b/tests/router/intent.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { classifyIntent, IntentType } from '../../src/router/intent.js';
+import { classifyIntent, isCompoundCommand, type IntentType } from '../../src/router/intent.js';
 
 describe('classifyIntent', () => {
   describe('bash command classification', () => {
@@ -128,6 +128,56 @@ describe('classifyIntent', () => {
 
     it('file_modify wins over file_read in compound command', () => {
       expect(classifyIntent('Bash', { command: "cat file ; sed -i 's/a/b/g' file" })).toBe('file_modify');
+    });
+  });
+
+  describe('isCompoundCommand', () => {
+    it('detects semicolon separator', () => {
+      expect(isCompoundCommand('ls -la /path/file 2>/dev/null; diff /path/file -')).toBe(true);
+    });
+
+    it('detects && separator', () => {
+      expect(isCompoundCommand('git status && git diff')).toBe(true);
+    });
+
+    it('detects || separator', () => {
+      expect(isCompoundCommand('cmd1 || cmd2')).toBe(true);
+    });
+
+    it('detects | pipe', () => {
+      expect(isCompoundCommand('cat file | grep pattern')).toBe(true);
+    });
+
+    it('detects mixed operators', () => {
+      expect(isCompoundCommand('cat file | grep foo && ls')).toBe(true);
+    });
+
+    it('returns false for simple command', () => {
+      expect(isCompoundCommand('cat file.ts')).toBe(false);
+    });
+
+    it('returns false for redirect without pipe', () => {
+      expect(isCompoundCommand('ls -la /path 2>/dev/null')).toBe(false);
+    });
+
+    it('returns false for 2>&1 redirect', () => {
+      expect(isCompoundCommand('docker compose build 2>&1 | grep error')).toBe(true);
+    });
+
+    it('ignores semicolon inside single quotes', () => {
+      expect(isCompoundCommand("grep 'foo;bar' file")).toBe(false);
+    });
+
+    it('ignores pipe inside double quotes', () => {
+      expect(isCompoundCommand('grep "a|b" file')).toBe(false);
+    });
+
+    it('ignores && inside double quotes', () => {
+      expect(isCompoundCommand('echo "run && check"')).toBe(false);
+    });
+
+    it('detects operator outside quotes even when quotes present', () => {
+      expect(isCompoundCommand("echo 'hello' && grep 'world' file")).toBe(true);
     });
   });
 });

--- a/tests/router/rewrite.test.ts
+++ b/tests/router/rewrite.test.ts
@@ -399,21 +399,14 @@ describe('handlePreToolUse: pipe handling', () => {
     detectedAt: Date.now(),
   };
 
-  it('piped command where rtk rewrites first segment', () => {
+  it('piped command skips rtk rewrite and passes through', () => {
     const cache = new SessionCache();
     cache.setEnvironment(ENV_WITH_RTK);
-    // mockRewriteSuccess rewrites "cat file" but not piped content
-    const mockPipedRewrite: ExecRewriteFn = (_rtkPath, args) => {
-      const cmd = args[1];
-      if (cmd.startsWith('cat ')) return cmd.replace(/^cat\s+/, 'rtk read ');
-      return null;
-    };
     const result = handlePreToolUse(
-      'Bash', { command: 'cat file | grep pattern' }, cache, DEFAULT_CONFIG, undefined, mockPipedRewrite,
+      'Bash', { command: 'cat file | grep pattern' }, cache, DEFAULT_CONFIG, undefined, mockRewriteSuccess,
     );
-    expect(result).not.toBeNull();
-    expect((result as RewriteResult).type).toBe('rewrite');
-    expect((result as RewriteResult).command).toContain('rtk read');
+    // Compound commands (with |) pass through without rewrite or advise
+    expect(result).toBeNull();
   });
 
   it('pipelines that rtk skips fall through to allow', () => {
@@ -439,6 +432,42 @@ describe('handlePreToolUse: pipe handling', () => {
     );
     expect(typeof result).toBe('string');
     expect(result).toContain('[BLOCK]');
+  });
+
+  it('chained ls; diff passes through without rtk rewrite', () => {
+    const cache = new SessionCache();
+    cache.setEnvironment(ENV_WITH_RTK);
+    const result = handlePreToolUse(
+      'Bash', { command: 'ls -la /path/file 2>/dev/null; diff /path/file -' }, cache, DEFAULT_CONFIG, undefined, mockRewriteSuccess,
+    );
+    expect(result).toBeNull();
+  });
+
+  it('piped cat | grep passes through without rtk rewrite', () => {
+    const cache = new SessionCache();
+    cache.setEnvironment(ENV_WITH_RTK);
+    const result = handlePreToolUse(
+      'Bash', { command: 'cat file | grep pattern' }, cache, DEFAULT_CONFIG, undefined, mockRewriteSuccess,
+    );
+    expect(result).toBeNull();
+  });
+
+  it('chained git status && git diff passes through without rtk rewrite', () => {
+    const cache = new SessionCache();
+    cache.setEnvironment(ENV_WITH_RTK);
+    const result = handlePreToolUse(
+      'Bash', { command: 'git status && git diff' }, cache, DEFAULT_CONFIG, undefined, mockRewriteSuccess,
+    );
+    expect(result).toBeNull();
+  });
+
+  it('or-chained command passes through without rtk rewrite', () => {
+    const cache = new SessionCache();
+    cache.setEnvironment(ENV_WITH_RTK);
+    const result = handlePreToolUse(
+      'Bash', { command: 'grep "TODO" src/ 2>/dev/null || echo "none"' }, cache, DEFAULT_CONFIG, undefined, mockRewriteSuccess,
+    );
+    expect(result).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

- Commands containing shell chaining operators (`;`, `&&`, `||`, `|`) now pass through the tool router without rtk rewriting or advisory
- This prevents approval prompts that were triggered when rtk rewrote compound commands like `ls -la file; diff file -`, changing the command string
- `file_modify` blocks (e.g., `sed -i`) still fire before the compound check, so destructive operations in chains are still blocked

## Changes

- `src/router/intent.ts` — added `isCompoundCommand()` helper that detects chaining operators outside quoted strings
- `src/router/hook.ts` — compound commands skip rtk rewrite (Step 3) and advisory (Step 4b)
- `tests/router/intent.test.ts` — 12 new tests for `isCompoundCommand`
- `tests/router/rewrite.test.ts` — 4 new pass-through tests + 1 updated existing test
- `tests/eval/scenarios.ts` — updated `pipe_cat_grep` eval + fixed pre-existing TS errors (duplicate property, missing category type)

## Test plan

- [x] All 807 tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)
- [x] Eval suite updated — compound commands excluded from rtk success rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)