### PR TITLE
fix: create graphify graph.json placeholder during rig init

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "PATH=\"/home/jerome/.nvm/versions/node/v22.20.0/bin:$PATH\" /home/jerome/.nvm/versions/node/v22.20.0/bin/npx tsx ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/pre-tool-use.ts"
+            "command": "PATH=\"/home/jerome/.local/share/nvm/v25.6.1/bin:$PATH\" /home/jerome/.local/share/nvm/v25.6.1/bin/npx tsx ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/pre-tool-use.ts"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "PATH=\"/home/jerome/.nvm/versions/node/v22.20.0/bin:$PATH\" /home/jerome/.nvm/versions/node/v22.20.0/bin/npx tsx ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/post-tool-use.ts"
+            "command": "PATH=\"/home/jerome/.local/share/nvm/v25.6.1/bin:$PATH\" /home/jerome/.local/share/nvm/v25.6.1/bin/npx tsx ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/post-tool-use.ts"
           }
         ]
       }
@@ -28,7 +28,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "PATH=\"/home/jerome/.nvm/versions/node/v22.20.0/bin:$PATH\" /home/jerome/.nvm/versions/node/v22.20.0/bin/npx tsx ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/session-start.ts"
+            "command": "PATH=\"/home/jerome/.local/share/nvm/v25.6.1/bin:$PATH\" /home/jerome/.local/share/nvm/v25.6.1/bin/npx tsx ${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/session-start.ts"
           }
         ]
       }

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -99,6 +99,14 @@ export async function initCommand(projectDir: string, options: InitOptions): Pro
     writeFileSync(configPath, yamlStringify(DEFAULT_CONFIG, { lineWidth: 0 }));
   }
 
+  // Create graphify placeholder so the MCP server doesn't crash on startup
+  const graphifyDir = join(projectDir, 'graphify-out');
+  const graphJsonPath = join(graphifyDir, 'graph.json');
+  if (!existsSync(graphJsonPath)) {
+    mkdirSync(graphifyDir, { recursive: true });
+    writeFileSync(graphJsonPath, '{"nodes": [], "links": []}\n');
+  }
+
   // Update settings.json with hook registrations
   const npxCommand = resolveNpxPath(options.exec);
   updateSettingsJson(claudeDir, npxCommand, rtkAvailable);
@@ -112,6 +120,7 @@ const GITIGNORE_MARKER_END = '# --- end rig-managed ---';
 const GITIGNORE_ENTRIES = [
   '.harness.yaml.local',
   '*.session-cache.json',
+  'graphify-out/',
 ];
 
 function updateGitignore(projectDir: string): void {
@@ -124,6 +133,22 @@ function updateGitignore(projectDir: string): void {
 
   // Check if rig-managed section already exists
   if (content.includes(GITIGNORE_MARKER_START)) {
+    // Update entries within existing section if any are missing
+    const startIdx = content.indexOf(GITIGNORE_MARKER_START);
+    const endIdx = content.indexOf(GITIGNORE_MARKER_END);
+    if (endIdx > startIdx) {
+      const section = content.substring(startIdx, endIdx + GITIGNORE_MARKER_END.length);
+      let updated = section;
+      for (const entry of GITIGNORE_ENTRIES) {
+        if (!section.includes(entry)) {
+          // Insert before the end marker
+          updated = updated.replace(GITIGNORE_MARKER_END, `${entry}\n${GITIGNORE_MARKER_END}`);
+        }
+      }
+      if (updated !== section) {
+        writeFileSync(gitignorePath, content.replace(section, updated));
+      }
+    }
     return;
   }
 

--- a/tests/cli/init.test.ts
+++ b/tests/cli/init.test.ts
@@ -57,6 +57,29 @@ describe('initCommand', () => {
     expect(content).toContain('stale_tests');
   });
 
+  it('creates graphify-out/graph.json placeholder', async () => {
+    await initCommand(tempDir, { force: false });
+    const graphPath = join(tempDir, 'graphify-out', 'graph.json');
+    expect(existsSync(graphPath)).toBe(true);
+    const content = readFileSync(graphPath, 'utf-8');
+    const parsed = JSON.parse(content);
+    expect(parsed).toEqual({ nodes: [], links: [] });
+  });
+
+  it('does not overwrite existing graphify graph.json', async () => {
+    // Simulate a real graph already built by graphify
+    const graphifyDir = join(tempDir, 'graphify-out');
+    mkdirSync(graphifyDir, { recursive: true });
+    const realGraph = { nodes: [{ id: 'a' }], links: [{ source: 'a', target: 'b' }] };
+    writeFileSync(join(graphifyDir, 'graph.json'), JSON.stringify(realGraph));
+
+    await initCommand(tempDir, { force: false });
+
+    const content = readFileSync(join(graphifyDir, 'graph.json'), 'utf-8');
+    const parsed = JSON.parse(content);
+    expect(parsed).toEqual(realGraph);
+  });
+
   it('does not overwrite existing files without --force', async () => {
     await initCommand(tempDir, { force: false });
     // Modify a file by appending custom content and removing the rig marker
@@ -455,6 +478,7 @@ console.log('stale old hook');
       expect(gitignore).toContain('rig-managed');
       expect(gitignore).toContain('.harness.yaml.local');
       expect(gitignore).toContain('*.session-cache.json');
+      expect(gitignore).toContain('graphify-out/');
     });
 
     it('does not duplicate rig-managed section on re-init', async () => {
@@ -476,6 +500,22 @@ console.log('stale old hook');
       const after = readFileSync(gitignorePath, 'utf-8');
       expect(after).toContain('node_modules/');
       expect(after).toContain('.harness.yaml.local');
+    });
+
+    it('adds new entries to existing rig-managed section on re-init', async () => {
+      await initCommand(tempDir, { force: false });
+      const gitignorePath = join(tempDir, '.gitignore');
+      // Remove graphify-out/ to simulate an older rig install
+      let content = readFileSync(gitignorePath, 'utf-8');
+      content = content.replace('graphify-out/\n', '');
+      writeFileSync(gitignorePath, content);
+
+      await initCommand(tempDir, { force: false });
+      const after = readFileSync(gitignorePath, 'utf-8');
+      // Should have been added back without duplicating the section
+      expect(after).toContain('graphify-out/');
+      const matches = after.match(/rig-managed/g);
+      expect(matches).toHaveLength(2); // still just opening + closing marker
     });
   });
 


### PR DESCRIPTION
## Summary

- Creates `graphify-out/graph.json` with `{"nodes": [], "links": []}` during `rig init` so the graphify MCP server doesn't crash at startup when no graph exists
- Adds `graphify-out/` to rig-managed `.gitignore` entries
- Fixes gitignore migration to append missing entries to existing rig-managed sections (previously skipped if markers existed)

## Root cause

Graphify's MCP server calls `_load_graph()` at startup and `sys.exit(1)` if the file is missing (serve.py:159 → :26). MCP servers initialize **before** SessionStart hooks run (confirmed via anthropics/claude-code#51148), so the hook can't create the file in time. `rig init` runs before any session, making it the correct insertion point.

## Test plan

- [x] `npx vitest run tests/cli/init.test.ts` — 43/43 pass
- [x] Rebuilt and reinstalled in claude-rig, ai-news, my-claw
- [x] Verified placeholder created in all three projects
- [x] Verified gitignore migration works on existing installs (ai-news, my-claw)

🤖 Generated with [Claude Code](https://claude.com/claude-code)