### PR TITLE
fix: macOS uvx jcodemunch reliability + auto-index fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rig",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rig",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/session/environment.ts
+++ b/src/session/environment.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'node:child_process';
+import { execSync, spawn } from 'node:child_process';
 import { basename, join } from 'node:path';
 import { existsSync, statSync } from 'node:fs';
 import type { Environment, GraphBuildInfo } from '../types.js';
@@ -7,17 +7,82 @@ export interface ExecFn {
   (command: string, options?: { encoding?: string; timeout?: number }): string;
 }
 
+/**
+ * Sends JSON-RPC messages to an MCP server over stdio and resolves with raw stdout
+ * once a response containing `"id":<matchId>` is observed, or null on timeout/error.
+ *
+ * Keeps stdin OPEN while waiting: closing it on EOF causes some MCP servers (notably
+ * uvx-managed `jcodemunch-mcp`) to shut down before emitting later responses. The
+ * caller (this helper) kills the child the moment the desired response arrives.
+ */
+export interface McpQueryFn {
+  (
+    command: string,
+    args: string[],
+    messages: string[],
+    matchId: number,
+    timeoutMs: number,
+  ): Promise<string | null>;
+}
+
 const defaultExec: ExecFn = (cmd, opts) =>
   execSync(cmd, { encoding: 'utf-8', ...opts } as Parameters<typeof execSync>[1]) as string;
