### PR TITLE
fix: catch `cd <cwd> && ...` in cwd_path_expand guard

### DIFF
--- a/src/router/hook.ts
+++ b/src/router/hook.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import type { HarnessConfig, RewriteResult } from '../types.js';
 import { SessionCache } from '../session/cache.js';
-import { findMatchingRule, getDefaultRules, matchCwdPathPrefix } from './rules.js';
+import { findMatchingRule, getDefaultRules, matchCwdReference } from './rules.js';
 import { resolve } from './resolver.js';
 import { tryPythonRewrite } from './python-rewrite.js';
 import { isCompoundCommand } from './intent.js';
@@ -146,8 +146,15 @@ export function handlePreToolUse(
   // Step 4: No match = pass through
   if (!match) return null;
 
-  // Step 4b: Compound commands skip advisory (but file_modify still blocks above)
-  if (tool === 'Bash' && typeof args.command === 'string' && isCompoundCommand(args.command)) {
+  // Step 4b: Compound commands skip advisory (but file_modify still blocks above).
+  // Exception: cwd_path_expand is specifically about catching compound commands
+  // like `cd <cwd> && <cmd>`, so it must bypass this suppression.
+  if (
+    tool === 'Bash' &&
+    typeof args.command === 'string' &&
+    isCompoundCommand(args.command) &&
+    match.intent !== 'cwd_path_expand'
+  ) {
     return null;
   }
 
@@ -170,8 +177,29 @@ export function handlePreToolUse(
   // cwd_path_expand has special output format
   if (match.intent === 'cwd_path_expand' && tool === 'Bash') {
     const command = args.command as string;
-    const prefixLen = matchCwdPathPrefix(command, effectiveCwd) ?? effectiveCwd.length + 1;
-    const relativePart = command.slice(prefixLen);
+    const ref = matchCwdReference(command, effectiveCwd);
+    if (ref?.isCdForm && ref.isExactCwd) {
+      // Pattern: `cd <cwd>[ && cmd]` — the cd is redundant.
+      const tail = command.slice(ref.prefixLen).replace(/^\s*&&\s*/, '').trim();
+      const suggested = tail.length > 0 ? `\`${tail}\`` : '(nothing — you are already there)';
+      return [
+        `${prefix} Tool Router: redundant cd to cwd detected`,
+        `advise: drop the \`cd\`; run ${suggested} directly. You are already in ${effectiveCwd}.`,
+        'Shorter, saves tokens, more portable.',
+      ].join('\n');
+    }
+    if (ref?.isCdForm) {
+      // Pattern: `cd <cwd>/subdir[ && cmd]` — suggest relative cd.
+      const subdirAndRest = command.slice(ref.prefixLen);
+      const subdir = subdirAndRest.split(/[\s&;|]/)[0];
+      return [
+        `${prefix} Tool Router: fully-qualified CWD path in \`cd\``,
+        `advise: use \`cd ./${subdir}\` instead — you are already in ${effectiveCwd}.`,
+        'Shorter, saves tokens, more portable.',
+      ].join('\n');
+    }
+    // Default: bare absolute-path invocation, e.g. `/abs/cwd/bin/foo args`.
+    const relativePart = command.slice(ref?.prefixLen ?? effectiveCwd.length + 1);
     const binary = relativePart.split(/\s+/)[0];
     return [
       `${prefix} Tool Router: fully-qualified CWD path detected`,

--- a/src/router/rules.ts
+++ b/src/router/rules.ts
@@ -160,7 +160,7 @@ export function getDefaultRules(cwd?: string): ToolRule[] {
         if (tool !== 'Bash') return false;
         const command = args.command as string | undefined;
         if (!command || !cwd) return false;
-        if (matchCwdPathPrefix(command, cwd) === null) return false;
+        if (matchCwdReference(command, cwd) === null) return false;
         // .venv/bin paths are legitimate — the Python rewrite produces them
         if (command.includes('.venv/')) return false;
         return true;
@@ -181,27 +181,75 @@ export function getDefaultRules(cwd?: string): ToolRule[] {
 /**
  * Detects whether `command` begins with a reference to the cwd as a
  * fully-qualified path, accounting for shell-quoting forms that come up when
- * cwd contains spaces. Returns the length of the cwd prefix in the command
- * (so the caller can slice the remainder), or null if no prefix matches.
+ * cwd contains spaces and for the `cd <cwd>...` anti-pattern that agents
+ * frequently emit.
  *
- * Forms recognized:
- *   - bare:               /Users/bob/Some Project/app/foo
- *   - backslash-escaped:  /Users/bob/Some\ Project/app/foo
- *   - double-quoted:      "/Users/bob/Some Project/app/foo"
- *   - single-quoted:      '/Users/bob/Some Project/app/foo'
+ * Returns:
+ *   - `prefixLen`: index into `command` where the cwd reference ends and
+ *     the remainder begins (slice with this to get what follows).
+ *   - `isCdForm`: true when the match was preceded by a leading `cd ` —
+ *     lets callers produce a different advice message.
+ *   - `isExactCwd`: true when the reference was to exactly cwd (no subdir).
+ *     Distinguishes "redundant cd" from "cd to subdir".
+ *
+ * Forms recognized for the cwd reference (with or without leading `cd `):
+ *   - bare:               /abs/some path/foo  (no spaces in cwd)
+ *   - backslash-escaped:  /abs/some\ path/foo
+ *   - double-quoted:      "/abs/some path/foo"
+ *   - single-quoted:      '/abs/some path/foo'
  */
-export function matchCwdPathPrefix(command: string, cwd: string): number | null {
-  const bare = cwd + '/';
-  if (command.startsWith(bare)) return bare.length;
+export function matchCwdReference(
+  command: string,
+  cwd: string,
+): { prefixLen: number; isCdForm: boolean; isExactCwd: boolean } | null {
+  const direct = tryMatchAt(command, 0, cwd);
+  if (direct) return { ...direct, isCdForm: false };
 
-  if (cwd.includes(' ')) {
-    const escaped = cwd.replace(/ /g, '\\ ') + '/';
-    if (command.startsWith(escaped)) return escaped.length;
+  if (command.startsWith('cd ')) {
+    const afterCd = tryMatchAt(command, 3, cwd);
+    if (afterCd) return { ...afterCd, isCdForm: true };
   }
 
-  for (const quote of ['"', "'"]) {
-    const quoted = quote + cwd + '/';
-    if (command.startsWith(quoted)) return quoted.length;
+  return null;
+}
+
+function tryMatchAt(
+  command: string,
+  offset: number,
+  cwd: string,
+): { prefixLen: number; isExactCwd: boolean } | null {
+  // Path-continuation forms first (cwd followed by `/` — i.e. cwd/subdir or
+  // cwd/binary). Return `prefixLen` pointing PAST the `/` so the slice yields
+  // the subdir/binary directly.
+  const continuations: string[] = [cwd + '/'];
+  if (cwd.includes(' ')) continuations.push(cwd.replace(/ /g, '\\ ') + '/');
+  continuations.push('"' + cwd + '/');
+  continuations.push("'" + cwd + '/');
+  for (const text of continuations) {
+    if (command.startsWith(text, offset)) {
+      return { prefixLen: offset + text.length, isExactCwd: false };
+    }
+  }
+
+  // Exact-cwd forms next (cwd followed by end-of-string or a shell boundary
+  // — space, tab, &, ;, |, ). Quoted forms must include the closing quote.
+  const exacts: string[] = [cwd];
+  if (cwd.includes(' ')) exacts.push(cwd.replace(/ /g, '\\ '));
+  exacts.push('"' + cwd + '"');
+  exacts.push("'" + cwd + "'");
+  for (const text of exacts) {
+    if (!command.startsWith(text, offset)) continue;
+    const next = command[offset + text.length];
+    if (
+      next === undefined ||
+      next === ' ' ||
+      next === '\t' ||
+      next === '&' ||
+      next === ';' ||
+      next === '|'
+    ) {
+      return { prefixLen: offset + text.length, isExactCwd: true };
+    }
   }
 
   return null;

--- a/tests/router/hook.test.ts
+++ b/tests/router/hook.test.ts
@@ -234,6 +234,36 @@ describe('handlePreToolUse', () => {
     expect(result).toContain('./scripts/foo');
   });
 
+  it('advises to drop redundant `cd <cwd> && ...`', () => {
+    cache.setEnvironment(makeEnv());
+    const result = handlePreToolUse(
+      'Bash',
+      { command: 'cd /Users/bob/Documents/Some\\ Project/app && make test' },
+      cache,
+      config,
+      '/Users/bob/Documents/Some Project/app',
+    );
+    expect(result).not.toBeNull();
+    expect(result).toContain('ADVISE');
+    // Output must mention that the cd is redundant or suggest running the
+    // post-`&&` command directly. Match either wording option.
+    expect(result).toMatch(/redundant|drop the .?cd|already in/i);
+  });
+
+  it('advises ./subdir for `cd <cwd>/subdir && ...`', () => {
+    cache.setEnvironment(makeEnv());
+    const result = handlePreToolUse(
+      'Bash',
+      { command: 'cd /home/user/project/src && npm test' },
+      cache,
+      config,
+      '/home/user/project',
+    );
+    expect(result).not.toBeNull();
+    expect(result).toContain('ADVISE');
+    expect(result).toContain('./src');
+  });
+
   it('cwd_path_expand respects block enforcement', () => {
     config.rules.tool_routing!.cwd_path_expand = 'block';
     cache.setEnvironment(makeEnv());

--- a/tests/router/rules.test.ts
+++ b/tests/router/rules.test.ts
@@ -296,6 +296,70 @@ describe('cwd_path_expand rule', () => {
     expect(match!.intent).toBe('cwd_path_expand');
   });
 
+  it('matches `cd <cwd> && cmd` (redundant cd to cwd, escaped form)', () => {
+    // Real-world report: agent kept emitting
+    //   cd /Users/bob/Documents/Some\ Project/app && make test
+    // The previous matcher only checked startsWith(cwd) — the `cd ` prefix
+    // pushed the cwd off position 0, so it missed.
+    const cwdWithSpace = '/Users/bob/Documents/Some Project/app';
+    const rules = getDefaultRules(cwdWithSpace);
+    const match = findMatchingRule(
+      'Bash',
+      { command: 'cd /Users/bob/Documents/Some\\ Project/app && make test' },
+      rules,
+    );
+    expect(match).toBeDefined();
+    expect(match!.intent).toBe('cwd_path_expand');
+  });
+
+  it('matches `cd "<cwd>" && cmd` (redundant cd to cwd, quoted form)', () => {
+    const cwdWithSpace = '/Users/bob/Documents/Some Project/app';
+    const rules = getDefaultRules(cwdWithSpace);
+    const match = findMatchingRule(
+      'Bash',
+      { command: 'cd "/Users/bob/Documents/Some Project/app" && git log --oneline -3' },
+      rules,
+    );
+    expect(match).toBeDefined();
+    expect(match!.intent).toBe('cwd_path_expand');
+  });
+
+  it('matches `cd <cwd>/subdir && cmd` (cd to subdir of cwd)', () => {
+    // Agent using absolute path to address a subdir is still cwd_path_expand;
+    // the relative form `cd ./subdir` (or just `cd subdir`) is preferred.
+    const cwd = '/home/user/project';
+    const rules = getDefaultRules(cwd);
+    const match = findMatchingRule(
+      'Bash',
+      { command: 'cd /home/user/project/src && npm test' },
+      rules,
+    );
+    expect(match).toBeDefined();
+    expect(match!.intent).toBe('cwd_path_expand');
+  });
+
+  it('does not match `cd /other/path && cmd` (different absolute path)', () => {
+    const cwd = '/home/user/project';
+    const rules = getDefaultRules(cwd);
+    const match = findMatchingRule(
+      'Bash',
+      { command: 'cd /other/path && ls' },
+      rules,
+    );
+    expect(match).toBeUndefined();
+  });
+
+  it('does not match `cd ./subdir && cmd` (already relative)', () => {
+    const cwd = '/home/user/project';
+    const rules = getDefaultRules(cwd);
+    const match = findMatchingRule(
+      'Bash',
+      { command: 'cd ./src && npm test' },
+      rules,
+    );
+    expect(match).toBeUndefined();
+  });
+
   it('does not match relative ./path', () => {
     const rules = getDefaultRules(cwd);
     const match = findMatchingRule('Bash', { command: './.venv/bin/pip install pytest' }, rules);


### PR DESCRIPTION
## Summary

The Tool Router's `cwd_path_expand` guard didn't fire for the most common form of the anti-pattern: `cd /abs/cwd && <cmd>`. Two root causes layered:

1. The matcher (post-v0.3.7) only recognized cwd references at position 0. The `cd ` prefix pushed the cwd off position 0.
2. `hook.ts:150` globally suppressed advisories for compound commands (anything with `&&`/`;`/`|`), which would have suppressed the advice even if the matcher had matched.

## Fix

- Replaces `matchCwdPathPrefix` with `matchCwdReference`. Handles direct (`/abs/cwd/foo`) and `cd `-prefixed forms across all four quoting variants (bare, backslash-escaped, double-quoted, single-quoted). Returns `{ prefixLen, isCdForm, isExactCwd }`.
- Hook now produces three distinct advice messages:
  - **Direct path** (`/abs/cwd/bin/foo`): "use `./bin/foo` instead of `/abs/cwd/bin/foo`"
  - **Redundant cd** (`cd /abs/cwd && make test`): "drop the redundant cd; run `make test` directly"
  - **Cd to subdir** (`cd /abs/cwd/src && npm test`): "use `cd ./src` instead"
- Compound-command suppression in `hook.ts` now exempts `cwd_path_expand` specifically.

## Test plan

- [x] Reproduced — original report had two `cd /Users/.../Some\ Project/app && ...` cases that didn't trigger
- [x] 7 new tests across `tests/router/rules.test.ts` + `tests/router/hook.test.ts` using `/Users/bob/Documents/Some Project/app`
- [x] 1029/1029 tests pass
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)