### PR TITLE
chore: bump version to 0.3.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rig",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rig",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rig",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Agent harness that enforces tool routing, skill chains, and multi-agent discipline in Claude Code",
   "type": "module",
   "main": "dist/cli/index.js",


### PR DESCRIPTION
## Summary

Patch release bundling the post-v0.3.3 fixes from #19:

- `rig --version` now reports the real version (read from `package.json`) instead of the stale hardcoded `0.1.0`
- Cleared 4 npm audit vulnerabilities (3 moderate, 1 high) in transitive devDependencies — lockfile-only update

## Test plan

- [x] `rig --version` prints `0.3.4` after build
- [x] `npm audit` — 0 vulnerabilities
- [x] `npm test` — 982/982 passing
- [ ] CI confirms on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)