+
+export const defaultMcpQuery: McpQueryFn = (command, args, messages, matchId, timeoutMs) =>
+  new Promise((resolve) => {
+    const matchPattern = `"id":${matchId}`;
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(command, args, { stdio: ['pipe', 'pipe', 'ignore'] });
+    } catch {
+      resolve(null);
+      return;
+    }
+
+    let buffer = '';
+    let settled = false;
+
+    const finish = (result: string | null): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      try { child.kill('SIGTERM'); } catch { /* already dead */ }
+      resolve(result);
+    };
+
+    const timer = setTimeout(() => finish(buffer.includes(matchPattern) ? buffer : null), timeoutMs);
+
+    child.stdout?.on('data', (chunk: Buffer) => {
+      buffer += chunk.toString('utf-8');
+      if (buffer.includes(matchPattern)) {
+        finish(buffer);
+      }
+    });
+
+    child.on('error', () => finish(null));
+    child.on('exit', () => finish(buffer.includes(matchPattern) ? buffer : null));
+
+    // Write all messages, but deliberately do NOT call stdin.end().
+    // Some MCP servers exit at EOF before processing queued messages — we hold
+    // stdin open until we observe the target response, then kill the child.
+    try {
+      for (const msg of messages) {
+        child.stdin?.write(msg + '\n');
+      }
+    } catch {
+      finish(null);
+    }
+  });
 
 export async function detectEnvironment(
   cwd: string,
   exec: ExecFn = defaultExec,
   existsCheck: (path: string) => boolean = existsSync,
   statCheck: (path: string) => { size: number } | undefined = defaultStatCheck,
+  mcpQuery: McpQueryFn = defaultMcpQuery,
 ): Promise<Environment> {
   const rtkResult = detectRtk(exec);
-  const jmResult = detectJcodemunch(cwd, exec);
+  const jmResult = await detectJcodemunch(cwd, exec, mcpQuery);
   const graphifyResult = detectGraphify(cwd, exec, existsCheck, statCheck);
 
   return {
@@ -94,12 +159,18 @@ export function detectGraphify(
   return { state: 'absent', _cliFound: true };
 }
 
-function detectJcodemunch(cwd: string, exec: ExecFn): {
+interface JcodemunchDetection {
   available: boolean;
   cwdIndexed: boolean;
   cwdRepo: string | null;
   knownRepos: string[];
-} {
+}
+
+async function detectJcodemunch(
+  cwd: string,
+  exec: ExecFn,
+  mcpQuery: McpQueryFn,
+): Promise<JcodemunchDetection> {
   // Try CLI binary first
   try {
     exec('which jcodemunch');
@@ -111,7 +182,7 @@ function detectJcodemunch(cwd: string, exec: ExecFn): {
   try {
     const mcpPath = exec('which jcodemunch-mcp').trim();
     if (mcpPath) {
-      return detectJcodemunchMcp(cwd, mcpPath, exec);
+      return await detectJcodemunchMcp(cwd, mcpPath, mcpQuery);
     }
   } catch {
     // MCP binary not found either
@@ -119,11 +190,11 @@ function detectJcodemunch(cwd: string, exec: ExecFn): {
 
   // macOS/uvx install: jcodemunch-mcp is managed by uvx and not in PATH.
   // Claude Code's recommended install (command: "uvx", args: ["jcodemunch-mcp"])
-  // works but `which jcodemunch-mcp` fails. Pipe JSON-RPC via uvx directly.
+  // works but `which jcodemunch-mcp` fails. Send JSON-RPC via uvx directly.
   // This also applies to Linux users who install via uvx instead of pip/pipx.
   try {
     exec('which uvx');
-    return detectJcodemunchViaUvx(cwd, exec);
+    return await detectJcodemunchViaUvx(cwd, mcpQuery);
   } catch {
     // uvx not available
   }
@@ -131,12 +202,7 @@ function detectJcodemunch(cwd: string, exec: ExecFn): {
   return { available: false, cwdIndexed: false, cwdRepo: null, knownRepos: [] };
 }
 
-function detectJcodemunchCli(cwd: string, exec: ExecFn): {
-  available: boolean;
-  cwdIndexed: boolean;
-  cwdRepo: string | null;
-  knownRepos: string[];
-} {
+function detectJcodemunchCli(cwd: string, exec: ExecFn): JcodemunchDetection {
   try {
     const raw = exec('jcodemunch list_repos').trim();
     const parsed = JSON.parse(raw);
@@ -146,56 +212,29 @@ function detectJcodemunchCli(cwd: string, exec: ExecFn): {
   }
 }
 
-function detectJcodemunchMcp(cwd: string, mcpPath: string, exec: ExecFn): {
-  available: boolean;
-  cwdIndexed: boolean;
-  cwdRepo: string | null;
-  knownRepos: string[];
-} {
-  try {
-    const output = queryJcodemunchMcp(mcpPath, exec);
-    if (!output) return { available: true, cwdIndexed: false, cwdRepo: null, knownRepos: [] };
+const LIST_REPOS_MESSAGES = [
+  '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"rig","version":"1.0"}},"id":1}',
+  '{"jsonrpc":"2.0","method":"notifications/initialized"}',
+  '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"list_repos","arguments":{}},"id":2}',
+];
 
-    // Parse JSON-RPC responses — find the list_repos response (id:2)
-    const lines = output.trim().split('\n');
-    const reposLine = lines.find(l => l.includes('"id":2'));
-    if (!reposLine) return { available: true, cwdIndexed: false, cwdRepo: null, knownRepos: [] };
-
-    const rpcResponse = JSON.parse(reposLine);
-    const textContent = rpcResponse?.result?.content?.[0]?.text;
-    if (!textContent) return { available: true, cwdIndexed: false, cwdRepo: null, knownRepos: [] };
-
-    const reposData = JSON.parse(textContent);
-    // MCP returns repos as objects with a "repo" field; extract repo names
-    const repoNames: string[] = (reposData.repos ?? []).map((r: { repo: string }) => r.repo);
-    return resolveJcodemunchRepos(cwd, repoNames);
-  } catch {
-    return { available: true, cwdIndexed: false, cwdRepo: null, knownRepos: [] };
-  }
+async function detectJcodemunchMcp(
+  cwd: string,
+  mcpPath: string,
+  mcpQuery: McpQueryFn,
+): Promise<JcodemunchDetection> {
+  const output = await mcpQuery(mcpPath, [], LIST_REPOS_MESSAGES, 2, 10_000);
+  return parseListReposResponse(cwd, output);
 }
 
-function queryJcodemunchMcp(mcpPath: string, exec: ExecFn): string | null {
-  const init = '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"rig","version":"1.0"}},"id":1}';
-  const ready = '{"jsonrpc":"2.0","method":"notifications/initialized"}';
-  const listRepos = '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"list_repos","arguments":{}},"id":2}';
-
-  const cmd = `printf '%s\\n' '${init}' '${ready}' '${listRepos}' | '${mcpPath}' 2>/dev/null`;
-  try {
-    return exec(cmd, { timeout: 10000 });
-  } catch {
-    return null;
-  }
-}
-
-function detectJcodemunchViaUvx(cwd: string, exec: ExecFn): {
-  available: boolean;
-  cwdIndexed: boolean;
-  cwdRepo: string | null;
-  knownRepos: string[];
-} {
-  const output = queryJcodemunchViaUvx(exec);
+async function detectJcodemunchViaUvx(cwd: string, mcpQuery: McpQueryFn): Promise<JcodemunchDetection> {
+  const output = await mcpQuery('uvx', ['jcodemunch-mcp'], LIST_REPOS_MESSAGES, 2, 15_000);
   if (!output) return { available: false, cwdIndexed: false, cwdRepo: null, knownRepos: [] };
+  return parseListReposResponse(cwd, output);
+}
 
+function parseListReposResponse(cwd: string, output: string | null): JcodemunchDetection {
+  if (!output) return { available: true, cwdIndexed: false, cwdRepo: null, knownRepos: [] };
   try {
     const lines = output.trim().split('\n');
     const reposLine = lines.find(l => l.includes('"id":2'));
@@ -210,39 +249,38 @@ function detectJcodemunchViaUvx(cwd: string, exec: ExecFn): {
     return resolveJcodemunchRepos(cwd, repoNames);
   } catch {
     return { available: true, cwdIndexed: false, cwdRepo: null, knownRepos: [] };
-  }
-}
-
-function queryJcodemunchViaUvx(exec: ExecFn): string | null {
-  const init = '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"rig","version":"1.0"}},"id":1}';
-  const ready = '{"jsonrpc":"2.0","method":"notifications/initialized"}';
-  const listRepos = '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"list_repos","arguments":{}},"id":2}';
-
-  const cmd = `printf '%s\\n' '${init}' '${ready}' '${listRepos}' | uvx jcodemunch-mcp 2>/dev/null`;
-  try {
-    return exec(cmd, { timeout: 15000 });
-  } catch {
-    return null;
   }
 }
 
 /**
- * Call a jcodemunch MCP tool via JSON-RPC stdio protocol.
- * Returns the parsed text content of the result, or null on failure.
+ * Call a jcodemunch MCP tool via JSON-RPC stdio. Returns the parsed `result.content[0].text`
+ * (typically a JSON string the caller parses), or null on failure.
+ *
+ * If `command` is a binary path like `/usr/local/bin/jcodemunch-mcp`, pass empty `args`.
+ * For uvx installs, use `command='uvx'`, `args=['jcodemunch-mcp']`.
  */
-export function callJcodemunchMcpTool(mcpPath: string, toolName: string, args: Record<string, string>, exec: ExecFn): string | null {
-  const init = '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"rig","version":"1.0"}},"id":1}';
-  const ready = '{"jsonrpc":"2.0","method":"notifications/initialized"}';
-  const call = JSON.stringify({
-    jsonrpc: '2.0',
-    method: 'tools/call',
-    params: { name: toolName, arguments: args },
-    id: 2,
-  });
+export async function callJcodemunchMcpTool(
+  command: string,
+  args: string[],
+  toolName: string,
+  toolArgs: Record<string, string>,
+  mcpQuery: McpQueryFn = defaultMcpQuery,
+  timeoutMs: number = 60_000,
+): Promise<string | null> {
+  const messages = [
+    '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"rig","version":"1.0"}},"id":1}',
+    '{"jsonrpc":"2.0","method":"notifications/initialized"}',
+    JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'tools/call',
+      params: { name: toolName, arguments: toolArgs },
+      id: 2,
+    }),
+  ];
 
-  const cmd = `printf '%s\\n' '${init}' '${ready}' '${call}' | '${mcpPath}' 2>/dev/null`;
+  const output = await mcpQuery(command, args, messages, 2, timeoutMs);
+  if (!output) return null;
   try {
-    const output = exec(cmd, { timeout: 60_000 });
     const lines = output.trim().split('\n');
     const responseLine = lines.find(l => l.includes('"id":2'));
     if (!responseLine) return null;
@@ -253,12 +291,7 @@ export function callJcodemunchMcpTool(mcpPath: string, toolName: string, args: R
   }
 }
 
-function resolveJcodemunchRepos(cwd: string, repos: string[]): {
-  available: boolean;
-  cwdIndexed: boolean;
-  cwdRepo: string | null;
-  knownRepos: string[];
-} {
+function resolveJcodemunchRepos(cwd: string, repos: string[]): JcodemunchDetection {
   const folderName = basename(cwd);
   const cwdRepo = repos.find(r => r.split('/').pop() === folderName) ?? null;
 

--- a/src/session/start.ts
+++ b/src/session/start.ts
@@ -18,6 +18,26 @@ interface FileCapWarning {
 }
 
 /**
+ * Resolves how to invoke `jcodemunch-mcp`: prefer a binary in PATH, fall back
+ * to `uvx jcodemunch-mcp` (macOS/Linux uvx installs). Returns null if neither
+ * is available.
+ */
+function resolveJcodemunchMcpTransport(): { command: string; args: string[] } | null {
+  try {
+    const mcpPath = execSync('which jcodemunch-mcp', { encoding: 'utf-8' }).trim();
+    if (mcpPath) return { command: mcpPath, args: [] };
+  } catch {
+    // Not in PATH — try uvx
+  }
+  try {
+    execSync('which uvx', { encoding: 'utf-8' });
+    return { command: 'uvx', args: ['jcodemunch-mcp'] };
+  } catch {
+    return null;
+  }
+}
+
+/**
  * SessionStart hook handler. Detects environment and auto-indexes CWD
  * with jcodemunch if available but not yet indexed.
  */
@@ -245,13 +265,17 @@ async function detectAndIndex(
         }
       }
     } catch {
-      // CLI not available — try MCP auto-index via JSON-RPC
-      try {
-        const mcpPath = execSync('which jcodemunch-mcp', { encoding: 'utf-8' }).trim();
-        if (mcpPath) {
-          const execFn = (cmd: string, opts?: { encoding?: string; timeout?: number }) =>
-            execSync(cmd, { encoding: 'utf-8', ...opts } as Parameters<typeof execSync>[1]) as string;
-          const text = callJcodemunchMcpTool(mcpPath, 'index_folder', { path: cwd }, execFn);
+      // CLI not available — try MCP auto-index via JSON-RPC.
+      // Resolve transport: direct binary first, then uvx fallback (macOS).
+      const transport = resolveJcodemunchMcpTransport();
+      if (transport) {
+        try {
+          const text = await callJcodemunchMcpTool(
+            transport.command,
+            transport.args,
+            'index_folder',
+            { path: cwd },
+          );
           if (text) {
             const parsedResult = JSON.parse(text);
             if (parsedResult.success) {
@@ -266,9 +290,9 @@ async function detectAndIndex(
               }
             }
           }
+        } catch {
+          // MCP auto-index failed — agent can index via MCP directly
         }
-      } catch {
-        // MCP auto-index failed — agent can index via MCP directly
       }
     }
   }

--- a/tests/session/environment.test.ts
+++ b/tests/session/environment.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { detectEnvironment, detectGraphify } from '../../src/session/environment.js';
-import type { ExecFn } from '../../src/session/environment.js';
+import {
+  detectEnvironment,
+  detectGraphify,
+  callJcodemunchMcpTool,
+  defaultMcpQuery,
+} from '../../src/session/environment.js';
+import type { ExecFn, McpQueryFn } from '../../src/session/environment.js';
 
 function makeExec(responses: Record<string, string | Error>): ExecFn {
   return (cmd: string) => {
@@ -11,6 +16,20 @@ function makeExec(responses: Record<string, string | Error>): ExecFn {
       }
     }
     throw new Error(`unexpected command: ${cmd}`);
+  };
+}
+
+// Mock for the McpQueryFn — keyed by [command, ...args].join(' ').
+function makeMcpQuery(responses: Record<string, string | Error | null>): McpQueryFn {
+  return async (command, args) => {
+    const key = [command, ...args].join(' ');
+    for (const [pattern, result] of Object.entries(responses)) {
+      if (key.includes(pattern)) {
+        if (result instanceof Error) throw result;
+        return result;
+      }
+    }
+    return null;
   };
 }
 
@@ -35,6 +54,7 @@ describe('detectEnvironment', () => {
       'which rtk': '/usr/local/bin/rtk',
       'which jcodemunch': new Error('not found'),
       'which jcodemunch-mcp': new Error('not found'),
+      'which uvx': new Error('not found'),
     });
 
     const env = await detectEnvironment('/fake/cwd', exec);
@@ -47,6 +67,7 @@ describe('detectEnvironment', () => {
       'which rtk': new Error('not found'),
       'which jcodemunch': new Error('not found'),
       'which jcodemunch-mcp': new Error('not found'),
+      'which uvx': new Error('not found'),
     });
 
     const env = await detectEnvironment('/fake/cwd', exec);
@@ -65,11 +86,12 @@ describe('detectEnvironment', () => {
     expect(env.jcodemunchAvailable).toBe(true);
   });
 
-  it('detects jcodemunch unavailable when neither CLI nor MCP found', async () => {
+  it('detects jcodemunch unavailable when neither CLI, MCP, nor uvx found', async () => {
     const exec = makeExec({
       'which rtk': new Error('not found'),
       'which jcodemunch': new Error('not found'),
       'which jcodemunch-mcp': new Error('not found'),
+      'which uvx': new Error('not found'),
     });
 
     const env = await detectEnvironment('/fake/cwd', exec);
@@ -120,15 +142,16 @@ describe('detectEnvironment', () => {
   });
 
   it('detects jcodemunch via MCP server binary when CLI not found', async () => {
-    const mcpOutput = mcpListReposResponse([{ repo: 'local/ai-news' }]);
     const exec = makeExec({
       'which rtk': new Error('not found'),
       'which jcodemunch-mcp': '/home/user/.local/bin/jcodemunch-mcp\n',
       'which jcodemunch': new Error('not found'),
-      'jcodemunch-mcp': mcpOutput,
+    });
+    const mcpQuery = makeMcpQuery({
+      '/home/user/.local/bin/jcodemunch-mcp': mcpListReposResponse([{ repo: 'local/ai-news' }]),
     });
 
-    const env = await detectEnvironment('/home/user/projects/ai-news', exec);
+    const env = await detectEnvironment('/home/user/projects/ai-news', exec, undefined, undefined, mcpQuery);
     expect(env.jcodemunchAvailable).toBe(true);
     expect(env.jcodemunchCwdIndexed).toBe(true);
     expect(env.jcodemunchCwdRepo).toBe('local/ai-news');
@@ -136,18 +159,19 @@ describe('detectEnvironment', () => {
   });
 
   it('detects jcodemunch MCP available but CWD not indexed', async () => {
-    const mcpOutput = mcpListReposResponse([
-      { repo: 'local/other-project' },
-      { repo: 'local/third-project' },
-    ]);
     const exec = makeExec({
       'which rtk': new Error('not found'),
       'which jcodemunch-mcp': '/home/user/.local/bin/jcodemunch-mcp\n',
       'which jcodemunch': new Error('not found'),
-      'jcodemunch-mcp': mcpOutput,
+    });
+    const mcpQuery = makeMcpQuery({
+      '/home/user/.local/bin/jcodemunch-mcp': mcpListReposResponse([
+        { repo: 'local/other-project' },
+        { repo: 'local/third-project' },
+      ]),
     });
 
-    const env = await detectEnvironment('/home/user/projects/ai-news', exec);
+    const env = await detectEnvironment('/home/user/projects/ai-news', exec, undefined, undefined, mcpQuery);
     expect(env.jcodemunchAvailable).toBe(true);
     expect(env.jcodemunchCwdIndexed).toBe(false);
     expect(env.jcodemunchKnownRepos).toHaveLength(2);
@@ -158,24 +182,28 @@ describe('detectEnvironment', () => {
       'which rtk': new Error('not found'),
       'which jcodemunch-mcp': '/home/user/.local/bin/jcodemunch-mcp\n',
       'which jcodemunch': new Error('not found'),
-      'jcodemunch-mcp': 'not valid json',
+    });
+    const mcpQuery = makeMcpQuery({
+      '/home/user/.local/bin/jcodemunch-mcp': 'not valid json',
     });
 
-    const env = await detectEnvironment('/home/user/projects/ai-news', exec);
+    const env = await detectEnvironment('/home/user/projects/ai-news', exec, undefined, undefined, mcpQuery);
     // Should still mark as available since the binary exists
     expect(env.jcodemunchAvailable).toBe(true);
     expect(env.jcodemunchCwdIndexed).toBe(false);
   });
 
-  it('handles MCP query failure gracefully', async () => {
+  it('handles MCP query null result gracefully (timeout / no match)', async () => {
     const exec = makeExec({
       'which rtk': new Error('not found'),
       'which jcodemunch-mcp': '/home/user/.local/bin/jcodemunch-mcp\n',
       'which jcodemunch': new Error('not found'),
-      'jcodemunch-mcp': new Error('timeout'),
+    });
+    const mcpQuery = makeMcpQuery({
+      '/home/user/.local/bin/jcodemunch-mcp': null,
     });
 
-    const env = await detectEnvironment('/home/user/projects/ai-news', exec);
+    const env = await detectEnvironment('/home/user/projects/ai-news', exec, undefined, undefined, mcpQuery);
     expect(env.jcodemunchAvailable).toBe(true);
     expect(env.jcodemunchCwdIndexed).toBe(false);
   });
@@ -197,6 +225,7 @@ describe('detectEnvironment', () => {
       'which rtk': new Error('not found'),
       'which jcodemunch': new Error('not found'),
       'which jcodemunch-mcp': new Error('not found'),
+      'which uvx': new Error('not found'),
     });
 
     const before = Date.now();
@@ -227,32 +256,46 @@ describe('detectEnvironment', () => {
   // ── macOS/uvx-install detection (jcodemunch-mcp not in PATH, managed by uvx) ──
 
   it('macOS/uvx: detects jcodemunch when binary not in PATH but uvx available and CWD is indexed', async () => {
-    const mcpOutput = mcpListReposResponse([{ repo: 'local/forgd-onboarding' }]);
     const exec = makeExec({
       'which rtk': new Error('not found'),
       'which jcodemunch': new Error('not found'),
       'which jcodemunch-mcp': new Error('not found'),
       'which uvx': '/opt/homebrew/bin/uvx',
-      'uvx jcodemunch-mcp': mcpOutput,
+    });
+    const mcpQuery = makeMcpQuery({
+      'uvx jcodemunch-mcp': mcpListReposResponse([{ repo: 'local/forgd-onboarding' }]),
     });
 
-    const env = await detectEnvironment('/Users/jerome/Documents/Claude/Projects/forgd-onboarding', exec);
+    const env = await detectEnvironment(
+      '/Users/jerome/Documents/Claude/Projects/forgd-onboarding',
+      exec,
+      undefined,
+      undefined,
+      mcpQuery,
+    );
     expect(env.jcodemunchAvailable).toBe(true);
     expect(env.jcodemunchCwdIndexed).toBe(true);
     expect(env.jcodemunchCwdRepo).toBe('local/forgd-onboarding');
   });
 
   it('macOS/uvx: marks available=true but cwdIndexed=false when uvx runs but CWD not in repo list', async () => {
-    const mcpOutput = mcpListReposResponse([{ repo: 'local/other-project' }]);
     const exec = makeExec({
       'which rtk': new Error('not found'),
       'which jcodemunch': new Error('not found'),
       'which jcodemunch-mcp': new Error('not found'),
       'which uvx': '/opt/homebrew/bin/uvx',
-      'uvx jcodemunch-mcp': mcpOutput,
+    });
+    const mcpQuery = makeMcpQuery({
+      'uvx jcodemunch-mcp': mcpListReposResponse([{ repo: 'local/other-project' }]),
     });
 
-    const env = await detectEnvironment('/Users/jerome/Documents/Claude/Projects/forgd-onboarding', exec);
+    const env = await detectEnvironment(
+      '/Users/jerome/Documents/Claude/Projects/forgd-onboarding',
+      exec,
+      undefined,
+      undefined,
+      mcpQuery,
+    );
     expect(env.jcodemunchAvailable).toBe(true);
     expect(env.jcodemunchCwdIndexed).toBe(false);
     expect(env.jcodemunchCwdRepo).toBeNull();
@@ -271,38 +314,88 @@ describe('detectEnvironment', () => {
     expect(env.jcodemunchCwdIndexed).toBe(false);
   });
 
-  it('macOS/uvx: handles uvx jcodemunch-mcp startup failure gracefully (exit nonzero / timeout)', async () => {
+  it('macOS/uvx: handles uvx jcodemunch-mcp startup failure (mcpQuery returns null) gracefully', async () => {
     const exec = makeExec({
       'which rtk': new Error('not found'),
       'which jcodemunch': new Error('not found'),
       'which jcodemunch-mcp': new Error('not found'),
       'which uvx': '/opt/homebrew/bin/uvx',
-      'uvx jcodemunch-mcp': new Error('uvx: Package jcodemunch-mcp not found'),
+    });
+    const mcpQuery = makeMcpQuery({
+      'uvx jcodemunch-mcp': null,
     });
 
-    const env = await detectEnvironment('/Users/jerome/Documents/Claude/Projects/forgd-onboarding', exec);
+    const env = await detectEnvironment(
+      '/Users/jerome/Documents/Claude/Projects/forgd-onboarding',
+      exec,
+      undefined,
+      undefined,
+      mcpQuery,
+    );
     expect(env.jcodemunchAvailable).toBe(false);
     expect(env.jcodemunchCwdIndexed).toBe(false);
+  });
+
+  it('macOS/uvx: mcpQuery is invoked with command=uvx args=[jcodemunch-mcp] (not a shell pipe)', async () => {
+    // Regression: previously detection used `printf ... | uvx jcodemunch-mcp` as a
+    // shell pipe, which closed stdin at EOF and caused the MCP server to exit
+    // before emitting the list_repos response. The new spawn-based approach calls
+    // the binary directly with args and holds stdin open until the response arrives.
+    let capturedCommand = '';
+    let capturedArgs: string[] = [];
+    let capturedMessages: string[] = [];
+    const exec = makeExec({
+      'which rtk': new Error('not found'),
+      'which jcodemunch': new Error('not found'),
+      'which jcodemunch-mcp': new Error('not found'),
+      'which uvx': '/opt/homebrew/bin/uvx',
+    });
+    const mcpQuery: McpQueryFn = async (command, args, messages) => {
+      capturedCommand = command;
+      capturedArgs = args;
+      capturedMessages = messages;
+      return mcpListReposResponse([{ repo: 'local/my-project' }]);
+    };
+
+    await detectEnvironment('/Users/jerome/projects/my-project', exec, undefined, undefined, mcpQuery);
+    expect(capturedCommand).toBe('uvx');
+    expect(capturedArgs).toEqual(['jcodemunch-mcp']);
+    // Must include initialize, notifications/initialized, and tools/call list_repos
+    expect(capturedMessages).toHaveLength(3);
+    expect(capturedMessages[0]).toContain('"method":"initialize"');
+    expect(capturedMessages[1]).toContain('"method":"notifications/initialized"');
+    expect(capturedMessages[2]).toContain('"name":"list_repos"');
   });
 
   it('Linux/direct-binary: existing which jcodemunch-mcp path still wins when binary is in PATH (uvx fallback not reached)', async () => {
     // On Linux with pip/pipx install, jcodemunch-mcp lands in ~/.local/bin (in PATH).
     // The direct binary path must be preferred; uvx fallback must not be reached.
-    // Note: 'which jcodemunch-mcp' must come before 'which jcodemunch' in the map
-    // because makeExec uses substring matching and the shorter key would match first.
-    const mcpOutput = mcpListReposResponse([{ repo: 'local/my-project' }]);
+    let mcpQueryCommand = '';
     const exec = makeExec({
       'which rtk': new Error('not found'),
       'which jcodemunch-mcp': '/home/user/.local/bin/jcodemunch-mcp',
       'which jcodemunch': new Error('not found'),
-      'jcodemunch-mcp': mcpOutput,
-      // uvx is NOT in this map — if the code reaches it, makeExec throws "unexpected command"
+      // uvx is NOT in this map — if `which uvx` is reached, makeExec throws
     });
+    const mcpQuery: McpQueryFn = async (command, args) => {
+      mcpQueryCommand = command;
+      if (command === '/home/user/.local/bin/jcodemunch-mcp' && args.length === 0) {
+        return mcpListReposResponse([{ repo: 'local/my-project' }]);
+      }
+      return null;
+    };
 
-    const env = await detectEnvironment('/home/user/projects/my-project', exec);
+    const env = await detectEnvironment(
+      '/home/user/projects/my-project',
+      exec,
+      undefined,
+      undefined,
+      mcpQuery,
+    );
     expect(env.jcodemunchAvailable).toBe(true);
     expect(env.jcodemunchCwdIndexed).toBe(true);
     expect(env.jcodemunchCwdRepo).toBe('local/my-project');
+    expect(mcpQueryCommand).toBe('/home/user/.local/bin/jcodemunch-mcp');
   });
 });
 
@@ -379,6 +472,7 @@ describe('detectGraphify', () => {
       'which rtk': new Error('not found'),
       'which jcodemunch': new Error('not found'),
       'which jcodemunch-mcp': new Error('not found'),
+      'which uvx': new Error('not found'),
       'which graphify': '/usr/local/bin/graphify',
     });
     const existsCheck = (path: string) =>
@@ -409,5 +503,168 @@ describe('detectGraphify', () => {
     const result = detectGraphify('/fake/cwd', exec, existsCheck, statCheck);
     expect(result.state).toBe('ready');
     expect(result.graphPath).toBe('graphify-out/graph.json');
+  });
+});
+
+describe('callJcodemunchMcpTool', () => {
+  // Helper to build an index_folder-style MCP response.
+  function mcpToolResponse(payload: object): string {
+    const rpcResponse = {
+      jsonrpc: '2.0',
+      id: 2,
+      result: {
+        content: [{ type: 'text', text: JSON.stringify(payload) }],
+        isError: false,
+      },
+    };
+    const initResponse = { jsonrpc: '2.0', id: 1, result: { protocolVersion: '2025-03-26' } };
+    return JSON.stringify(initResponse) + '\n' + JSON.stringify(rpcResponse);
+  }
+
+  it('invokes a direct binary with empty args', async () => {
+    let capturedCommand = '';
+    let capturedArgs: string[] = [];
+    const mcpQuery: McpQueryFn = async (command, args) => {
+      capturedCommand = command;
+      capturedArgs = args;
+      return mcpToolResponse({ success: true, repo: 'local/proj' });
+    };
+
+    const result = await callJcodemunchMcpTool(
+      '/usr/local/bin/jcodemunch-mcp',
+      [],
+      'index_folder',
+      { path: '/fake/cwd' },
+      mcpQuery,
+    );
+    expect(capturedCommand).toBe('/usr/local/bin/jcodemunch-mcp');
+    expect(capturedArgs).toEqual([]);
+    expect(result).toBeTruthy();
+    expect(JSON.parse(result!)).toEqual({ success: true, repo: 'local/proj' });
+  });
+
+  it('invokes uvx with [jcodemunch-mcp] args for macOS uvx installs', async () => {
+    let capturedCommand = '';
+    let capturedArgs: string[] = [];
+    const mcpQuery: McpQueryFn = async (command, args) => {
+      capturedCommand = command;
+      capturedArgs = args;
+      return mcpToolResponse({ success: true });
+    };
+
+    const result = await callJcodemunchMcpTool(
+      'uvx',
+      ['jcodemunch-mcp'],
+      'index_folder',
+      { path: '/fake/cwd' },
+      mcpQuery,
+    );
+    expect(capturedCommand).toBe('uvx');
+    expect(capturedArgs).toEqual(['jcodemunch-mcp']);
+    expect(result).toBeTruthy();
+  });
+
+  it('sends initialize + notifications/initialized + tool call in order', async () => {
+    let capturedMessages: string[] = [];
+    const mcpQuery: McpQueryFn = async (_command, _args, messages) => {
+      capturedMessages = messages;
+      return mcpToolResponse({ ok: true });
+    };
+
+    await callJcodemunchMcpTool(
+      'uvx',
+      ['jcodemunch-mcp'],
+      'search_symbols',
+      { query: 'foo' },
+      mcpQuery,
+    );
+    expect(capturedMessages).toHaveLength(3);
+    expect(capturedMessages[0]).toContain('"method":"initialize"');
+    expect(capturedMessages[1]).toContain('"method":"notifications/initialized"');
+    expect(capturedMessages[2]).toContain('"name":"search_symbols"');
+    expect(capturedMessages[2]).toContain('"query":"foo"');
+  });
+
+  it('returns null when mcpQuery returns null (timeout / no match)', async () => {
+    const mcpQuery: McpQueryFn = async () => null;
+    const result = await callJcodemunchMcpTool(
+      'uvx',
+      ['jcodemunch-mcp'],
+      'index_folder',
+      { path: '/fake' },
+      mcpQuery,
+    );
+    expect(result).toBeNull();
+  });
+
+  it('returns null when response lacks id:2 line', async () => {
+    const mcpQuery: McpQueryFn = async () =>
+      '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-03-26"}}';
+    const result = await callJcodemunchMcpTool(
+      'uvx',
+      ['jcodemunch-mcp'],
+      'index_folder',
+      { path: '/fake' },
+      mcpQuery,
+    );
+    expect(result).toBeNull();
+  });
+
+  it('returns null on malformed JSON', async () => {
+    const mcpQuery: McpQueryFn = async () => '{"id":2 not-valid-json';
+    const result = await callJcodemunchMcpTool(
+      'uvx',
+      ['jcodemunch-mcp'],
+      'index_folder',
+      { path: '/fake' },
+      mcpQuery,
+    );
+    expect(result).toBeNull();
+  });
+});
+
+describe('defaultMcpQuery (real-process integration)', () => {
+  // Smoke test: spawn a tiny shell script that emits a fake MCP response,
+  // verify defaultMcpQuery reads stdout and resolves when it sees `"id":<matchId>`.
+  it('resolves with stdout once matching id line arrives, then kills the child', async () => {
+    // Use printf with two separate calls so the inner JSON's quotes survive.
+    // The child sleeps after printing — defaultMcpQuery must kill it on match.
+    const start = Date.now();
+    const result = await defaultMcpQuery(
+      '/bin/sh',
+      ['-c', `printf '%s\\n' '{"jsonrpc":"2.0","id":1,"result":{}}'; printf '%s\\n' '{"jsonrpc":"2.0","id":2,"result":{"value":42}}'; sleep 10`],
+      [],
+      2,
+      5_000,
+    );
+    const elapsed = Date.now() - start;
+    expect(result).toContain('"id":2');
+    expect(result).toContain('"value":42');
+    // Must have returned quickly after id:2 — well under the sleep 10 + 5s timeout.
+    expect(elapsed).toBeLessThan(3_000);
+  });
+
+  it('returns null on timeout when no matching id appears', async () => {
+    // Spawn a process that emits unrelated output then sleeps. With a 200ms
+    // timeout and no matching id:2, we should resolve null.
+    const result = await defaultMcpQuery(
+      '/bin/sh',
+      ['-c', 'printf "unrelated\\n"; sleep 5'],
+      [],
+      2,
+      200,
+    );
+    expect(result).toBeNull();
+  });
+
+  it('returns null when spawned command does not exist', async () => {
+    const result = await defaultMcpQuery(
+      '/nonexistent/binary-that-should-not-exist',
+      [],
+      [],
+      2,
+      1_000,
+    );
+    expect(result).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Two related fixes for macOS users running jcodemunch via uvx (the Claude Code recommended install):

- **Detection**: replace `printf | uvx jcodemunch-mcp` pipe with a spawn-based `defaultMcpQuery` helper that keeps stdin open and reads stdout until the matching JSON-RPC response arrives. The shell-pipe pattern closed stdin at EOF, and uvx had enough startup overhead that the server emitted only `initialize` (id:1) before shutting down — `list_repos` (id:2) never returned, so detection saw `knownRepos: []` and the tool router never advised jcodemunch.
- **Auto-index**: extend `start.ts` auto-indexing to fall back to `uvx jcodemunch-mcp` when no direct binary is in PATH. Previously, a brand-new unindexed project on macOS uvx would never get auto-indexed at session start.

## Why this matters

On macOS, the previous code path resulted in 0 routed jcodemunch queries per session (router gate `jcodemunchAvailable && jcodemunchCwdIndexed` always false). Linux installs with the binary directly in PATH didn't hit the timing race, so this only manifested for macOS users (or Linux users who installed via uvx instead of pip/pipx).

## Approach

A previous iteration of this fix used a `sleep 2` after the printf to keep stdin open longer. That worked but masked the underlying race condition with an arbitrary number and added 2s to every session start. The spawn-based approach:

1. Spawns the MCP server (or `uvx jcodemunch-mcp`) directly with stdio pipes
2. Writes all JSON-RPC messages but does NOT close stdin
3. Reads stdout in real time
4. Kills the child the moment the expected response arrives, or on timeout

Same helper (`callJcodemunchMcpTool`) now handles both detection (`list_repos`) and auto-indexing (`index_folder`) for both direct-binary and uvx transports.

## Verification

End-to-end against real `uvx jcodemunch-mcp` on macOS:

- **Before**: `knownRepos: []`, `cwdIndexed: false` (2/3 tries returned nothing; sleep workaround took ~2000ms)
- **After**: 6 repos resolved, `cwdIndexed: true`, ~290ms total

## Test plan

- [x] Run `npm test` — 1021/1021 passing (9 new tests covering DI surface, real-process spawn integration, timeout, and kill-on-match)
- [x] Built `dist/` contains spawn-based code; no `printf`/`sleep` remnants
- [x] Live verification on macOS uvx install resolves indexed repos in <500ms
- [ ] Reviewer: confirm no regressions on Linux direct-binary install (covered by existing tests; substring-mock pattern preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)