### PR TITLE
fix: quote CLAUDE_PROJECT_DIR path in generated hook commands

### DIFF
--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -254,7 +254,9 @@ function updateSettingsJson(claudeDir: string, npxCommand: string, rtkAvailable:
       hooks[event] = [];
     }
     const entries = hooks[event] as Array<Record<string, unknown>>;
-    const hookScriptPath = `\${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/${script}`;
+    // Quote the path so a CLAUDE_PROJECT_DIR containing spaces (e.g.
+    // "/Users/.../Jerome Onboarding") doesn't split into multiple args.
+    const hookScriptPath = `"\${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/${script}"`;
     const command = `${npxCommand} ${hookScriptPath}`;
 
     // Remove old-format entries (flat matcher+command without nested hooks array)

--- a/tests/cli/init.test.ts
+++ b/tests/cli/init.test.ts
@@ -152,6 +152,35 @@ describe('initCommand', () => {
     }
   });
 
+  it('quotes ${CLAUDE_PROJECT_DIR} path in hook commands so spaces do not break shell parsing', async () => {
+    // Regression: when CLAUDE_PROJECT_DIR contains a space (e.g.,
+    // "/Users/.../Jerome Onboarding"), unquoted shell interpolation splits
+    // the path at the space and Node ESM reports
+    //   ERR_MODULE_NOT_FOUND: Cannot find module '/Users/.../Jerome'
+    // The fix is to wrap the path in double quotes in the generated command.
+    const claudeDir = join(tempDir, '.claude');
+    mkdirSync(claudeDir, { recursive: true });
+    writeFileSync(join(claudeDir, 'settings.json'), JSON.stringify({}));
+
+    await initCommand(tempDir, { force: false });
+
+    const settings = JSON.parse(readFileSync(join(claudeDir, 'settings.json'), 'utf-8'));
+    for (const [event, script] of [
+      ['PreToolUse', 'pre-tool-use.ts'],
+      ['PostToolUse', 'post-tool-use.ts'],
+      ['SessionStart', 'session-start.ts'],
+    ] as const) {
+      const cmd: string = settings.hooks[event][0].hooks[0].command;
+      const quotedPath = `"\${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/${script}"`;
+      expect(cmd).toContain(quotedPath);
+      // Negative assertion: the unquoted form must NOT appear elsewhere in the command
+      const unquotedPath = `\${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/${script}`;
+      const occurrences = cmd.split(unquotedPath).length - 1;
+      // The quoted form contains the unquoted as a substring, so 1 occurrence is expected
+      expect(occurrences).toBe(1);
+    }
+  });
+
   it('preserves existing settings when adding hooks', async () => {
     const claudeDir = join(tempDir, '.claude');
     mkdirSync(claudeDir, { recursive: true });


### PR DESCRIPTION
## Summary

Hook commands generated by `rig init` interpolated `\${CLAUDE_PROJECT_DIR}` unquoted. When the project path contains a space, the shell splits the path and `npx tsx` receives a truncated arg, causing Node's ESM resolver to throw `ERR_MODULE_NOT_FOUND`.

## Reproduction

User installed rig into `/Users/jerome/Documents/Claude/Projects/Jerome Onboarding` and saw:

```
SessionStart:resume hook error
Failed with non-blocking status code: node:internal/modules/esm/resolve:271
ERR_MODULE_NOT_FOUND: Cannot find module '/Users/jerome/Documents/Claude/Projects/Jerome'
```

Reproduced locally by running the exact generated command. Confirmed the fix by re-running `rig init --force` on the failing project; session-start now runs clean.

## Fix

One-line change in `src/cli/init.ts:257` — wrap the path in double quotes within the generated command string. Plus a TDD regression test in `tests/cli/init.test.ts` asserting all three hook events (`PreToolUse`, `PostToolUse`, `SessionStart`) emit quoted paths.

## Test plan

- [x] Reproduced the error before the fix
- [x] Confirmed the fix resolves it (E2E session-start runs clean on the original failing project)
- [x] Regression test added, asserts all three hook commands embed `\"\${CLAUDE_PROJECT_DIR}/.claude/hooks/scripts/<script>.ts\"`
- [x] 1018/1018 tests pass
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)