### PR TITLE
fix: add postinstall script to symlink rig into PATH

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "build": "tsc && chmod +x dist/cli/index.js",
+    "postinstall": "node -e \"const{symlinkSync,existsSync,mkdirSync}=require('fs');const{resolve}=require('path');const bin=resolve(process.env.HOME,'.local/bin');if(!existsSync(bin))mkdirSync(bin,{recursive:true});const target=resolve(__dirname,'dist/cli/index.js');const link=resolve(bin,'rig');try{symlinkSync(target,link)}catch(e){if(e.code!=='EEXIST')throw e}\"",
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "tsc --noEmit",


### PR DESCRIPTION
## Summary
- npm link puts the `rig` binary in `~/.hermes/node/bin`, which isn't on PATH
- Added a `postinstall` script that symlinks `dist/cli/index.js` into `~/.local/bin/rig` (which is on PATH)
- This makes `rig` available after `npm link` or `npm install -g` without manual PATH changes

## Test plan
- [x] `npm run build && npm link` — symlink created at `~/.local/bin/rig`
- [x] `rig --version` — works from any directory
- [x] `rig init --force` — installs into target projects
- [x] `npm test` — 977 tests pass
- [x] `npm run lint` — type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)