### PR TITLE
chore: bump version to 0.3.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rig",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rig",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rig",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Agent harness that enforces tool routing, skill chains, and multi-agent discipline in Claude Code",
   "type": "module",
   "main": "dist/cli/index.js",


### PR DESCRIPTION
## Summary

Patch release with two cross-platform fixes shipped in #17:

- Untrack `.claude/settings.json` so fresh clones don't fail SessionStart with a hardcoded Linux npx path pointing at gitignored hook scripts
- Canonicalize cwd in `sessionCachePath()` via `realpathSync`, fixing three integration tests that failed on macOS where `/var/folders/...` resolves to `/private/var/folders/...`

## Test plan

- [x] `npm test` — 982/982 passing on macOS
- [x] CI green on Linux runners (#17)

🤖 Generated with [Claude Code](https://claude.com/claude-code)