### PR TITLE
chore: bump version to 0.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "rig",
-  "version": "0.1.0",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rig",
-      "version": "0.1.0",
+      "version": "0.3.2",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rig",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Agent harness that enforces tool routing, skill chains, and multi-agent discipline in Claude Code",
   "type": "module",
   "main": "dist/cli/index.js",


### PR DESCRIPTION
## Summary
- Bump version from 0.3.1 to 0.3.2

## What's in 0.3.2
- fix: trigger graphify for already-indexed external repos on resolve_repo (#15)

## Test plan
- [x] Full suite: 980/980 green
- [x] Build compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)