### PR TITLE
fix: report real CLI version, clear audit vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1805,9 +1805,9 @@
       }
     },
     "node_modules/globby": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-16.1.1.tgz",
-      "integrity": "sha512-dW7vl+yiAJSp6aCekaVnVJxurRv7DCOLyXqEG3RYMYUg7AuJ2jCqPkZTA8ooqC2vtnkaMcV5WfFBMuEnTu1OQg==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.0.tgz",
+      "integrity": "sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2202,13 +2202,13 @@
       }
     },
     "node_modules/markdownlint-cli2": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.22.0.tgz",
-      "integrity": "sha512-mOC9BY/XGtdX3M9n3AgERd79F0+S7w18yBBTNIQ453sI87etZfp1z4eajqSMV70CYjbxKe5ktKvT2HCpvcWx9w==",
+      "version": "0.22.1",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.22.1.tgz",
+      "integrity": "sha512-X14ZbytybDCXAViDmtN4DKLt9ZTrRn+oOrxTYlg3a65jS6QcYYbAkGPh/En2L/GDNbFYJ6lKaQSUNrrbN1bPrw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "globby": "16.1.1",
+        "globby": "16.2.0",
         "js-yaml": "4.1.1",
         "jsonc-parser": "3.3.1",
         "jsonpointer": "5.0.1",
@@ -2216,7 +2216,7 @@
         "markdownlint": "0.40.0",
         "markdownlint-cli2-formatter-default": "0.0.6",
         "micromatch": "4.0.8",
-        "smol-toml": "1.6.0"
+        "smol-toml": "1.6.1"
       },
       "bin": {
         "markdownlint-cli2": "markdownlint-cli2-bin.mjs"
@@ -2965,9 +2965,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -3174,9 +3174,9 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.0.tgz",
-      "integrity": "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -3463,9 +3463,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,13 +2,23 @@
 import { Command } from 'commander';
 import { initCommand } from './init.js';
 import { resolve } from 'node:path';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+// Read version from package.json so the CLI and the published package can't drift.
+// __dirname is src/cli when compiled to src/cli/index.js, dist/cli when shipped.
+// In both layouts the repo's package.json lives two levels up.
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const pkg = JSON.parse(
+  readFileSync(resolve(__dirname, '..', '..', 'package.json'), 'utf-8'),
+) as { version: string };
 
 const program = new Command();
 
 program
   .name('rig')
   .description('Agent harness that enforces tool routing, skill chains, and multi-agent discipline for Claude Code')
-  .version('0.1.0');
+  .version(pkg.version);
 
 program
   .command('init')


### PR DESCRIPTION
## Summary

Two small fixes the user hit immediately after the v0.3.3 release:

- **`rig --version` reported `0.1.0`** — the commander `.version()` call was a hardcoded literal that never got bumped alongside `package.json`. Now reads `package.json` at startup so the CLI and the published package can't drift again.
- **`npm audit` flagged 4 vulnerabilities** (3 moderate, 1 high) in transitive devDependencies under `markdownlint-cli2` (postcss, smol-toml) and `@vitest/coverage-v8` (vite). `npm audit fix` resolves all of them as a lockfile-only change — no direct or major version updates required.

## Test plan

- [x] `rig --version` now prints `0.3.3`
- [x] `npm audit` — 0 vulnerabilities
- [x] `npm test` — 982/982 passing
- [x] `npm run build` — clean
- [ ] CI confirms on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)