### PR TITLE
fix: cwd_path_expand guard for cwds containing spaces

### DIFF
--- a/src/router/hook.ts
+++ b/src/router/hook.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import type { HarnessConfig, RewriteResult } from '../types.js';
 import { SessionCache } from '../session/cache.js';
-import { findMatchingRule, getDefaultRules } from './rules.js';
+import { findMatchingRule, getDefaultRules, matchCwdPathPrefix } from './rules.js';
 import { resolve } from './resolver.js';
 import { tryPythonRewrite } from './python-rewrite.js';
 import { isCompoundCommand } from './intent.js';
@@ -170,7 +170,8 @@ export function handlePreToolUse(
   // cwd_path_expand has special output format
   if (match.intent === 'cwd_path_expand' && tool === 'Bash') {
     const command = args.command as string;
-    const relativePart = command.slice(effectiveCwd.length + 1);
+    const prefixLen = matchCwdPathPrefix(command, effectiveCwd) ?? effectiveCwd.length + 1;
+    const relativePart = command.slice(prefixLen);
     const binary = relativePart.split(/\s+/)[0];
     return [
       `${prefix} Tool Router: fully-qualified CWD path detected`,

--- a/src/router/rules.ts
+++ b/src/router/rules.ts
@@ -160,7 +160,7 @@ export function getDefaultRules(cwd?: string): ToolRule[] {
         if (tool !== 'Bash') return false;
         const command = args.command as string | undefined;
         if (!command || !cwd) return false;
-        if (!command.startsWith(cwd + '/')) return false;
+        if (matchCwdPathPrefix(command, cwd) === null) return false;
         // .venv/bin paths are legitimate — the Python rewrite produces them
         if (command.includes('.venv/')) return false;
         return true;
@@ -176,6 +176,35 @@ export function getDefaultRules(cwd?: string): ToolRule[] {
       enforcement: 'advise',
     },
   ];
+}
+
+/**
+ * Detects whether `command` begins with a reference to the cwd as a
+ * fully-qualified path, accounting for shell-quoting forms that come up when
+ * cwd contains spaces. Returns the length of the cwd prefix in the command
+ * (so the caller can slice the remainder), or null if no prefix matches.
+ *
+ * Forms recognized:
+ *   - bare:               /Users/bob/Some Project/app/foo
+ *   - backslash-escaped:  /Users/bob/Some\ Project/app/foo
+ *   - double-quoted:      "/Users/bob/Some Project/app/foo"
+ *   - single-quoted:      '/Users/bob/Some Project/app/foo'
+ */
+export function matchCwdPathPrefix(command: string, cwd: string): number | null {
+  const bare = cwd + '/';
+  if (command.startsWith(bare)) return bare.length;
+
+  if (cwd.includes(' ')) {
+    const escaped = cwd.replace(/ /g, '\\ ') + '/';
+    if (command.startsWith(escaped)) return escaped.length;
+  }
+
+  for (const quote of ['"', "'"]) {
+    const quoted = quote + cwd + '/';
+    if (command.startsWith(quoted)) return quoted.length;
+  }
+
+  return null;
 }
 
 /**

--- a/tests/router/hook.test.ts
+++ b/tests/router/hook.test.ts
@@ -206,6 +206,34 @@ describe('handlePreToolUse', () => {
     expect(result).toBeNull();
   });
 
+  it('advises with correct relative path when cwd has a space (backslash-escaped form)', () => {
+    cache.setEnvironment(makeEnv());
+    const result = handlePreToolUse(
+      'Bash',
+      { command: '/Users/bob/Documents/Some\\ Project/app/scripts/foo --flag' },
+      cache,
+      config,
+      '/Users/bob/Documents/Some Project/app',
+    );
+    expect(result).not.toBeNull();
+    expect(result).toContain('ADVISE');
+    expect(result).toContain('./scripts/foo');
+  });
+
+  it('advises with correct relative path when cwd has a space (double-quoted form)', () => {
+    cache.setEnvironment(makeEnv());
+    const result = handlePreToolUse(
+      'Bash',
+      { command: '"/Users/bob/Documents/Some Project/app/scripts/foo" --flag' },
+      cache,
+      config,
+      '/Users/bob/Documents/Some Project/app',
+    );
+    expect(result).not.toBeNull();
+    expect(result).toContain('ADVISE');
+    expect(result).toContain('./scripts/foo');
+  });
+
   it('cwd_path_expand respects block enforcement', () => {
     config.rules.tool_routing!.cwd_path_expand = 'block';
     cache.setEnvironment(makeEnv());

--- a/tests/router/rules.test.ts
+++ b/tests/router/rules.test.ts
@@ -268,6 +268,34 @@ describe('cwd_path_expand rule', () => {
     expect(match).toBeUndefined();
   });
 
+  it('matches commands that escape spaces with backslash (paths with spaces)', () => {
+    // Regression: when cwd contains a space, agents typically emit the path
+    // shell-escaped (Some\ Project). The matcher must recognize the backslash-
+    // escaped form as the same path.
+    const cwdWithSpace = '/Users/bob/Documents/Some Project/app';
+    const rules = getDefaultRules(cwdWithSpace);
+    const match = findMatchingRule(
+      'Bash',
+      { command: '/Users/bob/Documents/Some\\ Project/app/scripts/foo' },
+      rules,
+    );
+    expect(match).toBeDefined();
+    expect(match!.intent).toBe('cwd_path_expand');
+  });
+
+  it('matches commands that quote the cwd path (paths with spaces)', () => {
+    // Same regression but using double quotes around the absolute path.
+    const cwdWithSpace = '/Users/bob/Documents/Some Project/app';
+    const rules = getDefaultRules(cwdWithSpace);
+    const match = findMatchingRule(
+      'Bash',
+      { command: '"/Users/bob/Documents/Some Project/app/scripts/foo"' },
+      rules,
+    );
+    expect(match).toBeDefined();
+    expect(match!.intent).toBe('cwd_path_expand');
+  });
+
   it('does not match relative ./path', () => {
     const rules = getDefaultRules(cwd);
     const match = findMatchingRule('Bash', { command: './.venv/bin/pip install pytest' }, rules);


### PR DESCRIPTION
## Summary

The Tool Router's `cwd_path_expand` guard (which advises agents to use `./foo` instead of `/abs/path/to/cwd/foo`) didn't fire when the project cwd contains a space. Agents emit the path either backslash-escaped (`Some\ Project`) or quoted (`\"Some Project\"`), neither of which matched the raw cwd via `startsWith`.

## Root cause

`src/router/rules.ts:163` compared `command.startsWith(cwd + '/')`. With `cwd = /Users/bob/Documents/Some Project/app`:

- Command `/Users/bob/Documents/Some\\ Project/app/foo` doesn't start with `/Users/bob/Documents/Some Project/app/` (mismatch at the backslash vs. space)
- Command `\"/Users/bob/Documents/Some Project/app/foo\"` doesn't start with the raw cwd either (leading quote)

Result: the rule silently missed for any project whose path contains a space.

## Fix

Extracted a `matchCwdPathPrefix(command, cwd)` helper in `src/router/rules.ts` that recognizes four forms — bare, backslash-escaped, double-quoted, single-quoted — and returns the prefix length. The rule matcher uses it for detection; `src/router/hook.ts` uses the same offset to slice the correct `./relative-path` suggestion.

## Test plan

- [x] Reproduced the bug via Node probe (`startsWith` returned `false`)
- [x] New tests in `tests/router/rules.test.ts` (matcher accepts escaped + quoted forms)
- [x] New tests in `tests/router/hook.test.ts` ([ADVISE] output produces correct relative slice)
- [x] 1022/1022 tests pass
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)