### PR TITLE
Integration reliability: jcodemunch detection redesign, graphify/rtk hardening

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1111,9 +1111,9 @@
       "license": "MIT"
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
-      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.6.tgz",
+      "integrity": "sha512-LsAdmUapA0qSN306d8+zOyawM0hFm2m2Hg9IwVNIKBm+qJV8cijiq2c+gxKZcB1HCfIWAy+0qEZDCUQA58A1cw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1135,8 +1135,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "3.2.4",
-        "vitest": "3.2.4"
+        "@vitest/browser": "3.2.6",
+        "vitest": "3.2.6"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -1145,15 +1145,15 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
-      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
         "chai": "^5.2.0",
         "tinyrainbow": "^2.0.0"
       },
@@ -1162,13 +1162,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
-      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.2.4",
+        "@vitest/spy": "3.2.6",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
       },
@@ -1189,9 +1189,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1202,13 +1202,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
-      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.4",
+        "@vitest/utils": "3.2.6",
         "pathe": "^2.0.3",
         "strip-literal": "^3.0.0"
       },
@@ -1217,13 +1217,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
-      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
+        "@vitest/pretty-format": "3.2.6",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
@@ -1232,9 +1232,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
-      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1245,13 +1245,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
+        "@vitest/pretty-format": "3.2.6",
         "loupe": "^3.1.4",
         "tinyrainbow": "^2.0.0"
       },
@@ -1332,9 +1332,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3561,20 +3561,20 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
-      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.4",
-        "@vitest/mocker": "3.2.4",
-        "@vitest/pretty-format": "^3.2.4",
-        "@vitest/runner": "3.2.4",
-        "@vitest/snapshot": "3.2.4",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
         "chai": "^5.2.0",
         "debug": "^4.4.1",
         "expect-type": "^1.2.1",
@@ -3604,8 +3604,8 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.4",
-        "@vitest/ui": "3.2.4",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
         "happy-dom": "*",
         "jsdom": "*"
       },

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -3,6 +3,7 @@ import { mkdirSync, existsSync, readFileSync, writeFileSync, unlinkSync, readdir
 import { join, resolve, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { renderTemplate } from './renderer.js';
+import { GRAPHIFY_OUT_DIR } from '../constants.js';
 import { DEFAULT_CONFIG } from '../config.js';
 import { stringify as yamlStringify } from 'yaml';
 import { detectEnvironment, type ExecFn } from '../session/environment.js';
@@ -102,7 +103,7 @@ export async function initCommand(projectDir: string, options: InitOptions): Pro
   }
 
   // Create graphify-out directory (graph built on-demand, no placeholder)
-  const graphifyDir = join(projectDir, 'graphify-out');
+  const graphifyDir = join(projectDir, GRAPHIFY_OUT_DIR);
   if (!existsSync(graphifyDir)) {
     mkdirSync(graphifyDir, { recursive: true });
   }
@@ -120,7 +121,7 @@ const GITIGNORE_MARKER_END = '# --- end rig-managed ---';
 const GITIGNORE_ENTRIES = [
   '.harness.yaml.local',
   '*.session-cache.json',
-  'graphify-out/',
+  `${GRAPHIFY_OUT_DIR}/`,
 ];
 
 function updateGitignore(projectDir: string): void {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,18 @@
+import { join } from 'node:path';
+
+// ── Graphify on-disk layout ──
+// Single source of truth for paths graphify writes; a layout change upstream
+// should be a one-file edit here, not a shotgun edit across detection,
+// stats capture, build state, and init.
+
+export const GRAPHIFY_OUT_DIR = 'graphify-out';
+export const GRAPH_JSON_REL = `${GRAPHIFY_OUT_DIR}/graph.json`;
+export const GRAPH_REPORT_REL = `${GRAPHIFY_OUT_DIR}/GRAPH_REPORT.md`;
+export const REBUILD_LOCK_REL = `${GRAPHIFY_OUT_DIR}/.rebuild.lock`;
+
+/** graph.json files smaller than this are placeholders, not real graphs. */
+export const GRAPHIFY_PLACEHOLDER_THRESHOLD = 1024; // bytes
+
+export const graphJsonPath = (dir: string): string => join(dir, GRAPHIFY_OUT_DIR, 'graph.json');
+export const graphReportPath = (dir: string): string => join(dir, GRAPHIFY_OUT_DIR, 'GRAPH_REPORT.md');
+export const rebuildLockPath = (dir: string): string => join(dir, GRAPHIFY_OUT_DIR, '.rebuild.lock');

--- a/src/enforcement/post-tool-use.ts
+++ b/src/enforcement/post-tool-use.ts
@@ -1,10 +1,15 @@
+import { resolve } from 'node:path';
 import { FileTracker } from './file-tracker.js';
 import { SessionCache } from '../session/cache.js';
 import type { HarnessConfig } from '../types.js';
 import { checkStaleTests } from './stale-test.js';
 import { checkConstitutional } from './constitutional.js';
 import { checkZeroDefect } from './zero-defect.js';
-import { incrementMetric, captureExternalGraphifyStats } from '../session/metrics.js';
+import {
+  incrementMetric,
+  captureExternalGraphifyStats,
+  captureGraphifyStatsViaReport,
+} from '../session/metrics.js';
 import type { ExecFn } from '../session/metrics.js';
 
 /**
@@ -60,12 +65,17 @@ export function handlePostToolUse(
   }
 
   // Capture graphify stats for external directories accessed via jcodemunch
-  const externalDir = extractExternalDirectory(tool, args);
-  if (externalDir && execFn) {
+  // or built directly with `graphify update` in Bash
+  const external = extractExternalDirectory(tool, args);
+  if (external && execFn) {
     try {
-      const stats = captureExternalGraphifyStats(externalDir, execFn);
+      // The Bash trigger fires right after `graphify update` completed — read
+      // the report directly instead of re-checking/re-building the graph.
+      const stats = external.source === 'bash'
+        ? captureGraphifyStatsViaReport(external.dir, execFn)
+        : captureExternalGraphifyStats(external.dir, execFn);
       if (stats) {
-        cache.setGraphifyStats(externalDir, stats);
+        cache.setGraphifyStats(resolve(external.dir), stats);
       }
     } catch {
       // graphify not available — skip silently
@@ -78,24 +88,35 @@ export function handlePostToolUse(
   return violations.join('\n\n---\n\n');
 }
 
+const BASH_GRAPHIFY_UPDATE = /\bgraphify(?:y)?\s+update\s+(?:"([^"]+)"|'([^']+)'|(\S+))/;
+
 /**
- * Extract an external (non-CWD) directory path from jcodemunch tool calls.
- * Returns null for CWD paths or unrecognized tools.
+ * Extract an external (non-CWD) directory path from jcodemunch tool calls or
+ * a Bash `graphify update <dir>` command. Returns null for CWD paths or
+ * unrecognized tools. The source distinguishes the just-built Bash case
+ * (read report directly) from MCP indexing (may need a build first).
  */
 function extractExternalDirectory(
   tool: string,
   args: Record<string, unknown>,
-): string | null {
+): { dir: string; source: 'mcp' | 'bash' } | null {
   let directory: string | undefined;
+  let source: 'mcp' | 'bash' = 'mcp';
 
   if (tool === 'mcp__jcodemunch__index_folder') {
     directory = (args.path as string) ?? (args.folder_path as string);
   } else if (tool === 'mcp__jcodemunch__resolve_repo') {
     directory = args.path as string;
+  } else if (tool === 'Bash' && typeof args.command === 'string') {
+    const match = args.command.match(BASH_GRAPHIFY_UPDATE);
+    if (match) {
+      directory = match[1] ?? match[2] ?? match[3];
+      source = 'bash';
+    }
   }
 
   if (!directory) return null;
   const cwd = process.cwd();
   if (directory.startsWith(cwd)) return null;
-  return directory;
+  return { dir: directory, source };
 }

--- a/src/router/hook.ts
+++ b/src/router/hook.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from 'node:child_process';
+import { appendFileSync } from 'node:fs';
 import type { HarnessConfig, RewriteResult } from '../types.js';
 import { SessionCache } from '../session/cache.js';
 import { findMatchingRule, getDefaultRules } from './rules.js';
@@ -14,19 +15,63 @@ export interface HookOptions {
   existsCheck?: ExistsCheckFn;
 }
 
-const defaultExecRewrite: ExecRewriteFn = (rtkPath: string, args: string[]): string | null => {
+export type RawExecFileFn = (file: string, args: string[], opts: object) => string;
+
+const RTK_DIAG_LOG = '/tmp/rig-rtk-rewrite-failures.log';
+
+const defaultWriteDiag = (line: string): void => {
   try {
-    const result = execFileSync(rtkPath, args, {
-      encoding: 'utf-8',
-      timeout: 5000,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-    return result.trim() || null;
+    appendFileSync(RTK_DIAG_LOG, line + '\n');
   } catch {
-    // exit 1 = no rewrite, exit 2 = denied — both fall through to rig rules
-    return null;
+    // Best-effort diagnostics — never break the hook
   }
 };
+
+/**
+ * Build the default ExecRewriteFn. Exit codes 1 (no rewrite) and 2 (denied)
+ * are rtk's expected decline contract and stay silent; anything else —
+ * unexpected exit codes, signals, ENOENT — is appended as a JSON line to
+ * the diagnostic log so silent fallthroughs become debuggable in the field.
+ * Set RIG_DEBUG to log expected declines too. Null-fallthrough is unchanged.
+ */
+export function makeDefaultExecRewrite(
+  writeDiag: (line: string) => void = defaultWriteDiag,
+  rawExec: RawExecFileFn = execFileSync as unknown as RawExecFileFn,
+): ExecRewriteFn {
+  return (rtkPath: string, args: string[]): string | null => {
+    try {
+      const result = rawExec(rtkPath, args, {
+        encoding: 'utf-8',
+        timeout: 5000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      return result.trim() || null;
+    } catch (err) {
+      const e = err as { status?: number; signal?: string; code?: string; stderr?: unknown };
+      const expectedDecline = e?.status === 1 || e?.status === 2;
+      if (!expectedDecline || process.env.RIG_DEBUG) {
+        const stderr =
+          typeof e?.stderr === 'string'
+            ? e.stderr
+            : Buffer.isBuffer(e?.stderr)
+              ? e.stderr.toString('utf-8')
+              : '';
+        writeDiag(
+          JSON.stringify({
+            ts: Date.now(),
+            command: args.join(' '),
+            exitCode: e?.status ?? null,
+            signal: e?.signal ?? e?.code ?? null,
+            stderr: stderr.slice(0, 300),
+          }),
+        );
+      }
+      return null;
+    }
+  };
+}
+
+const defaultExecRewrite: ExecRewriteFn = makeDefaultExecRewrite();
 
 /**
  * Try to rewrite a Bash command using `rtk rewrite`.

--- a/src/scout/graph-state.ts
+++ b/src/scout/graph-state.ts
@@ -48,23 +48,49 @@ export function triggerBuild(
   }
 }
 
+export interface WaitForBuildOpts {
+  /** How long to keep polling for the graph. 0 (default) = single immediate check. */
+  deadlineMs?: number;
+  intervalMs?: number;
+  sleep?: (ms: number) => void;
+}
+
+// Synchronous sleep that doesn't spin the CPU — hooks are synchronous processes.
+const defaultSleep = (ms: number): void => {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+};
+
 /**
  * Check the result of a previously-triggered build.
  * Returns ready if graph.json now exists with real content, failed otherwise.
+ *
+ * `graphify update` can return before graph.json is fully on disk — a single
+ * immediate check races the build output (observed in the field: update
+ * returned at T, graph landed at T+1s, "failed" got cached all session).
+ * Callers in a position to wait pass a deadline to poll across that window.
  */
 export function waitForBuild(
   _buildInfo: GraphBuildInfo,
   cwd: string,
   existsCheck: ExistsCheck,
   statCheck: StatCheck,
+  opts: WaitForBuildOpts = {},
 ): GraphBuildInfo {
+  const deadlineMs = opts.deadlineMs ?? 0;
+  const intervalMs = opts.intervalMs ?? 250;
+  const sleep = opts.sleep ?? defaultSleep;
   const graphFile = graphJsonPath(cwd);
+  const start = Date.now();
 
-  if (existsCheck(graphFile)) {
-    const stat = statCheck(graphFile);
-    if (stat && stat.size >= GRAPHIFY_PLACEHOLDER_THRESHOLD) {
-      return { state: 'ready', graphPath: GRAPH_JSON_REL };
+  for (;;) {
+    if (existsCheck(graphFile)) {
+      const stat = statCheck(graphFile);
+      if (stat && stat.size >= GRAPHIFY_PLACEHOLDER_THRESHOLD) {
+        return { state: 'ready', graphPath: GRAPH_JSON_REL };
+      }
     }
+    if (Date.now() - start >= deadlineMs) break;
+    sleep(intervalMs);
   }
 
   return { state: 'failed', errorReason: 'graph.json missing or placeholder after build' };
@@ -90,14 +116,22 @@ export function ensureGraphReady(
     case 'ready':
       return info;
 
-    case 'absent':
-      triggerBuild(directory, exec);
+    case 'absent': {
+      const build = triggerBuild(directory, exec);
+      // A failed trigger carries the error reason — don't discard it for a
+      // pointless disk check that would report a generic failure.
+      if (build.state === 'failed') return build;
       return waitForBuild(info, directory, existsCheck, statCheck);
+    }
 
     case 'building':
       return waitForBuild(info, directory, existsCheck, statCheck);
 
-    case 'failed':
-      return info;
+    case 'failed': {
+      // A cached failure may be stale: the build can land moments after the
+      // verdict was recorded (build-output race). The disk is truth.
+      const current = determineGraphState(directory, existsCheck, statCheck);
+      return current.state === 'ready' ? current : info;
+    }
   }
 }

--- a/src/scout/graph-state.ts
+++ b/src/scout/graph-state.ts
@@ -42,8 +42,10 @@ export function triggerBuild(
   try {
     exec(`graphify update "${directory}"`, { encoding: 'utf-8', timeout: BUILD_TIMEOUT });
     return { state: 'building', startedAt: Date.now() };
-  } catch {
-    return { state: 'failed' };
+  } catch (err) {
+    // Preserve why: timeout vs AST recursion vs missing CLI are very different fixes
+    const message = err instanceof Error ? err.message : String(err);
+    return { state: 'failed', errorReason: message.slice(0, 200) };
   }
 }
 
@@ -66,7 +68,7 @@ export function waitForBuild(
     }
   }
 
-  return { state: 'failed' };
+  return { state: 'failed', errorReason: 'graph.json missing or placeholder after build' };
 }
 
 /**

--- a/src/scout/graph-state.ts
+++ b/src/scout/graph-state.ts
@@ -1,7 +1,6 @@
-import { join } from 'node:path';
 import type { Environment, GraphBuildInfo } from '../types.js';
+import { graphJsonPath, GRAPH_JSON_REL, GRAPHIFY_PLACEHOLDER_THRESHOLD } from '../constants.js';
 
-const PLACEHOLDER_THRESHOLD = 1024; // bytes
 const BUILD_TIMEOUT = 120_000; // ms
 
 type ExecFn = (cmd: string, opts?: { encoding?: string; timeout?: number }) => string;
@@ -17,18 +16,18 @@ export function determineGraphState(
   existsCheck: ExistsCheck,
   statCheck: StatCheck,
 ): GraphBuildInfo {
-  const graphJsonPath = join(cwd, 'graphify-out', 'graph.json');
+  const graphFile = graphJsonPath(cwd);
 
-  if (!existsCheck(graphJsonPath)) {
+  if (!existsCheck(graphFile)) {
     return { state: 'absent' };
   }
 
-  const stat = statCheck(graphJsonPath);
-  if (!stat || stat.size < PLACEHOLDER_THRESHOLD) {
+  const stat = statCheck(graphFile);
+  if (!stat || stat.size < GRAPHIFY_PLACEHOLDER_THRESHOLD) {
     return { state: 'absent' };
   }
 
-  return { state: 'ready', graphPath: 'graphify-out/graph.json' };
+  return { state: 'ready', graphPath: GRAPH_JSON_REL };
 }
 
 /**
@@ -59,12 +58,12 @@ export function waitForBuild(
   existsCheck: ExistsCheck,
   statCheck: StatCheck,
 ): GraphBuildInfo {
-  const graphJsonPath = join(cwd, 'graphify-out', 'graph.json');
+  const graphFile = graphJsonPath(cwd);
 
-  if (existsCheck(graphJsonPath)) {
-    const stat = statCheck(graphJsonPath);
-    if (stat && stat.size >= PLACEHOLDER_THRESHOLD) {
-      return { state: 'ready', graphPath: 'graphify-out/graph.json' };
+  if (existsCheck(graphFile)) {
+    const stat = statCheck(graphFile);
+    if (stat && stat.size >= GRAPHIFY_PLACEHOLDER_THRESHOLD) {
+      return { state: 'ready', graphPath: GRAPH_JSON_REL };
     }
   }
 

--- a/src/session/claude-config.ts
+++ b/src/session/claude-config.ts
@@ -1,0 +1,90 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { homedir } from 'node:os';
+
+/**
+ * An MCP server registration as Claude Code launches it. Reading this from
+ * Claude's own config is ground truth for how to reach the server — guessing
+ * the invocation (e.g. bare `uvx jcodemunch-mcp`) fails for installs that use
+ * `uvx --from <wheel-url>`, since the package is not on PyPI.
+ */
+export interface McpRegistration {
+  command: string;
+  args: string[];
+  source: 'local' | 'project' | 'user';
+}
+
+export type ReadFileFn = (path: string) => string;
+
+interface RawServerEntry {
+  type?: string;
+  command?: unknown;
+  args?: unknown;
+}
+
+/**
+ * Find the jcodemunch MCP server registration in Claude Code's config files.
+ * Scope precedence mirrors Claude Code: local (~/.claude.json projects[cwd])
+ * > project (<cwd>/.mcp.json) > user (~/.claude.json top-level mcpServers).
+ * Returns null if no stdio registration is found; never throws.
+ */
+export function resolveJcodemunchRegistration(
+  cwd: string,
+  readFile: ReadFileFn = (p) => readFileSync(p, 'utf-8'),
+  existsCheck: (path: string) => boolean = existsSync,
+  homeDir: string = homedir(),
+): McpRegistration | null {
+  const claudeJson = readJson(join(homeDir, '.claude.json'), readFile, existsCheck);
+
+  const local = findJcodemunchEntry(claudeJson?.projects?.[resolve(cwd)]?.mcpServers);
+  if (local) return { ...local, source: 'local' };
+
+  const projectJson = readJson(join(cwd, '.mcp.json'), readFile, existsCheck);
+  const project = findJcodemunchEntry(projectJson?.mcpServers);
+  if (project) return { ...project, source: 'project' };
+
+  const user = findJcodemunchEntry(claudeJson?.mcpServers);
+  if (user) return { ...user, source: 'user' };
+
+  return null;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function readJson(
+  path: string,
+  readFile: ReadFileFn,
+  existsCheck: (path: string) => boolean,
+): any {
+  try {
+    if (!existsCheck(path)) return null;
+    return JSON.parse(readFile(path));
+  } catch {
+    return null;
+  }
+}
+
+function findJcodemunchEntry(
+  servers: Record<string, RawServerEntry> | undefined | null,
+): { command: string; args: string[] } | null {
+  if (!servers || typeof servers !== 'object') return null;
+
+  const exact = toStdioEntry(servers['jcodemunch']);
+  if (exact) return exact;
+
+  for (const [key, entry] of Object.entries(servers)) {
+    const candidate = toStdioEntry(entry);
+    if (!candidate) continue;
+    const haystack = `${key} ${candidate.command} ${candidate.args.join(' ')}`.toLowerCase();
+    if (haystack.includes('jcodemunch')) return candidate;
+  }
+
+  return null;
+}
+
+function toStdioEntry(entry: RawServerEntry | undefined): { command: string; args: string[] } | null {
+  if (!entry || typeof entry !== 'object') return null;
+  if (entry.type !== undefined && entry.type !== 'stdio') return null;
+  if (typeof entry.command !== 'string' || entry.command.length === 0) return null;
+  const args = Array.isArray(entry.args) ? entry.args.filter((a): a is string => typeof a === 'string') : [];
+  return { command: entry.command, args };
+}

--- a/src/session/environment.ts
+++ b/src/session/environment.ts
@@ -1,7 +1,11 @@
 import { execSync, spawn } from 'node:child_process';
 import { basename, join } from 'node:path';
 import { existsSync, statSync } from 'node:fs';
-import type { Environment, GraphBuildInfo } from '../types.js';
+import type { Environment, GraphBuildInfo, JcodemunchTransport } from '../types.js';
+import { resolveJcodemunchRegistration } from './claude-config.js';
+import type { McpRegistration } from './claude-config.js';
+
+export type RegistrationLookupFn = (cwd: string) => McpRegistration | null;
 
 export interface ExecFn {
   (command: string, options?: { encoding?: string; timeout?: number }): string;
@@ -80,9 +84,10 @@ export async function detectEnvironment(
   existsCheck: (path: string) => boolean = existsSync,
   statCheck: (path: string) => { size: number } | undefined = defaultStatCheck,
   mcpQuery: McpQueryFn = defaultMcpQuery,
+  registrationLookup: RegistrationLookupFn = resolveJcodemunchRegistration,
 ): Promise<Environment> {
   const rtkResult = detectRtk(exec);
-  const jmResult = await detectJcodemunch(cwd, exec, mcpQuery);
+  const jmResult = await detectJcodemunch(cwd, exec, mcpQuery, registrationLookup);
   const graphifyResult = detectGraphify(cwd, exec, existsCheck, statCheck);
 
   return {
@@ -92,6 +97,7 @@ export async function detectEnvironment(
     jcodemunchCwdIndexed: jmResult.cwdIndexed,
     jcodemunchCwdRepo: jmResult.cwdRepo,
     jcodemunchKnownRepos: jmResult.knownRepos,
+    jcodemunchTransport: jmResult.transport,
     graphifyAvailable: graphifyResult.state === 'ready',
     graphifyGraphPath: graphifyResult.state === 'ready' ? graphifyResult.graphPath ?? null : null,
     graphBuildInfo: graphifyResult.state === 'absent' && !graphifyResult._cliFound ? undefined : graphifyResult,
@@ -164,37 +170,72 @@ interface JcodemunchDetection {
   cwdIndexed: boolean;
   cwdRepo: string | null;
   knownRepos: string[];
+  transport?: JcodemunchTransport;
 }
 
 async function detectJcodemunch(
   cwd: string,
   exec: ExecFn,
   mcpQuery: McpQueryFn,
+  registrationLookup: RegistrationLookupFn,
 ): Promise<JcodemunchDetection> {
   // Try CLI binary first
   try {
     exec('which jcodemunch');
-    return detectJcodemunchCli(cwd, exec);
+    return {
+      ...detectJcodemunchCli(cwd, exec),
+      transport: { kind: 'cli', command: 'jcodemunch', args: [] },
+    };
   } catch {
-    // CLI not found — try MCP server binary
+    // CLI not found — try the registered MCP command
+  }
+
+  // Claude Code's own MCP registration is ground truth for how the server is
+  // launched (e.g. `uvx --from <wheel-url> jcodemunch-mcp` for GitHub-release
+  // installs that a bare `uvx jcodemunch-mcp` can never resolve).
+  let registration: McpRegistration | null = null;
+  try {
+    registration = registrationLookup(cwd);
+  } catch {
+    // Unreadable config — continue with the PATH-based chain
+  }
+  if (registration) {
+    const output = await mcpQuery(registration.command, registration.args, LIST_REPOS_MESSAGES, 2, 20_000);
+    if (output) {
+      return {
+        ...parseListReposResponse(cwd, output),
+        transport: {
+          kind: 'config',
+          command: registration.command,
+          args: registration.args,
+          source: registration.source,
+        },
+      };
+    }
+    // Registered command didn't respond — fall through to PATH-based detection
   }
 
   try {
     const mcpPath = exec('which jcodemunch-mcp').trim();
     if (mcpPath) {
-      return await detectJcodemunchMcp(cwd, mcpPath, mcpQuery);
+      return {
+        ...(await detectJcodemunchMcp(cwd, mcpPath, mcpQuery)),
+        transport: { kind: 'binary', command: mcpPath, args: [] },
+      };
     }
   } catch {
     // MCP binary not found either
   }
 
-  // macOS/uvx install: jcodemunch-mcp is managed by uvx and not in PATH.
-  // Claude Code's recommended install (command: "uvx", args: ["jcodemunch-mcp"])
-  // works but `which jcodemunch-mcp` fails. Send JSON-RPC via uvx directly.
-  // This also applies to Linux users who install via uvx instead of pip/pipx.
+  // Last resort: bare uvx invocation. Only works for PyPI-published installs —
+  // wheel-URL installs are covered by the registration probe above.
   try {
     exec('which uvx');
-    return await detectJcodemunchViaUvx(cwd, mcpQuery);
+    const result = await detectJcodemunchViaUvx(cwd, mcpQuery);
+    if (result.available) {
+      return { ...result, transport: { kind: 'uvx', command: 'uvx', args: ['jcodemunch-mcp'] } };
+    }
+    return result;
   } catch {
     // uvx not available
   }

--- a/src/session/environment.ts
+++ b/src/session/environment.ts
@@ -93,6 +93,7 @@ export async function detectEnvironment(
   return {
     rtkAvailable: rtkResult.available,
     rtkPath: rtkResult.path,
+    rtkVersion: rtkResult.version,
     jcodemunchAvailable: jmResult.available,
     jcodemunchCwdIndexed: jmResult.cwdIndexed,
     jcodemunchCwdRepo: jmResult.cwdRepo,
@@ -107,12 +108,19 @@ export async function detectEnvironment(
   };
 }
 
-function detectRtk(exec: ExecFn): { available: boolean; path: string | null } {
+function detectRtk(exec: ExecFn): { available: boolean; path: string | null; version: string | null } {
   try {
     const path = exec('which rtk').trim();
-    return { available: true, path };
+    // Version probe is diagnostics-only — failure never affects availability
+    let version: string | null = null;
+    try {
+      version = exec('rtk --version', { timeout: 5000 }).match(/(\d+\.\d+\.\d+)/)?.[1] ?? null;
+    } catch {
+      // Probe failed — version stays unknown
+    }
+    return { available: true, path, version };
   } catch {
-    return { available: false, path: null };
+    return { available: false, path: null, version: null };
   }
 }
 

--- a/src/session/environment.ts
+++ b/src/session/environment.ts
@@ -2,6 +2,12 @@ import { execSync, spawn } from 'node:child_process';
 import { basename, join, resolve } from 'node:path';
 import { existsSync, statSync } from 'node:fs';
 import type { Environment, GraphBuildInfo, JcodemunchTransport } from '../types.js';
+import {
+  graphJsonPath,
+  rebuildLockPath,
+  GRAPH_JSON_REL,
+  GRAPHIFY_PLACEHOLDER_THRESHOLD,
+} from '../constants.js';
 import { resolveJcodemunchRegistration } from './claude-config.js';
 import type { McpRegistration } from './claude-config.js';
 
@@ -124,8 +130,6 @@ function detectRtk(exec: ExecFn): { available: boolean; path: string | null; ver
   }
 }
 
-const PLACEHOLDER_THRESHOLD = 1024; // bytes
-
 const defaultStatCheck = (path: string): { size: number } | undefined => {
   try {
     return statSync(path);
@@ -193,18 +197,18 @@ export function detectGraphify(
   // A valid graph on disk is sufficient for 'ready' regardless of CLI
   // presence — the CLI may live off the hook PATH (e.g. ~/.local/bin) and is
   // only needed for rebuilding. _cliFound tells callers whether rebuild works.
-  const graphPath = join(cwd, 'graphify-out', 'graph.json');
+  const graphPath = graphJsonPath(cwd);
   let graphValid = false;
   if (existsCheck(graphPath)) {
     const stat = statCheck(graphPath);
-    graphValid = !!stat && stat.size >= PLACEHOLDER_THRESHOLD;
+    graphValid = !!stat && stat.size >= GRAPHIFY_PLACEHOLDER_THRESHOLD;
     // Placeholder or tiny file — treat as absent
   }
 
   // graphify leaves .rebuild.lock behind after completed builds: a lock with a
   // graph newer than it is stale (finished build); a lock newer than the graph
   // (or with no valid graph) means a rebuild is in progress.
-  const lockPath = join(cwd, 'graphify-out', '.rebuild.lock');
+  const lockPath = rebuildLockPath(cwd);
   if (existsCheck(lockPath)) {
     if (!graphValid) {
       return { state: 'building', _cliFound: cliAvailable, cliVersion };
@@ -218,7 +222,7 @@ export function detectGraphify(
   }
 
   if (graphValid) {
-    return { state: 'ready', graphPath: 'graphify-out/graph.json', _cliFound: cliAvailable, cliVersion };
+    return { state: 'ready', graphPath: GRAPH_JSON_REL, _cliFound: cliAvailable, cliVersion };
   }
 
   return { state: 'absent', _cliFound: cliAvailable, cliVersion };

--- a/src/session/environment.ts
+++ b/src/session/environment.ts
@@ -129,11 +129,20 @@ export interface GraphifyDetectResult extends GraphBuildInfo {
   _cliFound: boolean;
 }
 
+const defaultMtimeCheck = (path: string): Date | undefined => {
+  try {
+    return statSync(path).mtime;
+  } catch {
+    return undefined;
+  }
+};
+
 export function detectGraphify(
   cwd: string,
   exec: ExecFn,
   existsCheck: (path: string) => boolean = existsSync,
   statCheck: (path: string) => { size: number } | undefined = defaultStatCheck,
+  mtimeCheck: (path: string) => Date | undefined = defaultMtimeCheck,
 ): GraphifyDetectResult {
   // Check for graphify CLI — package installs as 'graphifyy' (double-y)
   let cliAvailable = false;
@@ -153,12 +162,31 @@ export function detectGraphify(
   // presence — the CLI may live off the hook PATH (e.g. ~/.local/bin) and is
   // only needed for rebuilding. _cliFound tells callers whether rebuild works.
   const graphPath = join(cwd, 'graphify-out', 'graph.json');
+  let graphValid = false;
   if (existsCheck(graphPath)) {
     const stat = statCheck(graphPath);
-    if (stat && stat.size >= PLACEHOLDER_THRESHOLD) {
-      return { state: 'ready', graphPath: 'graphify-out/graph.json', _cliFound: cliAvailable };
-    }
+    graphValid = !!stat && stat.size >= PLACEHOLDER_THRESHOLD;
     // Placeholder or tiny file — treat as absent
+  }
+
+  // graphify leaves .rebuild.lock behind after completed builds: a lock with a
+  // graph newer than it is stale (finished build); a lock newer than the graph
+  // (or with no valid graph) means a rebuild is in progress.
+  const lockPath = join(cwd, 'graphify-out', '.rebuild.lock');
+  if (existsCheck(lockPath)) {
+    if (!graphValid) {
+      return { state: 'building', _cliFound: cliAvailable };
+    }
+    const graphMtime = mtimeCheck(graphPath);
+    const lockMtime = mtimeCheck(lockPath);
+    if (graphMtime && lockMtime && lockMtime > graphMtime) {
+      return { state: 'building', _cliFound: cliAvailable };
+    }
+    // Stale lock (or mtimes unavailable) — the valid graph wins
+  }
+
+  if (graphValid) {
+    return { state: 'ready', graphPath: 'graphify-out/graph.json', _cliFound: cliAvailable };
   }
 
   return { state: 'absent', _cliFound: cliAvailable };

--- a/src/session/environment.ts
+++ b/src/session/environment.ts
@@ -98,6 +98,7 @@ export async function detectEnvironment(
     jcodemunchCwdRepo: jmResult.cwdRepo,
     jcodemunchKnownRepos: jmResult.knownRepos,
     jcodemunchTransport: jmResult.transport,
+    jcodemunchProtocolWarning: jmResult.protocolWarning,
     graphifyAvailable: graphifyResult.state === 'ready',
     graphifyGraphPath: graphifyResult.state === 'ready' ? graphifyResult.graphPath ?? null : null,
     graphBuildInfo: graphifyResult.state === 'absent' && !graphifyResult._cliFound ? undefined : graphifyResult,
@@ -171,6 +172,7 @@ interface JcodemunchDetection {
   cwdRepo: string | null;
   knownRepos: string[];
   transport?: JcodemunchTransport;
+  protocolWarning?: string;
 }
 
 async function detectJcodemunch(
@@ -253,11 +255,42 @@ function detectJcodemunchCli(cwd: string, exec: ExecFn): JcodemunchDetection {
   }
 }
 
+export const MCP_PROTOCOL_VERSION = '2025-03-26';
+
+const INITIALIZE_MESSAGE = JSON.stringify({
+  jsonrpc: '2.0',
+  method: 'initialize',
+  params: {
+    protocolVersion: MCP_PROTOCOL_VERSION,
+    capabilities: {},
+    clientInfo: { name: 'rig', version: '1.0' },
+  },
+  id: 1,
+});
+
 const LIST_REPOS_MESSAGES = [
-  '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"rig","version":"1.0"}},"id":1}',
+  INITIALIZE_MESSAGE,
   '{"jsonrpc":"2.0","method":"notifications/initialized"}',
   '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"list_repos","arguments":{}},"id":2}',
 ];
+
+/**
+ * Inspect the initialize response (id:1) already present in the stdout buffer
+ * and return a warning string when the server's protocolVersion differs from
+ * ours. Returns null on match or on any parse failure — never blocks detection.
+ */
+export function extractProtocolMismatch(output: string | null): string | null {
+  if (!output) return null;
+  try {
+    const initLine = output.trim().split('\n').find(l => l.includes('"id":1'));
+    if (!initLine) return null;
+    const serverVersion = JSON.parse(initLine)?.result?.protocolVersion;
+    if (typeof serverVersion !== 'string' || serverVersion === MCP_PROTOCOL_VERSION) return null;
+    return `jcodemunch MCP protocol version mismatch (server: ${serverVersion}, expected: ${MCP_PROTOCOL_VERSION})`;
+  } catch {
+    return null;
+  }
+}
 
 async function detectJcodemunchMcp(
   cwd: string,
@@ -276,19 +309,23 @@ async function detectJcodemunchViaUvx(cwd: string, mcpQuery: McpQueryFn): Promis
 
 function parseListReposResponse(cwd: string, output: string | null): JcodemunchDetection {
   if (!output) return { available: true, cwdIndexed: false, cwdRepo: null, knownRepos: [] };
+  const protocolWarning = extractProtocolMismatch(output) ?? undefined;
+  const fallback: JcodemunchDetection = {
+    available: true, cwdIndexed: false, cwdRepo: null, knownRepos: [], protocolWarning,
+  };
   try {
     const lines = output.trim().split('\n');
     const reposLine = lines.find(l => l.includes('"id":2'));
-    if (!reposLine) return { available: true, cwdIndexed: false, cwdRepo: null, knownRepos: [] };
+    if (!reposLine) return fallback;
 
     const rpcResponse = JSON.parse(reposLine);
     const textContent = rpcResponse?.result?.content?.[0]?.text;
-    if (!textContent) return { available: true, cwdIndexed: false, cwdRepo: null, knownRepos: [] };
+    if (!textContent) return fallback;
 
     const reposData = JSON.parse(textContent);
-    return resolveJcodemunchRepos(cwd, reposData.repos ?? []);
+    return { ...resolveJcodemunchRepos(cwd, reposData.repos ?? []), protocolWarning };
   } catch {
-    return { available: true, cwdIndexed: false, cwdRepo: null, knownRepos: [] };
+    return fallback;
   }
 }
 
@@ -306,9 +343,10 @@ export async function callJcodemunchMcpTool(
   toolArgs: Record<string, string>,
   mcpQuery: McpQueryFn = defaultMcpQuery,
   timeoutMs: number = 60_000,
+  onWarning?: (msg: string) => void,
 ): Promise<string | null> {
   const messages = [
-    '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"rig","version":"1.0"}},"id":1}',
+    INITIALIZE_MESSAGE,
     '{"jsonrpc":"2.0","method":"notifications/initialized"}',
     JSON.stringify({
       jsonrpc: '2.0',
@@ -320,6 +358,8 @@ export async function callJcodemunchMcpTool(
 
   const output = await mcpQuery(command, args, messages, 2, timeoutMs);
   if (!output) return null;
+  const mismatch = extractProtocolMismatch(output);
+  if (mismatch && onWarning) onWarning(mismatch);
   try {
     const lines = output.trim().split('\n');
     const responseLine = lines.find(l => l.includes('"id":2'));

--- a/src/session/environment.ts
+++ b/src/session/environment.ts
@@ -1,5 +1,5 @@
 import { execSync, spawn } from 'node:child_process';
-import { basename, join } from 'node:path';
+import { basename, join, resolve } from 'node:path';
 import { existsSync, statSync } from 'node:fs';
 import type { Environment, GraphBuildInfo, JcodemunchTransport } from '../types.js';
 import { resolveJcodemunchRegistration } from './claude-config.js';
@@ -286,8 +286,7 @@ function parseListReposResponse(cwd: string, output: string | null): JcodemunchD
     if (!textContent) return { available: true, cwdIndexed: false, cwdRepo: null, knownRepos: [] };
 
     const reposData = JSON.parse(textContent);
-    const repoNames: string[] = (reposData.repos ?? []).map((r: { repo: string }) => r.repo);
-    return resolveJcodemunchRepos(cwd, repoNames);
+    return resolveJcodemunchRepos(cwd, reposData.repos ?? []);
   } catch {
     return { available: true, cwdIndexed: false, cwdRepo: null, knownRepos: [] };
   }
@@ -332,14 +331,27 @@ export async function callJcodemunchMcpTool(
   }
 }
 
-function resolveJcodemunchRepos(cwd: string, repos: string[]): JcodemunchDetection {
+/** A repo entry from list_repos: bare name (CLI/older servers) or rich object (MCP). */
+type RepoEntry = string | { repo: string; source_root?: string };
+
+function resolveJcodemunchRepos(cwd: string, repos: RepoEntry[]): JcodemunchDetection {
+  const entries = repos
+    .map(r => (typeof r === 'string' ? { repo: r } : r))
+    .filter((e): e is { repo: string; source_root?: string } => typeof e?.repo === 'string');
+
+  // Exact source-root path match is authoritative — it disambiguates repos
+  // with the same basename and survives renamed checkouts. Basename equality
+  // is the fallback for entries that don't carry a source_root.
+  const resolvedCwd = resolve(cwd);
   const folderName = basename(cwd);
-  const cwdRepo = repos.find(r => r.split('/').pop() === folderName) ?? null;
+  const bySourceRoot = entries.find(e => e.source_root && resolve(e.source_root) === resolvedCwd);
+  const byBasename = entries.find(e => e.repo.split('/').pop() === folderName);
+  const cwdRepo = (bySourceRoot ?? byBasename)?.repo ?? null;
 
   return {
     available: true,
     cwdIndexed: cwdRepo !== null,
     cwdRepo,
-    knownRepos: repos,
+    knownRepos: entries.map(e => e.repo),
   };
 }

--- a/src/session/environment.ts
+++ b/src/session/environment.ts
@@ -101,6 +101,7 @@ export async function detectEnvironment(
     jcodemunchProtocolWarning: jmResult.protocolWarning,
     graphifyAvailable: graphifyResult.state === 'ready',
     graphifyGraphPath: graphifyResult.state === 'ready' ? graphifyResult.graphPath ?? null : null,
+    graphifyVersion: graphifyResult.cliVersion ?? null,
     graphBuildInfo: graphifyResult.state === 'absent' && !graphifyResult._cliFound ? undefined : graphifyResult,
     detectedAt: Date.now(),
   };
@@ -127,6 +128,18 @@ const defaultStatCheck = (path: string): { size: number } | undefined => {
 
 export interface GraphifyDetectResult extends GraphBuildInfo {
   _cliFound: boolean;
+  cliVersion?: string;
+}
+
+/**
+ * Parse the version from `graphify --version` output. Anchors on the binary's
+ * own version line — output may also contain a skew-warning line mentioning a
+ * different version ("skill is from graphify 0.7.16, package is 0.7.18").
+ */
+function parseGraphifyVersion(output: string): string | undefined {
+  const anchored = output.match(/^graphify(?:y)?\s+(\d+\.\d+\.\d+)/m);
+  if (anchored) return anchored[1];
+  return output.match(/(\d+\.\d+\.\d+)/)?.[1];
 }
 
 const defaultMtimeCheck = (path: string): Date | undefined => {
@@ -145,16 +158,27 @@ export function detectGraphify(
   mtimeCheck: (path: string) => Date | undefined = defaultMtimeCheck,
 ): GraphifyDetectResult {
   // Check for graphify CLI — package installs as 'graphifyy' (double-y)
-  let cliAvailable = false;
+  let cliBinary: string | null = null;
   try {
     exec('which graphify');
-    cliAvailable = true;
+    cliBinary = 'graphify';
   } catch {
     try {
       exec('which graphifyy');
-      cliAvailable = true;
+      cliBinary = 'graphifyy';
     } catch {
       // Neither binary found — MCP server may still be running via uvx
+    }
+  }
+  const cliAvailable = cliBinary !== null;
+
+  // Version probe is diagnostics-only — failure must never change state
+  let cliVersion: string | undefined;
+  if (cliBinary) {
+    try {
+      cliVersion = parseGraphifyVersion(exec(`${cliBinary} --version`, { timeout: 5000 }));
+    } catch {
+      // Probe failed — version stays unknown
     }
   }
 
@@ -175,21 +199,21 @@ export function detectGraphify(
   const lockPath = join(cwd, 'graphify-out', '.rebuild.lock');
   if (existsCheck(lockPath)) {
     if (!graphValid) {
-      return { state: 'building', _cliFound: cliAvailable };
+      return { state: 'building', _cliFound: cliAvailable, cliVersion };
     }
     const graphMtime = mtimeCheck(graphPath);
     const lockMtime = mtimeCheck(lockPath);
     if (graphMtime && lockMtime && lockMtime > graphMtime) {
-      return { state: 'building', _cliFound: cliAvailable };
+      return { state: 'building', _cliFound: cliAvailable, cliVersion };
     }
     // Stale lock (or mtimes unavailable) — the valid graph wins
   }
 
   if (graphValid) {
-    return { state: 'ready', graphPath: 'graphify-out/graph.json', _cliFound: cliAvailable };
+    return { state: 'ready', graphPath: 'graphify-out/graph.json', _cliFound: cliAvailable, cliVersion };
   }
 
-  return { state: 'absent', _cliFound: cliAvailable };
+  return { state: 'absent', _cliFound: cliAvailable, cliVersion };
 }
 
 interface JcodemunchDetection {

--- a/src/session/environment.ts
+++ b/src/session/environment.ts
@@ -149,21 +149,19 @@ export function detectGraphify(
     }
   }
 
-  if (!cliAvailable) {
-    return { state: 'absent', _cliFound: false };
-  }
-
+  // A valid graph on disk is sufficient for 'ready' regardless of CLI
+  // presence — the CLI may live off the hook PATH (e.g. ~/.local/bin) and is
+  // only needed for rebuilding. _cliFound tells callers whether rebuild works.
   const graphPath = join(cwd, 'graphify-out', 'graph.json');
   if (existsCheck(graphPath)) {
     const stat = statCheck(graphPath);
     if (stat && stat.size >= PLACEHOLDER_THRESHOLD) {
-      return { state: 'ready', graphPath: 'graphify-out/graph.json', _cliFound: true };
+      return { state: 'ready', graphPath: 'graphify-out/graph.json', _cliFound: cliAvailable };
     }
     // Placeholder or tiny file — treat as absent
-    return { state: 'absent', _cliFound: true };
   }
 
-  return { state: 'absent', _cliFound: true };
+  return { state: 'absent', _cliFound: cliAvailable };
 }
 
 interface JcodemunchDetection {

--- a/src/session/graphify-self-check.ts
+++ b/src/session/graphify-self-check.ts
@@ -1,4 +1,5 @@
 import { join } from 'node:path';
+import { graphJsonPath as resolveGraphJsonPath } from '../constants.js';
 import type { ExecFn } from './environment.js';
 import type { Environment, GraphifyMcpReadiness } from '../types.js';
 
@@ -56,7 +57,7 @@ export function checkGraphifyMcpReadiness(
   // Step 4: Is the server registered with Claude Code?
   const registered = isRegisteredWithClaude(exec);
   if (!registered) {
-    const graphJsonPath = join(cwd, 'graphify-out', 'graph.json');
+    const graphJsonPath = resolveGraphJsonPath(cwd);
     const fixCommand = buildMcpAddCommand(pythonPath!, graphJsonPath);
     return { status: 'cli_only_not_registered', fixCommand };
   }

--- a/src/session/metrics.ts
+++ b/src/session/metrics.ts
@@ -47,7 +47,11 @@ export function captureGraphifyStats(cwd: string, exec: ExecFn): GraphifyProject
  * Much lighter than reading graph.json (154KB vs 74MB).
  * Falls back to `graphify benchmark` CLI if report unavailable.
  */
-export function captureGraphifyStatsViaReport(cwd: string, exec: ExecFn): GraphifyProjectStats | null {
+export function captureGraphifyStatsViaReport(
+  cwd: string,
+  exec: ExecFn,
+  onWarn?: (msg: string) => void,
+): GraphifyProjectStats | null {
   // Try GRAPH_REPORT.md first (has full stats including confidence breakdown)
   try {
     const report = exec(`cat "${cwd}/graphify-out/GRAPH_REPORT.md"`, { timeout: REPORT_TIMEOUT_MS });
@@ -58,7 +62,7 @@ export function captureGraphifyStatsViaReport(cwd: string, exec: ExecFn): Graphi
     const extractionMatch = report.match(/Extraction:\s*(\d+)%\s*EXTRACTED\s*·\s*(\d+)%\s*INFERRED\s*·\s*(\d+)%\s*AMBIGUOUS/);
 
     if (summaryMatch) {
-      return {
+      const stats: GraphifyProjectStats = {
         nodes: parseInt(summaryMatch[1], 10),
         edges: parseInt(summaryMatch[2], 10),
         communities: parseInt(summaryMatch[3], 10),
@@ -66,7 +70,16 @@ export function captureGraphifyStatsViaReport(cwd: string, exec: ExecFn): Graphi
         inferredPct: extractionMatch ? parseInt(extractionMatch[2], 10) : 0,
         ambiguousPct: extractionMatch ? parseInt(extractionMatch[3], 10) : 0,
       };
+      if (extractionMatch) {
+        const sum = stats.extractedPct + stats.inferredPct + stats.ambiguousPct;
+        if (sum < 98 || sum > 102) {
+          onWarn?.(`graphify: confidence percentages sum to ${sum} (expected ~100) — report format may have drifted`);
+        }
+      }
+      return stats;
     }
+    // Report exists but didn't match the expected layout — format drift
+    onWarn?.('graphify: GRAPH_REPORT.md present but unparseable — format may have changed');
   } catch {
     // Report not available — fall through to benchmark
   }
@@ -76,6 +89,7 @@ export function captureGraphifyStatsViaReport(cwd: string, exec: ExecFn): Graphi
     const output = exec(`graphify benchmark "${cwd}/graphify-out/graph.json"`, { timeout: BENCHMARK_TIMEOUT_MS });
     const match = output.match(/Graph:\s*(\d[\d,]*)\s+nodes,\s*(\d[\d,]*)\s+edges/);
     if (match) {
+      onWarn?.('graphify: using benchmark fallback — confidence breakdown unavailable');
       return {
         nodes: parseInt(match[1].replace(/,/g, ''), 10),
         edges: parseInt(match[2].replace(/,/g, ''), 10),
@@ -96,7 +110,11 @@ export function captureGraphifyStatsViaReport(cwd: string, exec: ExecFn): Graphi
  * Build graphify graph for an external directory (if not already built)
  * and capture its stats. Returns null if graphify is unavailable or build fails.
  */
-export function captureExternalGraphifyStats(directory: string, exec: ExecFn): GraphifyProjectStats | null {
+export function captureExternalGraphifyStats(
+  directory: string,
+  exec: ExecFn,
+  onWarn?: (msg: string) => void,
+): GraphifyProjectStats | null {
   const graphPath = join(directory, 'graphify-out', 'graph.json');
 
   // Check if graph already exists
@@ -116,7 +134,7 @@ export function captureExternalGraphifyStats(directory: string, exec: ExecFn): G
     }
   }
 
-  return captureGraphifyStatsViaReport(directory, exec);
+  return captureGraphifyStatsViaReport(directory, exec, onWarn);
 }
 
 export function captureMetricsBaseline(exec: ExecFn): MetricsBaseline {

--- a/src/session/metrics.ts
+++ b/src/session/metrics.ts
@@ -1,7 +1,13 @@
 import type { GraphifyProjectStats, MetricsBaseline } from '../types.js';
 import { basename, join } from 'node:path';
 
-export type ExecFn = (cmd: string) => string;
+export type ExecFn = (cmd: string, opts?: { timeout?: number }) => string;
+
+// Hooks must never hang on a stuck child process — every exec is bounded.
+const REPORT_TIMEOUT_MS = 10_000;
+const BENCHMARK_TIMEOUT_MS = 30_000;
+const BUILD_TIMEOUT_MS = 120_000;
+const GAIN_TIMEOUT_MS = 10_000;
 
 /**
  * Read graphify-out/graph.json (NetworkX node-link format) and compute stats.
@@ -10,7 +16,7 @@ export type ExecFn = (cmd: string) => string;
  */
 export function captureGraphifyStats(cwd: string, exec: ExecFn): GraphifyProjectStats | null {
   try {
-    const raw = exec(`cat "${cwd}/graphify-out/graph.json"`);
+    const raw = exec(`cat "${cwd}/graphify-out/graph.json"`, { timeout: BENCHMARK_TIMEOUT_MS });
     const data = JSON.parse(raw) as { nodes?: unknown[]; links?: unknown[] };
     const nodes = data.nodes ?? [];
     const links = data.links ?? [];
@@ -44,7 +50,7 @@ export function captureGraphifyStats(cwd: string, exec: ExecFn): GraphifyProject
 export function captureGraphifyStatsViaReport(cwd: string, exec: ExecFn): GraphifyProjectStats | null {
   // Try GRAPH_REPORT.md first (has full stats including confidence breakdown)
   try {
-    const report = exec(`cat "${cwd}/graphify-out/GRAPH_REPORT.md"`);
+    const report = exec(`cat "${cwd}/graphify-out/GRAPH_REPORT.md"`, { timeout: REPORT_TIMEOUT_MS });
 
     // Match: "40994 nodes · 129501 edges · 439 communities detected"
     const summaryMatch = report.match(/(\d+)\s+nodes\s*·\s*(\d+)\s+edges\s*·\s*(\d+)\s+communities/);
@@ -67,7 +73,7 @@ export function captureGraphifyStatsViaReport(cwd: string, exec: ExecFn): Graphi
 
   // Fallback: graphify benchmark CLI (nodes/edges only)
   try {
-    const output = exec(`graphify benchmark "${cwd}/graphify-out/graph.json"`);
+    const output = exec(`graphify benchmark "${cwd}/graphify-out/graph.json"`, { timeout: BENCHMARK_TIMEOUT_MS });
     const match = output.match(/Graph:\s*(\d[\d,]*)\s+nodes,\s*(\d[\d,]*)\s+edges/);
     if (match) {
       return {
@@ -96,7 +102,7 @@ export function captureExternalGraphifyStats(directory: string, exec: ExecFn): G
   // Check if graph already exists
   let graphExists = false;
   try {
-    exec(`test -f "${graphPath}"`);
+    exec(`test -f "${graphPath}"`, { timeout: REPORT_TIMEOUT_MS });
     graphExists = true;
   } catch {
     // Graph doesn't exist — trigger build
@@ -104,7 +110,7 @@ export function captureExternalGraphifyStats(directory: string, exec: ExecFn): G
 
   if (!graphExists) {
     try {
-      exec(`graphify update "${directory}"`);
+      exec(`graphify update "${directory}"`, { timeout: BUILD_TIMEOUT_MS });
     } catch {
       return null;
     }
@@ -115,7 +121,7 @@ export function captureExternalGraphifyStats(directory: string, exec: ExecFn): G
 
 export function captureMetricsBaseline(exec: ExecFn): MetricsBaseline {
   try {
-    const raw = exec('rtk gain --format json');
+    const raw = exec('rtk gain --format json', { timeout: GAIN_TIMEOUT_MS });
     const parsed = JSON.parse(raw);
     const totalSaved = parsed?.summary?.total_saved ?? 0;
     return { totalSaved, capturedAt: Date.now() };

--- a/src/session/metrics.ts
+++ b/src/session/metrics.ts
@@ -1,5 +1,6 @@
 import type { GraphifyProjectStats, MetricsBaseline } from '../types.js';
-import { basename, join } from 'node:path';
+import { basename } from 'node:path';
+import { graphJsonPath, graphReportPath } from '../constants.js';
 
 export type ExecFn = (cmd: string, opts?: { timeout?: number }) => string;
 
@@ -16,7 +17,7 @@ const GAIN_TIMEOUT_MS = 10_000;
  */
 export function captureGraphifyStats(cwd: string, exec: ExecFn): GraphifyProjectStats | null {
   try {
-    const raw = exec(`cat "${cwd}/graphify-out/graph.json"`, { timeout: BENCHMARK_TIMEOUT_MS });
+    const raw = exec(`cat "${graphJsonPath(cwd)}"`, { timeout: BENCHMARK_TIMEOUT_MS });
     const data = JSON.parse(raw) as { nodes?: unknown[]; links?: unknown[] };
     const nodes = data.nodes ?? [];
     const links = data.links ?? [];
@@ -54,7 +55,7 @@ export function captureGraphifyStatsViaReport(
 ): GraphifyProjectStats | null {
   // Try GRAPH_REPORT.md first (has full stats including confidence breakdown)
   try {
-    const report = exec(`cat "${cwd}/graphify-out/GRAPH_REPORT.md"`, { timeout: REPORT_TIMEOUT_MS });
+    const report = exec(`cat "${graphReportPath(cwd)}"`, { timeout: REPORT_TIMEOUT_MS });
 
     // Match: "40994 nodes · 129501 edges · 439 communities detected"
     const summaryMatch = report.match(/(\d+)\s+nodes\s*·\s*(\d+)\s+edges\s*·\s*(\d+)\s+communities/);
@@ -86,7 +87,7 @@ export function captureGraphifyStatsViaReport(
 
   // Fallback: graphify benchmark CLI (nodes/edges only)
   try {
-    const output = exec(`graphify benchmark "${cwd}/graphify-out/graph.json"`, { timeout: BENCHMARK_TIMEOUT_MS });
+    const output = exec(`graphify benchmark "${graphJsonPath(cwd)}"`, { timeout: BENCHMARK_TIMEOUT_MS });
     const match = output.match(/Graph:\s*(\d[\d,]*)\s+nodes,\s*(\d[\d,]*)\s+edges/);
     if (match) {
       onWarn?.('graphify: using benchmark fallback — confidence breakdown unavailable');
@@ -115,7 +116,7 @@ export function captureExternalGraphifyStats(
   exec: ExecFn,
   onWarn?: (msg: string) => void,
 ): GraphifyProjectStats | null {
-  const graphPath = join(directory, 'graphify-out', 'graph.json');
+  const graphPath = graphJsonPath(directory);
 
   // Check if graph already exists
   let graphExists = false;

--- a/src/session/metrics.ts
+++ b/src/session/metrics.ts
@@ -137,15 +137,30 @@ export function captureExternalGraphifyStats(
   return captureGraphifyStatsViaReport(directory, exec, onWarn);
 }
 
-export function captureMetricsBaseline(exec: ExecFn): MetricsBaseline {
+export function captureMetricsBaseline(
+  exec: ExecFn,
+  onWarn?: (msg: string) => void,
+): MetricsBaseline {
+  let raw: string;
   try {
-    const raw = exec('rtk gain --format json', { timeout: GAIN_TIMEOUT_MS });
-    const parsed = JSON.parse(raw);
-    const totalSaved = parsed?.summary?.total_saved ?? 0;
-    return { totalSaved, capturedAt: Date.now() };
+    raw = exec('rtk gain --format json', { timeout: GAIN_TIMEOUT_MS });
   } catch {
+    // rtk absent — covered by the session-start not-installed warning
     return { totalSaved: 0, capturedAt: Date.now() };
   }
+
+  try {
+    const parsed = JSON.parse(raw);
+    const totalSaved = parsed?.summary?.total_saved;
+    if (typeof totalSaved === 'number' && Number.isFinite(totalSaved)) {
+      return { totalSaved, capturedAt: Date.now() };
+    }
+  } catch {
+    // Fall through — schema warning below
+  }
+  // rtk ran but the output shape is wrong: format drift, not absence
+  onWarn?.("rtk: 'rtk gain --format json' returned an unexpected schema — savings baseline unavailable");
+  return { totalSaved: 0, capturedAt: Date.now() };
 }
 
 export function incrementMetric(

--- a/src/session/permissions-self-check.ts
+++ b/src/session/permissions-self-check.ts
@@ -1,48 +1,63 @@
 import { join } from 'node:path';
+import { homedir } from 'node:os';
 import type { PermissionsReadiness } from '../types.js';
 import { REQUIRED_PERMISSIONS } from '../cli/permissions.js';
 
-const FIX_COMMAND = 'rig init --force';
+const INIT_FIX_COMMAND = 'rig init --force';
+// Plain `rig init` writes only the deny list; allow entries are opt-in.
+const ALLOW_FIX_COMMAND = 'rig init --broad-permissions';
 
 type ReadFileFn = (path: string, encoding: string) => string;
 type ExistsCheck = (path: string) => boolean;
 
 /**
- * Checks `.claude/settings.json` against the set of permissions `rig init`
- * is expected to have auto-allowed. Detects two failure modes:
+ * Checks the merged permission allow-list against the set of permissions
+ * `rig init --broad-permissions` is expected to have auto-allowed.
  *
- * 1. The settings file doesn't exist (rig was never initialized in this
- *    project, or settings.json was deleted).
- * 2. The settings file exists but is missing one or more required entries
- *    (e.g., user upgraded rig and the required set grew, or hand-edited
- *    settings.json removed entries).
+ * Claude Code merges permissions across scopes, so an entry satisfied at any
+ * of these locations counts (checking only the project file produced false
+ * positives for users who keep broad allows at user scope):
  *
- * Both fix paths are `rig init --force`, which is idempotent — it only adds
- * missing entries and preserves user customizations.
+ * 1. `<project>/.claude/settings.json`
+ * 2. `<project>/.claude/settings.local.json`
+ * 3. `~/.claude/settings.json`
  *
- * Errors reading or parsing settings.json are treated as "no_settings" rather
- * than thrown, so a broken settings file doesn't break session-start.
+ * A missing or malformed *project* settings.json still reports "no_settings"
+ * — that means rig was never initialized here, regardless of user scope.
+ *
+ * Read or parse errors in the other scopes are ignored (treated as empty), so
+ * a broken settings file never breaks session-start.
  */
 export function checkPermissionsReadiness(
   projectDir: string,
   readFile: ReadFileFn,
   existsCheck: ExistsCheck,
+  homeDir: string = homedir(),
 ): PermissionsReadiness {
-  const settingsPath = join(projectDir, '.claude', 'settings.json');
+  const projectSettingsPath = join(projectDir, '.claude', 'settings.json');
 
-  if (!existsCheck(settingsPath)) {
-    return { status: 'no_settings', fixCommand: FIX_COMMAND };
+  if (!existsCheck(projectSettingsPath)) {
+    return { status: 'no_settings', fixCommand: INIT_FIX_COMMAND };
   }
 
-  let settings: unknown;
+  let projectSettings: unknown;
   try {
-    settings = JSON.parse(readFile(settingsPath, 'utf-8'));
+    projectSettings = JSON.parse(readFile(projectSettingsPath, 'utf-8'));
   } catch {
-    return { status: 'no_settings', fixCommand: FIX_COMMAND };
+    return { status: 'no_settings', fixCommand: INIT_FIX_COMMAND };
   }
 
-  const allow = extractAllowList(settings);
-  const missing = REQUIRED_PERMISSIONS.filter((entry) => !allow.includes(entry));
+  const allow = new Set(extractAllowList(projectSettings));
+  for (const path of [
+    join(projectDir, '.claude', 'settings.local.json'),
+    join(homeDir, '.claude', 'settings.json'),
+  ]) {
+    for (const entry of readAllowList(path, readFile, existsCheck)) {
+      allow.add(entry);
+    }
+  }
+
+  const missing = REQUIRED_PERMISSIONS.filter((entry) => !allow.has(entry));
 
   if (missing.length === 0) {
     return { status: 'ok' };
@@ -51,8 +66,17 @@ export function checkPermissionsReadiness(
   return {
     status: 'missing',
     missing,
-    fixCommand: FIX_COMMAND,
+    fixCommand: ALLOW_FIX_COMMAND,
   };
+}
+
+function readAllowList(path: string, readFile: ReadFileFn, existsCheck: ExistsCheck): string[] {
+  try {
+    if (!existsCheck(path)) return [];
+    return extractAllowList(JSON.parse(readFile(path, 'utf-8')));
+  } catch {
+    return [];
+  }
 }
 
 function extractAllowList(settings: unknown): string[] {

--- a/src/session/start.ts
+++ b/src/session/start.ts
@@ -21,6 +21,23 @@ interface FileCapWarning {
 
 export type AutoIndexOutcome = 'succeeded' | 'failed' | 'not_needed';
 
+// graphify versions rig's stats parsing and state handling are tested against
+const GRAPHIFY_TESTED_MIN = '0.7.0';
+const GRAPHIFY_TESTED_MAX_EXCLUSIVE = '0.8.0';
+
+function versionInRange(version: string, min: string, maxExclusive: string): boolean {
+  const segments = (v: string): number[] => v.split('.').map(Number);
+  const compare = (a: number[], b: number[]): number => {
+    for (let i = 0; i < 3; i++) {
+      const diff = (a[i] ?? 0) - (b[i] ?? 0);
+      if (diff !== 0) return diff;
+    }
+    return 0;
+  };
+  const v = segments(version);
+  return compare(v, segments(min)) >= 0 && compare(v, segments(maxExclusive)) < 0;
+}
+
 /** Injectable seams for handleSessionStart; production callers pass nothing. */
 export interface SessionStartDeps {
   exec?: ExecFn;
@@ -124,6 +141,10 @@ export async function handleSessionStart(
 
   if (env.jcodemunchProtocolWarning) {
     lines.push(`[WARNING] ${env.jcodemunchProtocolWarning}`);
+  }
+
+  if (env.graphifyVersion && !versionInRange(env.graphifyVersion, GRAPHIFY_TESTED_MIN, GRAPHIFY_TESTED_MAX_EXCLUSIVE)) {
+    lines.push(`[WARNING] graphify ${env.graphifyVersion} is outside the tested range (>=${GRAPHIFY_TESTED_MIN} <${GRAPHIFY_TESTED_MAX_EXCLUSIVE}) — proceeding anyway`);
   }
 
   if (graphInfo?.state === 'ready' && baseline.graphifyStats) {

--- a/src/session/start.ts
+++ b/src/session/start.ts
@@ -68,11 +68,11 @@ export async function handleSessionStart(
 
   const execFn: ExecFn = (cmd, opts) =>
     execSync(cmd, { encoding: 'utf-8', ...opts } as Parameters<typeof execSync>[1]) as string;
-  const baseline = captureMetricsBaseline(execFn);
-  // Capture graphify stats via report (not the 74MB graph.json)
-  const graphInfo = env.graphBuildInfo;
   const statsWarnings: string[] = [];
   const onStatsWarn = (msg: string): void => { statsWarnings.push(msg); };
+  const baseline = captureMetricsBaseline(execFn, onStatsWarn);
+  // Capture graphify stats via report (not the 74MB graph.json)
+  const graphInfo = env.graphBuildInfo;
   if (graphInfo?.state === 'ready') {
     const cwdStats = captureGraphifyStatsViaReport(cwd, execFn, onStatsWarn);
     if (cwdStats) {

--- a/src/session/start.ts
+++ b/src/session/start.ts
@@ -9,6 +9,7 @@ import { detectPythonEnv } from './python-env.js';
 import { checkWorktreeSuggestion } from './worktree.js';
 import { captureMetricsBaseline, captureGraphifyStatsViaReport } from './metrics.js';
 import { triggerBuild, waitForBuild } from '../scout/graph-state.js';
+import type { WaitForBuildOpts } from '../scout/graph-state.js';
 import { loadConfig } from '../config.js';
 import { checkGraphifyMcpReadiness } from './graphify-self-check.js';
 import { checkPermissionsReadiness } from './permissions-self-check.js';
@@ -47,7 +48,12 @@ export interface SessionStartDeps {
   registrationLookup?: RegistrationLookupFn;
   readdir?: (path: string) => string[];
   homeDir?: string;
+  graphWait?: WaitForBuildOpts;
 }
+
+// graphify update can return before graph.json is fully written; poll across
+// that window instead of caching a false "failed" for the whole session.
+const GRAPH_WAIT_DEFAULT: WaitForBuildOpts = { deadlineMs: 5000, intervalMs: 250 };
 
 /**
  * SessionStart hook handler. Detects environment and auto-indexes CWD
@@ -82,10 +88,11 @@ export async function handleSessionStart(
     // Async build: trigger in background, mark as building
     const buildResult = triggerBuild(cwd, execFn);
     if (buildResult.state === 'building') {
-      // Check if it completed quickly (small projects)
+      // Poll briefly — graphify update can return before graph.json lands
       const checkResult = waitForBuild(buildResult, cwd,
-        (p) => { try { execSync(`test -f "${p}"`, { encoding: 'utf-8' }); return true; } catch { return false; } },
-        (p) => { try { return require('node:fs').statSync(p); } catch { return undefined; } },
+        deps.existsCheck ?? ((p) => { try { execSync(`test -f "${p}"`, { encoding: 'utf-8' }); return true; } catch { return false; } }),
+        deps.statCheck ?? ((p) => { try { return require('node:fs').statSync(p); } catch { return undefined; } }),
+        deps.graphWait ?? GRAPH_WAIT_DEFAULT,
       );
       if (checkResult.state === 'ready') {
         env.graphBuildInfo = checkResult;

--- a/src/session/start.ts
+++ b/src/session/start.ts
@@ -66,10 +66,11 @@ export async function handleSessionStart(
   const pyEnv = await detectPythonEnv(cwd);
   cache.setPythonEnv(pyEnv);
 
-  const baseline = captureMetricsBaseline((cmd) => execSync(cmd, { encoding: 'utf-8' }));
+  const execFn: ExecFn = (cmd, opts) =>
+    execSync(cmd, { encoding: 'utf-8', ...opts } as Parameters<typeof execSync>[1]) as string;
+  const baseline = captureMetricsBaseline(execFn);
   // Capture graphify stats via report (not the 74MB graph.json)
   const graphInfo = env.graphBuildInfo;
-  const execFn = (cmd: string) => execSync(cmd, { encoding: 'utf-8' });
   if (graphInfo?.state === 'ready') {
     const cwdStats = captureGraphifyStatsViaReport(cwd, execFn);
     if (cwdStats) {

--- a/src/session/start.ts
+++ b/src/session/start.ts
@@ -96,7 +96,7 @@ export async function handleSessionStart(
           baseline.graphifyStats = { [resolve(cwd)]: buildStats };
         }
       } else {
-        env.graphBuildInfo = { state: 'failed' };
+        env.graphBuildInfo = checkResult;
       }
     } else {
       env.graphBuildInfo = buildResult;
@@ -129,7 +129,7 @@ export async function handleSessionStart(
     '[rig] Session initialized',
     `  rtk: ${env.rtkAvailable ? `available (${env.rtkPath}${env.rtkVersion ? `, v${env.rtkVersion}` : ''})` : 'not found'}`,
     `  jcodemunch: ${describeJcodemunch(env)}`,
-    `  graphify: ${graphInfo?.state === 'ready' ? 'available' : graphInfo?.state === 'building' ? 'building graph...' : graphInfo?.state === 'failed' ? 'build failed' : 'not found'}`,
+    `  graphify: ${describeGraphify(env.graphBuildInfo)}`,
   ];
 
   if (env.jcodemunchAvailable) {
@@ -154,7 +154,7 @@ export async function handleSessionStart(
     lines.push(`[WARNING] ${warning}`);
   }
 
-  if (graphInfo?.state === 'ready' && baseline.graphifyStats) {
+  if (env.graphBuildInfo?.state === 'ready' && baseline.graphifyStats) {
     const entries = Object.entries(baseline.graphifyStats);
     if (entries.length > 0) {
       const [dir, gs] = entries[0];
@@ -196,7 +196,7 @@ export async function handleSessionStart(
     lines.push('  Do NOT dismiss this advisory — always use scout for codebase exploration tasks');
   }
 
-  if (graphInfo?.state === 'ready') {
+  if (env.graphBuildInfo?.state === 'ready') {
     lines.push('[rig] Graphify graph tools available for relationship queries:');
     lines.push('  - mcp__graphify__query_graph for relationship context');
     lines.push('  - mcp__graphify__god_nodes for core abstractions');
@@ -249,13 +249,26 @@ export async function handleSessionStart(
         lines.push("  The server is likely registered but unreachable — check 'claude mcp list' output.");
       }
     }
-    if (!graphInfo) {
+    if (!env.graphBuildInfo) {
       lines.push('[HINT] graphify is not installed. Install for knowledge graph analysis: https://github.com/safishamsi/graphify');
     }
     cache.setToolsWarned(true);
   }
 
   return lines.join('\n');
+}
+
+function describeGraphify(info: GraphBuildInfo | undefined): string {
+  switch (info?.state) {
+    case 'ready':
+      return 'available';
+    case 'building':
+      return 'building graph...';
+    case 'failed':
+      return info.errorReason ? `build failed (${info.errorReason})` : 'build failed';
+    default:
+      return 'not found';
+  }
 }
 
 function describeJcodemunch(env: Environment): string {

--- a/src/session/start.ts
+++ b/src/session/start.ts
@@ -71,8 +71,10 @@ export async function handleSessionStart(
   const baseline = captureMetricsBaseline(execFn);
   // Capture graphify stats via report (not the 74MB graph.json)
   const graphInfo = env.graphBuildInfo;
+  const statsWarnings: string[] = [];
+  const onStatsWarn = (msg: string): void => { statsWarnings.push(msg); };
   if (graphInfo?.state === 'ready') {
-    const cwdStats = captureGraphifyStatsViaReport(cwd, execFn);
+    const cwdStats = captureGraphifyStatsViaReport(cwd, execFn, onStatsWarn);
     if (cwdStats) {
       baseline.graphifyStats = { [resolve(cwd)]: cwdStats };
     }
@@ -89,7 +91,7 @@ export async function handleSessionStart(
         env.graphBuildInfo = checkResult;
         env.graphifyAvailable = true;
         env.graphifyGraphPath = checkResult.graphPath ?? null;
-        const buildStats = captureGraphifyStatsViaReport(cwd, execFn);
+        const buildStats = captureGraphifyStatsViaReport(cwd, execFn, onStatsWarn);
         if (buildStats) {
           baseline.graphifyStats = { [resolve(cwd)]: buildStats };
         }
@@ -146,6 +148,10 @@ export async function handleSessionStart(
 
   if (env.graphifyVersion && !versionInRange(env.graphifyVersion, GRAPHIFY_TESTED_MIN, GRAPHIFY_TESTED_MAX_EXCLUSIVE)) {
     lines.push(`[WARNING] graphify ${env.graphifyVersion} is outside the tested range (>=${GRAPHIFY_TESTED_MIN} <${GRAPHIFY_TESTED_MAX_EXCLUSIVE}) — proceeding anyway`);
+  }
+
+  for (const warning of statsWarnings) {
+    lines.push(`[WARNING] ${warning}`);
   }
 
   if (graphInfo?.state === 'ready' && baseline.graphifyStats) {

--- a/src/session/start.ts
+++ b/src/session/start.ts
@@ -1,8 +1,10 @@
 import { execSync } from 'node:child_process';
 import { join, resolve, basename } from 'node:path';
+import { homedir } from 'node:os';
 import { SessionCache } from './cache.js';
 import type { Environment, GraphBuildInfo, HarnessConfig } from '../types.js';
 import { detectEnvironment, callJcodemunchMcpTool } from './environment.js';
+import type { ExecFn, McpQueryFn, RegistrationLookupFn } from './environment.js';
 import { detectPythonEnv } from './python-env.js';
 import { checkWorktreeSuggestion } from './worktree.js';
 import { captureMetricsBaseline, captureGraphifyStatsViaReport } from './metrics.js';
@@ -10,39 +12,38 @@ import { triggerBuild, waitForBuild } from '../scout/graph-state.js';
 import { loadConfig } from '../config.js';
 import { checkGraphifyMcpReadiness } from './graphify-self-check.js';
 import { checkPermissionsReadiness } from './permissions-self-check.js';
-import { readFileSync, existsSync } from 'node:fs';
+import { readFileSync, existsSync, readdirSync } from 'node:fs';
 
 interface FileCapWarning {
   indexed: number;
   total: number;
 }
 
-/**
- * Resolves how to invoke `jcodemunch-mcp`: prefer a binary in PATH, fall back
- * to `uvx jcodemunch-mcp` (macOS/Linux uvx installs). Returns null if neither
- * is available.
- */
-function resolveJcodemunchMcpTransport(): { command: string; args: string[] } | null {
-  try {
-    const mcpPath = execSync('which jcodemunch-mcp', { encoding: 'utf-8' }).trim();
-    if (mcpPath) return { command: mcpPath, args: [] };
-  } catch {
-    // Not in PATH — try uvx
-  }
-  try {
-    execSync('which uvx', { encoding: 'utf-8' });
-    return { command: 'uvx', args: ['jcodemunch-mcp'] };
-  } catch {
-    return null;
-  }
+export type AutoIndexOutcome = 'succeeded' | 'failed' | 'not_needed';
+
+/** Injectable seams for handleSessionStart; production callers pass nothing. */
+export interface SessionStartDeps {
+  exec?: ExecFn;
+  existsCheck?: (path: string) => boolean;
+  statCheck?: (path: string) => { size: number } | undefined;
+  mcpQuery?: McpQueryFn;
+  registrationLookup?: RegistrationLookupFn;
+  readdir?: (path: string) => string[];
+  homeDir?: string;
 }
 
 /**
  * SessionStart hook handler. Detects environment and auto-indexes CWD
  * with jcodemunch if available but not yet indexed.
  */
-export async function handleSessionStart(cwd: string, cache: SessionCache): Promise<string> {
-  const { env, fileCapHit } = await detectAndIndex(cwd);
+export async function handleSessionStart(
+  cwd: string,
+  cache: SessionCache,
+  deps: SessionStartDeps = {},
+): Promise<string> {
+  const { env, fileCapHit, autoIndex } = await detectAndIndex(
+    cwd, deps.exec, deps.existsCheck, deps.statCheck, deps.mcpQuery, deps.registrationLookup,
+  );
   cache.setEnvironment(env);
 
   const pyEnv = await detectPythonEnv(cwd);
@@ -107,16 +108,22 @@ export async function handleSessionStart(cwd: string, cache: SessionCache): Prom
   const lines = [
     '[rig] Session initialized',
     `  rtk: ${env.rtkAvailable ? `available (${env.rtkPath})` : 'not found'}`,
-    `  jcodemunch: ${env.jcodemunchAvailable ? 'available' : 'not found'}`,
+    `  jcodemunch: ${describeJcodemunch(env)}`,
     `  graphify: ${graphInfo?.state === 'ready' ? 'available' : graphInfo?.state === 'building' ? 'building graph...' : graphInfo?.state === 'failed' ? 'build failed' : 'not found'}`,
   ];
 
   if (env.jcodemunchAvailable) {
     if (env.jcodemunchCwdIndexed) {
       lines.push(`  CWD indexed: ${env.jcodemunchCwdRepo}`);
+    } else if (autoIndex === 'failed') {
+      lines.push('  CWD not indexed (auto-index failed — run mcp__jcodemunch__index_folder manually)');
     } else {
-      lines.push(`  CWD: not indexed (auto-indexing skipped)`);
+      lines.push('  CWD: not indexed');
     }
+  }
+
+  if (env.jcodemunchProtocolWarning) {
+    lines.push(`[WARNING] ${env.jcodemunchProtocolWarning}`);
   }
 
   if (graphInfo?.state === 'ready' && baseline.graphifyStats) {
@@ -207,7 +214,12 @@ export async function handleSessionStart(cwd: string, cache: SessionCache): Prom
       lines.push('[WARNING] rtk is not installed. Install for 60-90% token savings on dev operations: https://github.com/franklywatson/rtk');
     }
     if (!env.jcodemunchAvailable) {
-      lines.push('[WARNING] jcodemunch is not installed. Install for indexed code search: https://github.com/franklywatson/jcodemunch');
+      lines.push('[WARNING] jcodemunch was not detected. Install for indexed code search: https://github.com/franklywatson/jcodemunch');
+      lines.push("  If installed as an MCP server, verify its registration with 'claude mcp list'.");
+      if (hasOrphanedIndexData(deps.homeDir ?? homedir(), deps.readdir ?? readdirSync)) {
+        lines.push('[WARNING] jcodemunch index data found at ~/.code-index but no working transport detected.');
+        lines.push("  The server is likely registered but unreachable — check 'claude mcp list' output.");
+      }
     }
     if (!graphInfo) {
       lines.push('[HINT] graphify is not installed. Install for knowledge graph analysis: https://github.com/safishamsi/graphify');
@@ -216,6 +228,34 @@ export async function handleSessionStart(cwd: string, cache: SessionCache): Prom
   }
 
   return lines.join('\n');
+}
+
+function describeJcodemunch(env: Environment): string {
+  if (!env.jcodemunchAvailable) return 'not found';
+  const t = env.jcodemunchTransport;
+  if (!t) return 'available';
+  switch (t.kind) {
+    case 'cli':
+      return 'available (cli)';
+    case 'binary':
+      return `available (mcp binary: ${t.command})`;
+    case 'uvx':
+      return 'available (mcp via uvx)';
+    case 'config': {
+      const cmd = `${t.command} ${t.args.join(' ')}`.trim();
+      const shown = cmd.length > 100 ? cmd.slice(0, 97) + '...' : cmd;
+      return `available (mcp via ${t.source ?? 'claude'} config: ${shown})`;
+    }
+  }
+}
+
+/** Index DBs on disk + failed detection = registration/transport problem, not a missing install. */
+function hasOrphanedIndexData(homeDir: string, readdir: (path: string) => string[]): boolean {
+  try {
+    return readdir(join(homeDir, '.code-index')).some(f => f.endsWith('.db'));
+  } catch {
+    return false;
+  }
 }
 
 function formatActiveRules(config: HarnessConfig): string | null {
@@ -234,68 +274,73 @@ function formatActiveRules(config: HarnessConfig): string | null {
   return `  Active enforcement: ${active.join(', ')}`;
 }
 
-async function detectAndIndex(
+export async function detectAndIndex(
   cwd: string,
-  exec?: import('./environment.js').ExecFn,
+  exec?: ExecFn,
   existsCheck?: (path: string) => boolean,
   statCheck?: (path: string) => { size: number } | undefined,
-): Promise<{ env: Environment; fileCapHit?: FileCapWarning }> {
-  const env = await detectEnvironment(cwd, exec, existsCheck, statCheck);
+  mcpQuery?: McpQueryFn,
+  registrationLookup?: RegistrationLookupFn,
+): Promise<{ env: Environment; fileCapHit?: FileCapWarning; autoIndex: AutoIndexOutcome }> {
+  const env = await detectEnvironment(cwd, exec, existsCheck, statCheck, mcpQuery, registrationLookup);
   let fileCapHit: FileCapWarning | undefined;
+  let autoIndex: AutoIndexOutcome = 'not_needed';
 
-  // Auto-index if jcodemunch is available but CWD isn't indexed
+  // Auto-index if jcodemunch is available but CWD isn't indexed, reusing the
+  // exact transport that detection succeeded with — never re-derive it.
   if (env.jcodemunchAvailable && !env.jcodemunchCwdIndexed) {
-    // Try CLI auto-index first (only works when jcodemunch CLI binary is installed)
-    try {
-      execSync('which jcodemunch', { encoding: 'utf-8' });
-      const indexResult = execSync(
-        `jcodemunch index_folder --path "${cwd}"`,
-        { encoding: 'utf-8', timeout: 60_000 },
-      ).trim();
-      const parsedResult = JSON.parse(indexResult);
-      if (parsedResult.success) {
-        env.jcodemunchCwdIndexed = true;
-        env.jcodemunchCwdRepo = parsedResult.repo ?? env.jcodemunchCwdRepo;
-        if (env.jcodemunchCwdRepo && !env.jcodemunchKnownRepos.includes(env.jcodemunchCwdRepo)) {
-          env.jcodemunchKnownRepos.push(env.jcodemunchCwdRepo);
+    autoIndex = 'failed';
+    const transport = env.jcodemunchTransport;
+    const execFn: ExecFn = exec ??
+      ((cmd, opts) => execSync(cmd, { encoding: 'utf-8', ...opts } as Parameters<typeof execSync>[1]) as string);
+
+    if (transport?.kind === 'cli') {
+      try {
+        const indexResult = execFn(
+          `jcodemunch index_folder --path "${cwd}"`,
+          { timeout: 60_000 },
+        ).trim();
+        if (applyIndexResult(env, JSON.parse(indexResult), (cap) => { fileCapHit = cap; })) {
+          autoIndex = 'succeeded';
         }
-        const skipped = parsedResult.discovery_skip_counts?.file_limit ?? 0;
-        if (skipped > 0 && parsedResult.file_count) {
-          fileCapHit = { indexed: parsedResult.file_count, total: parsedResult.file_count + skipped };
-        }
+      } catch {
+        // CLI auto-index failed — surfaced via the autoIndex outcome
       }
-    } catch {
-      // CLI not available — try MCP auto-index via JSON-RPC.
-      // Resolve transport: direct binary first, then uvx fallback (macOS).
-      const transport = resolveJcodemunchMcpTransport();
-      if (transport) {
-        try {
-          const text = await callJcodemunchMcpTool(
-            transport.command,
-            transport.args,
-            'index_folder',
-            { path: cwd },
-          );
-          if (text) {
-            const parsedResult = JSON.parse(text);
-            if (parsedResult.success) {
-              env.jcodemunchCwdIndexed = true;
-              env.jcodemunchCwdRepo = parsedResult.repo ?? env.jcodemunchCwdRepo;
-              if (env.jcodemunchCwdRepo && !env.jcodemunchKnownRepos.includes(env.jcodemunchCwdRepo)) {
-                env.jcodemunchKnownRepos.push(env.jcodemunchCwdRepo);
-              }
-              const skipped = parsedResult.discovery_skip_counts?.file_limit ?? 0;
-              if (skipped > 0 && parsedResult.file_count) {
-                fileCapHit = { indexed: parsedResult.file_count, total: parsedResult.file_count + skipped };
-              }
-            }
-          }
-        } catch {
-          // MCP auto-index failed — agent can index via MCP directly
+    } else if (transport) {
+      try {
+        const text = await callJcodemunchMcpTool(
+          transport.command,
+          transport.args,
+          'index_folder',
+          { path: cwd },
+          mcpQuery,
+        );
+        if (text && applyIndexResult(env, JSON.parse(text), (cap) => { fileCapHit = cap; })) {
+          autoIndex = 'succeeded';
         }
+      } catch {
+        // MCP auto-index failed — agent can index via MCP directly
       }
     }
   }
 
-  return { env, fileCapHit };
+  return { env, fileCapHit, autoIndex };
+}
+
+function applyIndexResult(
+  env: Environment,
+  parsedResult: { success?: boolean; repo?: string; file_count?: number; discovery_skip_counts?: { file_limit?: number } },
+  onFileCap: (cap: FileCapWarning) => void,
+): boolean {
+  if (!parsedResult.success) return false;
+  env.jcodemunchCwdIndexed = true;
+  env.jcodemunchCwdRepo = parsedResult.repo ?? env.jcodemunchCwdRepo;
+  if (env.jcodemunchCwdRepo && !env.jcodemunchKnownRepos.includes(env.jcodemunchCwdRepo)) {
+    env.jcodemunchKnownRepos.push(env.jcodemunchCwdRepo);
+  }
+  const skipped = parsedResult.discovery_skip_counts?.file_limit ?? 0;
+  if (skipped > 0 && parsedResult.file_count) {
+    onFileCap({ indexed: parsedResult.file_count, total: parsedResult.file_count + skipped });
+  }
+  return true;
 }

--- a/src/session/start.ts
+++ b/src/session/start.ts
@@ -124,7 +124,7 @@ export async function handleSessionStart(
 
   const lines = [
     '[rig] Session initialized',
-    `  rtk: ${env.rtkAvailable ? `available (${env.rtkPath})` : 'not found'}`,
+    `  rtk: ${env.rtkAvailable ? `available (${env.rtkPath}${env.rtkVersion ? `, v${env.rtkVersion}` : ''})` : 'not found'}`,
     `  jcodemunch: ${describeJcodemunch(env)}`,
     `  graphify: ${graphInfo?.state === 'ready' ? 'available' : graphInfo?.state === 'building' ? 'building graph...' : graphInfo?.state === 'failed' ? 'build failed' : 'not found'}`,
   ];

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,6 +98,18 @@ export interface GraphBuildInfo {
 
 // ── Environment Types ──
 
+/**
+ * How a working jcodemunch transport was found: 'cli' (binary on PATH),
+ * 'config' (MCP registration read from Claude Code's config — ground truth),
+ * 'binary' (jcodemunch-mcp on PATH), 'uvx' (bare uvx fallback, PyPI-only).
+ */
+export interface JcodemunchTransport {
+  kind: 'cli' | 'config' | 'binary' | 'uvx';
+  command: string;
+  args: string[];
+  source?: string;
+}
+
 export interface Environment {
   rtkAvailable: boolean;
   rtkPath: string | null;
@@ -105,6 +117,7 @@ export interface Environment {
   jcodemunchCwdIndexed: boolean;
   jcodemunchCwdRepo: string | null;
   jcodemunchKnownRepos: string[];
+  jcodemunchTransport?: JcodemunchTransport;
   /** @deprecated Use graphBuildInfo instead. Removed after graphify-redesign migration. */
   graphifyAvailable: boolean;
   /** @deprecated Use graphBuildInfo instead. Removed after graphify-redesign migration. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -118,6 +118,7 @@ export interface Environment {
   jcodemunchCwdRepo: string | null;
   jcodemunchKnownRepos: string[];
   jcodemunchTransport?: JcodemunchTransport;
+  jcodemunchProtocolWarning?: string;
   /** @deprecated Use graphBuildInfo instead. Removed after graphify-redesign migration. */
   graphifyAvailable: boolean;
   /** @deprecated Use graphBuildInfo instead. Removed after graphify-redesign migration. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -113,6 +113,7 @@ export interface JcodemunchTransport {
 export interface Environment {
   rtkAvailable: boolean;
   rtkPath: string | null;
+  rtkVersion?: string | null;
   jcodemunchAvailable: boolean;
   jcodemunchCwdIndexed: boolean;
   jcodemunchCwdRepo: string | null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -124,6 +124,7 @@ export interface Environment {
   /** @deprecated Use graphBuildInfo instead. Removed after graphify-redesign migration. */
   graphifyGraphPath: string | null;
   graphBuildInfo?: GraphBuildInfo;
+  graphifyVersion?: string | null;
   detectedAt: number;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,6 +94,7 @@ export interface GraphBuildInfo {
   pid?: number;
   startedAt?: number;
   graphPath?: string;
+  errorReason?: string;
 }
 
 // ── Environment Types ──

--- a/templates/agents/scout.md
+++ b/templates/agents/scout.md
@@ -71,8 +71,8 @@ Determine each directory's state from its `graphify-out/`:
 
 | State | On-disk indicator (per-directory) |
 | ----- | --------------------------------- |
-| ready | `<dir>/graphify-out/graph.json` exists and is >1KB |
-| building | `<dir>/graphify-out/.rebuild.lock` is present (another process owns this build — session-start, a git hook, or a parallel agent) |
+| ready | `<dir>/graphify-out/graph.json` exists and is >1KB — even when a `.rebuild.lock` is also present but **older** than `graph.json` (graphify leaves locks behind after completed builds; graph newer than lock = stale lock from a finished build) |
+| building | `<dir>/graphify-out/.rebuild.lock` is present and either no valid `graph.json` exists or the lock is **newer** than `graph.json` (another process owns this build — session-start, a git hook, or a parallel agent) |
 | absent | neither `graph.json` (>1KB) nor `.rebuild.lock` exists |
 | failed | a previous `graphify update` attempt errored this session for this directory |
 
@@ -91,6 +91,13 @@ Parse `<dir>/graphify-out/graph.json` directly with `python3` or `jq` to
 compute degree-ranked god nodes and community membership. Label all findings
 `(via CLI fallback)`. Do not invent fields not present in `graph.json`.
 
+**ready + graphify CLI not on PATH:**
+
+A valid `graph.json` is readable regardless of CLI presence — proceed with
+the graph data, but label findings `(graph present, CLI rebuild unavailable)`
+and do not attempt `graphify update` for this directory. Rebuilding requires
+the CLI; reading does not.
+
 **absent + graphify CLI available:**
 
 1. Run `graphify update <dir>` to build the graph for that specific directory
@@ -99,7 +106,7 @@ compute degree-ranked god nodes and community membership. Label all findings
    report the failure (see Alert Reporting). Other directories' graphs are
    unaffected.
 
-**building** (`<dir>/graphify-out/.rebuild.lock` present):
+**building** (`<dir>/graphify-out/.rebuild.lock` newer than `graph.json`, or no valid graph):
 
 Another process owns this directory's build — do not run `graphify update`
 on it; the second invocation will conflict with the first. If `graph.json`
@@ -107,6 +114,11 @@ is also present and >1KB, you may still read it (the lock indicates a
 *re*build, so the previous graph is on disk). Otherwise skip graph context
 for this directory and note `graph build in progress — retry next session`.
 Continue with any other directories whose state is independent.
+
+Note on stale locks: graphify does not clean up `.rebuild.lock` after a
+completed build, so a lock alongside a valid graph is common. Compare
+mtimes — `graph.json` newer than the lock means the build finished and the
+directory is actually **ready**, not building.
 
 **failed:** skip graph context for this directory. Report the failure.
 

--- a/templates/hooks/post-tool-use.ts
+++ b/templates/hooks/post-tool-use.ts
@@ -10,6 +10,7 @@
  */
 import { resolve } from 'node:path';
 import { readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
 
 (async () => {
   let handlePostToolUse: any;
@@ -45,8 +46,13 @@ import { readFileSync } from 'node:fs';
   const cache = new SessionCache(cwd, input.session_id);
   const tracker = new FileTracker();
 
+  // execFn powers external-directory graphify stats capture; without it that
+  // branch of handlePostToolUse is dead code.
+  const execFn = (cmd: string, opts?: { timeout?: number }) =>
+    execSync(cmd, { encoding: 'utf-8', ...opts }) as string;
+
   loadConfig(resolve(cwd, '.harness.yaml')).then((config: any) => {
-    const result = handlePostToolUse(input.tool_name, input.tool_input, tracker, cache, config);
+    const result = handlePostToolUse(input.tool_name, input.tool_input, tracker, cache, config, execFn);
 
     if (result) {
       console.error(result);

--- a/templates/hooks/post-tool-use.ts
+++ b/templates/hooks/post-tool-use.ts
@@ -49,7 +49,7 @@ import { execSync } from 'node:child_process';
   // execFn powers external-directory graphify stats capture; without it that
   // branch of handlePostToolUse is dead code.
   const execFn = (cmd: string, opts?: { timeout?: number }) =>
-    execSync(cmd, { encoding: 'utf-8', ...opts }) as string;
+    execSync(cmd, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], ...opts }) as string;
 
   loadConfig(resolve(cwd, '.harness.yaml')).then((config: any) => {
     const result = handlePostToolUse(input.tool_name, input.tool_input, tracker, cache, config, execFn);

--- a/tests/enforcement/post-tool-use.test.ts
+++ b/tests/enforcement/post-tool-use.test.ts
@@ -128,6 +128,74 @@ describe('handlePostToolUse', () => {
     });
   });
 
+  it('captures stats when an external graph is built via Bash graphify update', () => {
+    const report = [
+      '# Graph Report - /external/meridian',
+      '',
+      '## Summary',
+      '- 420 nodes · 891 edges · 67 communities detected',
+      '- Extraction: 91% EXTRACTED · 9% INFERRED · 0% AMBIGUOUS',
+    ].join('\n');
+    // Only the report read is expected: the graph was just built by the Bash
+    // command itself, so no test -f / graphify update retry should run.
+    const exec = (cmd: string) => {
+      if (cmd.includes('GRAPH_REPORT.md')) return report;
+      throw new Error(`unexpected: ${cmd}`);
+    };
+
+    handlePostToolUse(
+      'Bash',
+      { command: 'graphify update "/external/meridian"' },
+      tracker,
+      cache,
+      config,
+      exec,
+    );
+
+    expect(cache.getGraphifyStats('/external/meridian')).toEqual({
+      nodes: 420, edges: 891, communities: 67,
+      extractedPct: 91, inferredPct: 9, ambiguousPct: 0,
+    });
+  });
+
+  it('captures stats for unquoted and graphifyy command variants', () => {
+    const report = '- 10 nodes · 20 edges · 3 communities detected';
+    const exec = (cmd: string) => {
+      if (cmd.includes('GRAPH_REPORT.md')) return report;
+      throw new Error(`unexpected: ${cmd}`);
+    };
+
+    handlePostToolUse(
+      'Bash', { command: 'graphifyy update /external/alpha' }, tracker, cache, config, exec,
+    );
+
+    expect(cache.getGraphifyStats('/external/alpha')?.nodes).toBe(10);
+  });
+
+  it('does not capture stats for Bash graphify update on the CWD', () => {
+    const exec = () => { throw new Error('should not be called'); };
+
+    handlePostToolUse(
+      'Bash',
+      { command: `graphify update "${process.cwd()}"` },
+      tracker,
+      cache,
+      config,
+      exec,
+    );
+
+    expect(cache.getGraphifyStats(process.cwd())).toBeUndefined();
+  });
+
+  it('ignores Bash commands that merely mention graphify without update', () => {
+    const exec = () => { throw new Error('should not be called'); };
+
+    expect(() => handlePostToolUse(
+      'Bash', { command: 'graphify benchmark "/external/x"' }, tracker, cache, config, exec,
+    )).not.toThrow();
+    expect(cache.getGraphifyStats('/external/x')).toBeUndefined();
+  });
+
   it('does not capture stats for CWD directory on index_folder', () => {
     const exec = () => '';
     handlePostToolUse(

--- a/tests/integration/pre-tool-use.test.ts
+++ b/tests/integration/pre-tool-use.test.ts
@@ -102,10 +102,14 @@ describe('PreToolUse hook E2E', () => {
       tool_input: { command: 'rtk cat /some/file.ts' },
     }, tempDir);
 
-    // The E2E hook template may not load the latest rules due to
-    // require/ESM interop. Verify it doesn't crash (exit code 0, 1, or 2).
-    // Exit 1 = subprocess failure on CI (npx tsx resolution), not a hook bug.
-    expect([0, 1, 2]).toContain(result.exitCode);
+    // The hook's only legitimate exits are 0 (allow/advise) and 2 (block).
+    // CI environment failures (npx/tsx resolution races, observed as exit 1
+    // and exit 254 under the coverage job) produce arbitrary codes — what
+    // must never happen is a crash inside the hook itself, which would leave
+    // a stack trace referencing the hook script or a typed JS error.
+    if (![0, 2].includes(result.exitCode)) {
+      expect(result.stderr).not.toMatch(/pre-tool-use\.ts:\d+|TypeError|ReferenceError|SyntaxError/);
+    }
   });
 
   it('allows rtk cat on non-code files', async () => {

--- a/tests/router/rewrite.test.ts
+++ b/tests/router/rewrite.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { handlePreToolUse, tryRtkRewrite, type ExecRewriteFn } from '../../src/router/hook.js';
+import { describe, it, expect, vi } from 'vitest';
+import { handlePreToolUse, tryRtkRewrite, makeDefaultExecRewrite, type ExecRewriteFn } from '../../src/router/hook.js';
 import { SessionCache } from '../../src/session/cache.js';
 import { DEFAULT_CONFIG } from '../../src/config.js';
 import type { RewriteResult } from '../../src/types.js';
@@ -21,6 +21,72 @@ const mockRewriteSuccess: ExecRewriteFn = (_rtkPath, args) => {
 const mockRewriteNone: ExecRewriteFn = () => null;
 
 const mockRewriteIdentical: ExecRewriteFn = (_rtkPath, args) => args[1];
+
+// ── makeDefaultExecRewrite diagnostics ──
+
+describe('makeDefaultExecRewrite diagnostics', () => {
+  function execError(props: Record<string, unknown>): () => never {
+    return () => {
+      throw Object.assign(new Error('exec failed'), props);
+    };
+  }
+
+  it('returns the rewritten command on success with no diagnostics', () => {
+    const writeDiag = vi.fn();
+    const rewrite = makeDefaultExecRewrite(writeDiag, () => 'rtk grep foo\n');
+
+    expect(rewrite('/usr/bin/rtk', ['rewrite', 'grep foo'])).toBe('rtk grep foo');
+    expect(writeDiag).not.toHaveBeenCalled();
+  });
+
+  it('stays silent on expected declines (exit 1 and 2)', () => {
+    const writeDiag = vi.fn();
+    for (const status of [1, 2]) {
+      const rewrite = makeDefaultExecRewrite(writeDiag, execError({ status }));
+      expect(rewrite('/usr/bin/rtk', ['rewrite', 'grep foo'])).toBeNull();
+    }
+    expect(writeDiag).not.toHaveBeenCalled();
+  });
+
+  it('logs unexpected exit codes with stderr context', () => {
+    const writeDiag = vi.fn();
+    const rewrite = makeDefaultExecRewrite(
+      writeDiag,
+      execError({ status: 127, stderr: 'boom: library mismatch' }),
+    );
+
+    expect(rewrite('/usr/bin/rtk', ['rewrite', 'grep foo'])).toBeNull();
+    expect(writeDiag).toHaveBeenCalledTimes(1);
+    const line = writeDiag.mock.calls[0][0] as string;
+    expect(line).toContain('127');
+    expect(line).toContain('boom: library mismatch');
+    expect(line).toContain('grep foo');
+  });
+
+  it('logs signals and ENOENT-style failures', () => {
+    const writeDiag = vi.fn();
+    const rewrite = makeDefaultExecRewrite(writeDiag, execError({ signal: 'SIGTERM' }));
+    expect(rewrite('/usr/bin/rtk', ['rewrite', 'cat f'])).toBeNull();
+    expect(writeDiag).toHaveBeenCalledWith(expect.stringContaining('SIGTERM'));
+
+    const writeDiag2 = vi.fn();
+    const rewrite2 = makeDefaultExecRewrite(writeDiag2, execError({ code: 'ENOENT' }));
+    expect(rewrite2('/missing/rtk', ['rewrite', 'cat f'])).toBeNull();
+    expect(writeDiag2).toHaveBeenCalledWith(expect.stringContaining('ENOENT'));
+  });
+
+  it('truncates stderr in the diagnostic line to 300 chars', () => {
+    const writeDiag = vi.fn();
+    const rewrite = makeDefaultExecRewrite(
+      writeDiag,
+      execError({ status: 101, stderr: 'x'.repeat(1000) }),
+    );
+
+    rewrite('/usr/bin/rtk', ['rewrite', 'grep foo']);
+    const parsed = JSON.parse(writeDiag.mock.calls[0][0] as string);
+    expect(parsed.stderr).toHaveLength(300);
+  });
+});
 
 // ── tryRtkRewrite unit tests ──
 

--- a/tests/scout/graph-state.test.ts
+++ b/tests/scout/graph-state.test.ts
@@ -112,6 +112,51 @@ describe('waitForBuild', () => {
 
     expect(result.errorReason).toBe('graph.json missing or placeholder after build');
   });
+
+  it('polls until the graph lands when a deadline is given (build-output race)', () => {
+    // Field bug: graphify update returned at T, graph.json landed at T+1s,
+    // the single immediate check recorded "failed" and cached it all session.
+    const buildInfo: GraphBuildInfo = { state: 'building', startedAt: Date.now() };
+    let landed = false;
+    const sleeps: number[] = [];
+
+    const result = waitForBuild(
+      buildInfo,
+      '/project',
+      () => landed,
+      () => (landed ? { size: 5000 } : undefined),
+      {
+        deadlineMs: 5000,
+        intervalMs: 250,
+        sleep: (ms) => { sleeps.push(ms); if (sleeps.length === 2) landed = true; },
+      },
+    );
+
+    expect(result.state).toBe('ready');
+    expect(sleeps).toEqual([250, 250]);
+  });
+
+  it('fails after the deadline when the graph never lands', () => {
+    const buildInfo: GraphBuildInfo = { state: 'building', startedAt: Date.now() };
+    const sleeps: number[] = [];
+
+    const result = waitForBuild(
+      buildInfo, '/project', () => false, () => undefined,
+      { deadlineMs: 500, intervalMs: 250, sleep: (ms) => sleeps.push(ms) },
+    );
+
+    expect(result.state).toBe('failed');
+    expect(sleeps.length).toBeGreaterThan(0);
+  });
+
+  it('default behavior stays a single immediate check (no sleeping)', () => {
+    const buildInfo: GraphBuildInfo = { state: 'building', startedAt: Date.now() };
+    let checks = 0;
+    const result = waitForBuild(buildInfo, '/project', () => { checks++; return false; }, () => undefined);
+
+    expect(result.state).toBe('failed');
+    expect(checks).toBe(1);
+  });
 });
 
 // ── ensureGraphReady ──
@@ -182,20 +227,38 @@ describe('ensureGraphReady', () => {
     expect(mockExec).not.toHaveBeenCalled();
   });
 
-  it('returns failed when state is failed', () => {
-    const env = makeEnv({ state: 'failed' });
+  it('revalidates a cached failed state against the disk — stale failure becomes ready', () => {
+    // Field bug: the build-output race cached "failed" for the whole session
+    // even though graph.json landed seconds later. The disk is truth.
+    const env = makeEnv({ state: 'failed', errorReason: 'graph.json missing or placeholder after build' });
     const result = ensureGraphReady('/project', env, mockExec as any, () => true, () => ({ size: 5000 }));
+
+    expect(result).not.toBeNull();
+    expect(result!.state).toBe('ready');
+    expect(result!.graphPath).toBe('graphify-out/graph.json');
+    expect(mockExec).not.toHaveBeenCalled(); // revalidation reads disk, never rebuilds
+  });
+
+  it('keeps the failed state (and its reason) when the graph really is absent', () => {
+    const env = makeEnv({ state: 'failed', errorReason: 'recursion depth' });
+    const result = ensureGraphReady('/project', env, mockExec as any, () => false, () => undefined);
+
     expect(result).not.toBeNull();
     expect(result!.state).toBe('failed');
+    expect(result!.errorReason).toBe('recursion depth');
     expect(mockExec).not.toHaveBeenCalled();
   });
 
-  it('returns build_failed when build exec throws', () => {
+  it('returns build_failed with the error reason when build exec throws', () => {
     const env = makeEnv({ state: 'absent' });
     const failExec = vi.fn(() => { throw new Error('recursion depth'); });
+    let checks = 0;
 
-    const result = ensureGraphReady('/project', env, failExec as any, () => false, () => undefined);
+    const result = ensureGraphReady('/project', env, failExec as any, () => { checks++; return false; }, () => undefined);
     expect(result).not.toBeNull();
     expect(result!.state).toBe('failed');
+    expect(result!.errorReason).toBe('recursion depth');
+    // A failed trigger short-circuits — no pointless waitForBuild check
+    expect(checks).toBe(0);
   });
 });

--- a/tests/scout/graph-state.test.ts
+++ b/tests/scout/graph-state.test.ts
@@ -62,6 +62,23 @@ describe('triggerBuild', () => {
     expect(result.state).toBe('failed');
     expect(result.graphPath).toBeUndefined();
   });
+
+  it('preserves the error message on build failure', () => {
+    const mockExec = vi.fn(() => {
+      throw new Error('maximum recursion depth exceeded during tree-sitter traversal');
+    });
+    const result = triggerBuild('/project', mockExec as any);
+
+    expect(result.state).toBe('failed');
+    expect(result.errorReason).toBe('maximum recursion depth exceeded during tree-sitter traversal');
+  });
+
+  it('truncates very long error messages to 200 chars', () => {
+    const mockExec = vi.fn(() => { throw new Error('x'.repeat(500)); });
+    const result = triggerBuild('/project', mockExec as any);
+
+    expect(result.errorReason).toHaveLength(200);
+  });
 });
 
 // ── waitForBuild ──
@@ -87,6 +104,13 @@ describe('waitForBuild', () => {
     const result = waitForBuild(buildInfo, '/project', () => true, () => ({ size: 50 }));
 
     expect(result.state).toBe('failed');
+  });
+
+  it('explains the failure when the graph never materialized', () => {
+    const buildInfo: GraphBuildInfo = { state: 'building', startedAt: Date.now() };
+    const result = waitForBuild(buildInfo, '/project', () => false, () => undefined);
+
+    expect(result.errorReason).toBe('graph.json missing or placeholder after build');
   });
 });
 

--- a/tests/session/claude-config.test.ts
+++ b/tests/session/claude-config.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect } from 'vitest';
+import { resolveJcodemunchRegistration } from '../../src/session/claude-config.js';
+
+const HOME = '/home/user';
+const CWD = '/work/my-project';
+
+// The real-world registration shape that motivated this module: jcodemunch-mcp
+// is distributed as a GitHub release wheel, not a PyPI package.
+const WHEEL_URL =
+  'https://github.com/jgravelle/jcodemunch-mcp/releases/download/v1.108.20/jcodemunch_mcp-1.108.20-py3-none-any.whl';
+const WHEEL_REGISTRATION = {
+  type: 'stdio',
+  command: 'uvx',
+  args: ['--from', WHEEL_URL, 'jcodemunch-mcp'],
+  env: {},
+};
+
+function makeFiles(files: Record<string, string>): {
+  readFile: (p: string) => string;
+  existsCheck: (p: string) => boolean;
+} {
+  return {
+    readFile: (p: string) => {
+      if (p in files) return files[p];
+      throw new Error(`ENOENT: ${p}`);
+    },
+    existsCheck: (p: string) => p in files,
+  };
+}
+
+describe('resolveJcodemunchRegistration', () => {
+  it('finds a user-scope registration in ~/.claude.json mcpServers', () => {
+    const { readFile, existsCheck } = makeFiles({
+      [`${HOME}/.claude.json`]: JSON.stringify({
+        mcpServers: { jcodemunch: WHEEL_REGISTRATION },
+      }),
+    });
+
+    const reg = resolveJcodemunchRegistration(CWD, readFile, existsCheck, HOME);
+    expect(reg).toEqual({
+      command: 'uvx',
+      args: ['--from', WHEEL_URL, 'jcodemunch-mcp'],
+      source: 'user',
+    });
+  });
+
+  it('prefers project-scope .mcp.json over user scope', () => {
+    const { readFile, existsCheck } = makeFiles({
+      [`${HOME}/.claude.json`]: JSON.stringify({
+        mcpServers: { jcodemunch: WHEEL_REGISTRATION },
+      }),
+      [`${CWD}/.mcp.json`]: JSON.stringify({
+        mcpServers: {
+          jcodemunch: { command: '/usr/local/bin/jcodemunch-mcp', args: [] },
+        },
+      }),
+    });
+
+    const reg = resolveJcodemunchRegistration(CWD, readFile, existsCheck, HOME);
+    expect(reg).toEqual({
+      command: '/usr/local/bin/jcodemunch-mcp',
+      args: [],
+      source: 'project',
+    });
+  });
+
+  it('prefers local scope (projects[cwd].mcpServers) over project and user', () => {
+    const { readFile, existsCheck } = makeFiles({
+      [`${HOME}/.claude.json`]: JSON.stringify({
+        mcpServers: { jcodemunch: WHEEL_REGISTRATION },
+        projects: {
+          [CWD]: {
+            mcpServers: {
+              jcodemunch: { command: 'local-jcodemunch-mcp', args: ['--local'] },
+            },
+          },
+        },
+      }),
+      [`${CWD}/.mcp.json`]: JSON.stringify({
+        mcpServers: {
+          jcodemunch: { command: 'project-jcodemunch-mcp', args: [] },
+        },
+      }),
+    });
+
+    const reg = resolveJcodemunchRegistration(CWD, readFile, existsCheck, HOME);
+    expect(reg).toEqual({
+      command: 'local-jcodemunch-mcp',
+      args: ['--local'],
+      source: 'local',
+    });
+  });
+
+  it('matches by substring when the server is keyed under another name', () => {
+    const { readFile, existsCheck } = makeFiles({
+      [`${HOME}/.claude.json`]: JSON.stringify({
+        mcpServers: {
+          'code-index': {
+            command: 'uvx',
+            args: ['--from', WHEEL_URL, 'jcodemunch-mcp'],
+          },
+        },
+      }),
+    });
+
+    const reg = resolveJcodemunchRegistration(CWD, readFile, existsCheck, HOME);
+    expect(reg?.command).toBe('uvx');
+    expect(reg?.args).toContain('jcodemunch-mcp');
+  });
+
+  it('prefers an exact "jcodemunch" key over a substring match', () => {
+    const { readFile, existsCheck } = makeFiles({
+      [`${HOME}/.claude.json`]: JSON.stringify({
+        mcpServers: {
+          'jcodemunch-legacy': { command: 'old-jcodemunch-mcp', args: [] },
+          jcodemunch: WHEEL_REGISTRATION,
+        },
+      }),
+    });
+
+    const reg = resolveJcodemunchRegistration(CWD, readFile, existsCheck, HOME);
+    expect(reg?.command).toBe('uvx');
+  });
+
+  it('skips non-stdio transports', () => {
+    const { readFile, existsCheck } = makeFiles({
+      [`${HOME}/.claude.json`]: JSON.stringify({
+        mcpServers: {
+          jcodemunch: { type: 'http', url: 'https://example.com/mcp' },
+        },
+      }),
+    });
+
+    expect(resolveJcodemunchRegistration(CWD, readFile, existsCheck, HOME)).toBeNull();
+  });
+
+  it('skips entries without a string command', () => {
+    const { readFile, existsCheck } = makeFiles({
+      [`${HOME}/.claude.json`]: JSON.stringify({
+        mcpServers: { jcodemunch: { args: ['jcodemunch-mcp'] } },
+      }),
+    });
+
+    expect(resolveJcodemunchRegistration(CWD, readFile, existsCheck, HOME)).toBeNull();
+  });
+
+  it('defaults args to [] when absent', () => {
+    const { readFile, existsCheck } = makeFiles({
+      [`${HOME}/.claude.json`]: JSON.stringify({
+        mcpServers: { jcodemunch: { type: 'stdio', command: 'jcodemunch-mcp' } },
+      }),
+    });
+
+    const reg = resolveJcodemunchRegistration(CWD, readFile, existsCheck, HOME);
+    expect(reg).toEqual({ command: 'jcodemunch-mcp', args: [], source: 'user' });
+  });
+
+  it('falls through to the next scope on malformed JSON', () => {
+    const { readFile, existsCheck } = makeFiles({
+      [`${HOME}/.claude.json`]: '{ not valid json',
+      [`${CWD}/.mcp.json`]: JSON.stringify({
+        mcpServers: { jcodemunch: { command: 'jcodemunch-mcp', args: [] } },
+      }),
+    });
+
+    const reg = resolveJcodemunchRegistration(CWD, readFile, existsCheck, HOME);
+    expect(reg?.source).toBe('project');
+  });
+
+  it('returns null when no config files exist', () => {
+    const { readFile, existsCheck } = makeFiles({});
+    expect(resolveJcodemunchRegistration(CWD, readFile, existsCheck, HOME)).toBeNull();
+  });
+
+  it('returns null when configs exist but contain no jcodemunch server', () => {
+    const { readFile, existsCheck } = makeFiles({
+      [`${HOME}/.claude.json`]: JSON.stringify({
+        mcpServers: { graphify: { command: 'graphify-mcp', args: [] } },
+      }),
+      [`${CWD}/.mcp.json`]: JSON.stringify({ mcpServers: {} }),
+    });
+
+    expect(resolveJcodemunchRegistration(CWD, readFile, existsCheck, HOME)).toBeNull();
+  });
+
+  it('never throws when readFile itself throws unexpectedly', () => {
+    const reg = resolveJcodemunchRegistration(
+      CWD,
+      () => { throw new Error('EACCES'); },
+      () => true,
+      HOME,
+    );
+    expect(reg).toBeNull();
+  });
+});

--- a/tests/session/environment.test.ts
+++ b/tests/session/environment.test.ts
@@ -94,7 +94,7 @@ describe('detectEnvironment', () => {
       'which uvx': new Error('not found'),
     });
 
-    const env = await detectEnvironment('/fake/cwd', exec);
+    const env = await detectEnvironment('/fake/cwd', exec, undefined, undefined, makeMcpQuery({}), () => null);
     expect(env.jcodemunchAvailable).toBe(false);
     expect(env.jcodemunchCwdIndexed).toBe(false);
     expect(env.jcodemunchCwdRepo).toBeNull();
@@ -243,7 +243,7 @@ describe('detectEnvironment', () => {
       'which uvx': new Error('not found'),
     });
 
-    const env = await detectEnvironment('/fake/cwd', exec);
+    const env = await detectEnvironment('/fake/cwd', exec, undefined, undefined, makeMcpQuery({}), () => null);
     expect(env.rtkAvailable).toBe(false);
     expect(env.rtkPath).toBeNull();
     expect(env.jcodemunchAvailable).toBe(false);
@@ -309,7 +309,14 @@ describe('detectEnvironment', () => {
       'which uvx': new Error('not found'),
     });
 
-    const env = await detectEnvironment('/Users/jerome/Documents/Claude/Projects/forgd-onboarding', exec);
+    const env = await detectEnvironment(
+      '/Users/jerome/Documents/Claude/Projects/forgd-onboarding',
+      exec,
+      undefined,
+      undefined,
+      makeMcpQuery({}),
+      () => null,
+    );
     expect(env.jcodemunchAvailable).toBe(false);
     expect(env.jcodemunchCwdIndexed).toBe(false);
   });
@@ -357,7 +364,7 @@ describe('detectEnvironment', () => {
       return mcpListReposResponse([{ repo: 'local/my-project' }]);
     };
 
-    await detectEnvironment('/Users/jerome/projects/my-project', exec, undefined, undefined, mcpQuery);
+    await detectEnvironment('/Users/jerome/projects/my-project', exec, undefined, undefined, mcpQuery, () => null);
     expect(capturedCommand).toBe('uvx');
     expect(capturedArgs).toEqual(['jcodemunch-mcp']);
     // Must include initialize, notifications/initialized, and tools/call list_repos
@@ -396,6 +403,147 @@ describe('detectEnvironment', () => {
     expect(env.jcodemunchCwdIndexed).toBe(true);
     expect(env.jcodemunchCwdRepo).toBe('local/my-project');
     expect(mcpQueryCommand).toBe('/home/user/.local/bin/jcodemunch-mcp');
+  });
+});
+
+describe('detectEnvironment with config-registered MCP transport', () => {
+  const WHEEL_URL =
+    'https://github.com/jgravelle/jcodemunch-mcp/releases/download/v1.108.20/jcodemunch_mcp-1.108.20-py3-none-any.whl';
+  const wheelRegistration = {
+    command: 'uvx',
+    args: ['--from', WHEEL_URL, 'jcodemunch-mcp'],
+    source: 'user' as const,
+  };
+
+  const noBinariesExec = makeExec({
+    'which rtk': new Error('not found'),
+    'which jcodemunch-mcp': new Error('not found'),
+    'which jcodemunch': new Error('not found'),
+    'which uvx': '/opt/homebrew/bin/uvx',
+    'which graphify': new Error('not found'),
+  });
+
+  it('detects via registered wheel-URL command when binaries are absent (live-bug regression)', async () => {
+    const probeCalls: Array<{ command: string; args: string[] }> = [];
+    const mcpQuery: McpQueryFn = async (command, args) => {
+      probeCalls.push({ command, args });
+      if (command === 'uvx' && args.includes(WHEEL_URL)) {
+        return mcpListReposResponse([{ repo: 'franklywatson/my-project' }]);
+      }
+      return null;
+    };
+
+    const env = await detectEnvironment(
+      '/work/my-project',
+      noBinariesExec,
+      () => false,
+      () => undefined,
+      mcpQuery,
+      () => wheelRegistration,
+    );
+
+    expect(env.jcodemunchAvailable).toBe(true);
+    expect(env.jcodemunchCwdIndexed).toBe(true);
+    expect(env.jcodemunchCwdRepo).toBe('franklywatson/my-project');
+    expect(env.jcodemunchTransport).toEqual({
+      kind: 'config',
+      command: 'uvx',
+      args: ['--from', WHEEL_URL, 'jcodemunch-mcp'],
+      source: 'user',
+    });
+    // The registration command/args must be passed to the probe verbatim
+    expect(probeCalls[0]).toEqual({
+      command: 'uvx',
+      args: ['--from', WHEEL_URL, 'jcodemunch-mcp'],
+    });
+  });
+
+  it('falls through to jcodemunch-mcp binary when the registration probe fails', async () => {
+    const exec = makeExec({
+      'which rtk': new Error('not found'),
+      'which jcodemunch-mcp': '/usr/local/bin/jcodemunch-mcp',
+      'which jcodemunch': new Error('not found'),
+      'which graphify': new Error('not found'),
+    });
+    const mcpQuery: McpQueryFn = async (command) => {
+      if (command === '/usr/local/bin/jcodemunch-mcp') {
+        return mcpListReposResponse([{ repo: 'local/my-project' }]);
+      }
+      return null; // registration probe fails
+    };
+
+    const env = await detectEnvironment(
+      '/work/my-project',
+      exec,
+      () => false,
+      () => undefined,
+      mcpQuery,
+      () => wheelRegistration,
+    );
+
+    expect(env.jcodemunchAvailable).toBe(true);
+    expect(env.jcodemunchTransport?.kind).toBe('binary');
+    expect(env.jcodemunchTransport?.command).toBe('/usr/local/bin/jcodemunch-mcp');
+  });
+
+  it('uses the bare uvx fallback when no registration exists', async () => {
+    const mcpQuery: McpQueryFn = async (command, args) => {
+      if (command === 'uvx' && args.length === 1 && args[0] === 'jcodemunch-mcp') {
+        return mcpListReposResponse([{ repo: 'local/my-project' }]);
+      }
+      return null;
+    };
+
+    const env = await detectEnvironment(
+      '/work/my-project',
+      noBinariesExec,
+      () => false,
+      () => undefined,
+      mcpQuery,
+      () => null,
+    );
+
+    expect(env.jcodemunchAvailable).toBe(true);
+    expect(env.jcodemunchTransport).toEqual({
+      kind: 'uvx',
+      command: 'uvx',
+      args: ['jcodemunch-mcp'],
+    });
+  });
+
+  it('records a cli transport when the jcodemunch binary is on PATH', async () => {
+    const exec = makeExec({
+      'which rtk': new Error('not found'),
+      'which jcodemunch-mcp': new Error('not found'),
+      'which jcodemunch': '/usr/local/bin/jcodemunch',
+      'jcodemunch list_repos': JSON.stringify({ repos: ['local/my-project'] }),
+      'which graphify': new Error('not found'),
+    });
+
+    const env = await detectEnvironment(
+      '/work/my-project',
+      exec,
+      () => false,
+      () => undefined,
+      makeMcpQuery({}),
+      () => null,
+    );
+
+    expect(env.jcodemunchAvailable).toBe(true);
+    expect(env.jcodemunchTransport?.kind).toBe('cli');
+  });
+
+  it('a throwing registrationLookup never breaks detection', async () => {
+    const env = await detectEnvironment(
+      '/work/my-project',
+      noBinariesExec,
+      () => false,
+      () => undefined,
+      makeMcpQuery({}),
+      () => { throw new Error('config unreadable'); },
+    );
+
+    expect(env.jcodemunchAvailable).toBe(false);
   });
 });
 

--- a/tests/session/environment.test.ts
+++ b/tests/session/environment.test.ts
@@ -709,17 +709,33 @@ describe('detectGraphify', () => {
     expect(result.graphPath).toBe('graphify-out/graph.json');
   });
 
-  it('returns state absent when which graphify fails', () => {
+  it('returns ready when graph.json exists even if CLI is not on PATH', () => {
+    // The CLI may be installed off the hook PATH (e.g. ~/.local/bin); a valid
+    // graph on disk is sufficient for 'ready' — CLI is only needed to rebuild.
     const exec = makeExec({
       'which graphify': new Error('not found'),
       'which graphifyy': new Error('not found'),
     });
-    const existsCheck = (_path: string) => true;
-    const statCheck = (_path: string) => ({ size: 5000 });
+    const existsCheck = (path: string) => path === '/fake/cwd/graphify-out/graph.json';
+    const statCheck = (path: string) =>
+      path === '/fake/cwd/graphify-out/graph.json' ? { size: 5000 } : undefined;
 
     const result = detectGraphify('/fake/cwd', exec, existsCheck, statCheck);
+    expect(result.state).toBe('ready');
+    expect(result.graphPath).toBe('graphify-out/graph.json');
+    expect(result._cliFound).toBe(false);
+  });
+
+  it('returns state absent when CLI not found and no graph.json', () => {
+    const exec = makeExec({
+      'which graphify': new Error('not found'),
+      'which graphifyy': new Error('not found'),
+    });
+
+    const result = detectGraphify('/fake/cwd', exec, () => false, () => undefined);
     expect(result.state).toBe('absent');
     expect(result.graphPath).toBeUndefined();
+    expect(result._cliFound).toBe(false);
   });
 
   it('returns state absent when graphifyy (uvx) binary exists but no graph.json', () => {

--- a/tests/session/environment.test.ts
+++ b/tests/session/environment.test.ts
@@ -800,6 +800,48 @@ describe('detectGraphify', () => {
     expect(env.graphifyGraphPath).toBe('graphify-out/graph.json');
   });
 
+  it('returns building when .rebuild.lock present and no valid graph', () => {
+    const exec = makeExec({ 'which graphify': '/usr/local/bin/graphify' });
+    const existsCheck = (path: string) => path === '/fake/cwd/graphify-out/.rebuild.lock';
+
+    const result = detectGraphify(
+      '/fake/cwd', exec, existsCheck, () => undefined,
+      (path) => (path.endsWith('.rebuild.lock') ? new Date(2000) : undefined),
+    );
+    expect(result.state).toBe('building');
+    expect(result._cliFound).toBe(true);
+  });
+
+  it('returns ready when graph.json is newer than .rebuild.lock (stale lock from completed build)', () => {
+    // graphify leaves lock files behind after completed builds
+    const exec = makeExec({ 'which graphify': '/usr/local/bin/graphify' });
+    const existsCheck = (path: string) =>
+      path === '/fake/cwd/graphify-out/graph.json' ||
+      path === '/fake/cwd/graphify-out/.rebuild.lock';
+    const statCheck = (path: string) =>
+      path === '/fake/cwd/graphify-out/graph.json' ? { size: 5000 } : undefined;
+    const mtimeCheck = (path: string) =>
+      path.endsWith('graph.json') ? new Date(5000) : new Date(1000);
+
+    const result = detectGraphify('/fake/cwd', exec, existsCheck, statCheck, mtimeCheck);
+    expect(result.state).toBe('ready');
+    expect(result.graphPath).toBe('graphify-out/graph.json');
+  });
+
+  it('returns building when .rebuild.lock is newer than graph.json (active rebuild)', () => {
+    const exec = makeExec({ 'which graphify': '/usr/local/bin/graphify' });
+    const existsCheck = (path: string) =>
+      path === '/fake/cwd/graphify-out/graph.json' ||
+      path === '/fake/cwd/graphify-out/.rebuild.lock';
+    const statCheck = (path: string) =>
+      path === '/fake/cwd/graphify-out/graph.json' ? { size: 5000 } : undefined;
+    const mtimeCheck = (path: string) =>
+      path.endsWith('graph.json') ? new Date(1000) : new Date(5000);
+
+    const result = detectGraphify('/fake/cwd', exec, existsCheck, statCheck, mtimeCheck);
+    expect(result.state).toBe('building');
+  });
+
   it('returns state ready when graphifyy binary and real graph exist', () => {
     const exec = (cmd: string) => {
       if (cmd === 'which graphify') throw new Error('not found');

--- a/tests/session/environment.test.ts
+++ b/tests/session/environment.test.ts
@@ -842,6 +842,77 @@ describe('detectGraphify', () => {
     expect(result.state).toBe('building');
   });
 
+  it('captures the CLI version when the probe succeeds', () => {
+    const exec = makeExec({
+      'which graphify': '/usr/local/bin/graphify',
+      'graphify --version': 'graphify 0.7.18',
+    });
+    const existsCheck = (path: string) => path === '/fake/cwd/graphify-out/graph.json';
+    const statCheck = () => ({ size: 5000 });
+
+    const result = detectGraphify('/fake/cwd', exec, existsCheck, statCheck);
+    expect(result.state).toBe('ready');
+    expect(result.cliVersion).toBe('0.7.18');
+  });
+
+  it('parses the version from the binary line, not from skew-warning noise', () => {
+    // Live output includes a warning line mentioning a different version:
+    //   warning: skill is from graphify 0.7.16, package is 0.7.18. ...
+    //   graphify 0.7.18
+    const exec = makeExec({
+      'which graphify': '/usr/local/bin/graphify',
+      'graphify --version':
+        "  warning: skill is from graphify 0.7.16, package is 0.7.18. Run 'graphify install' to update.\ngraphify 0.7.18",
+    });
+
+    const result = detectGraphify('/fake/cwd', exec, () => false, () => undefined);
+    expect(result.cliVersion).toBe('0.7.18');
+  });
+
+  it('version probe failure never changes detection state', () => {
+    const exec = makeExec({
+      'which graphify': '/usr/local/bin/graphify',
+      // no 'graphify --version' key — makeExec throws for it
+    });
+    const existsCheck = (path: string) => path === '/fake/cwd/graphify-out/graph.json';
+    const statCheck = () => ({ size: 5000 });
+
+    const result = detectGraphify('/fake/cwd', exec, existsCheck, statCheck);
+    expect(result.state).toBe('ready');
+    expect(result.cliVersion).toBeUndefined();
+  });
+
+  it('probes the graphifyy binary name when that is what resolved', () => {
+    const calls: string[] = [];
+    const exec = (cmd: string) => {
+      calls.push(cmd);
+      if (cmd === 'which graphify') throw new Error('not found');
+      if (cmd === 'which graphifyy') return '/home/user/.local/bin/graphifyy';
+      if (cmd === 'graphifyy --version') return 'graphifyy 0.7.16';
+      throw new Error(`unexpected: ${cmd}`);
+    };
+
+    const result = detectGraphify('/fake/cwd', exec, () => false, () => undefined);
+    expect(result.cliVersion).toBe('0.7.16');
+    expect(calls).toContain('graphifyy --version');
+  });
+
+  it('exposes graphifyVersion on the detected environment', async () => {
+    const exec = makeExec({
+      'which rtk': new Error('not found'),
+      'which jcodemunch-mcp': new Error('not found'),
+      'which jcodemunch': new Error('not found'),
+      'which uvx': new Error('not found'),
+      'which graphify': '/usr/local/bin/graphify',
+      'graphify --version': 'graphify 0.7.18',
+    });
+
+    const env = await detectEnvironment(
+      '/project', exec, () => false, () => undefined, makeMcpQuery({}), () => null,
+    );
+    expect(env.graphifyVersion).toBe('0.7.18');
+  });
+
   it('returns state ready when graphifyy binary and real graph exist', () => {
     const exec = (cmd: string) => {
       if (cmd === 'which graphify') throw new Error('not found');

--- a/tests/session/environment.test.ts
+++ b/tests/session/environment.test.ts
@@ -34,7 +34,10 @@ function makeMcpQuery(responses: Record<string, string | Error | null>): McpQuer
 }
 
 // Helper to build MCP JSON-RPC response for list_repos
-function mcpListReposResponse(repos: Array<{ repo: string; source_root?: string }>): string {
+function mcpListReposResponse(
+  repos: Array<{ repo: string; source_root?: string }>,
+  protocolVersion = '2025-03-26',
+): string {
   const reposJson = JSON.stringify({ repos });
   const rpcResponse = {
     jsonrpc: '2.0',
@@ -44,7 +47,7 @@ function mcpListReposResponse(repos: Array<{ repo: string; source_root?: string 
       isError: false,
     },
   };
-  const initResponse = { jsonrpc: '2.0', id: 1, result: { protocolVersion: '2025-03-26' } };
+  const initResponse = { jsonrpc: '2.0', id: 1, result: { protocolVersion } };
   return JSON.stringify(initResponse) + '\n' + JSON.stringify(rpcResponse);
 }
 
@@ -612,6 +615,82 @@ describe('detectEnvironment with config-registered MCP transport', () => {
     );
 
     expect(env.jcodemunchAvailable).toBe(false);
+  });
+});
+
+describe('MCP protocol version validation', () => {
+  const uvxExec = makeExec({
+    'which rtk': new Error('not found'),
+    'which jcodemunch-mcp': new Error('not found'),
+    'which jcodemunch': new Error('not found'),
+    'which uvx': '/opt/homebrew/bin/uvx',
+    'which graphify': new Error('not found'),
+  });
+
+  it('sets no warning when the server speaks the expected protocol version', async () => {
+    const mcpQuery = makeMcpQuery({
+      'uvx jcodemunch-mcp': mcpListReposResponse([{ repo: 'local/my-project' }]),
+    });
+
+    const env = await detectEnvironment(
+      '/work/my-project', uvxExec, () => false, () => undefined, mcpQuery, () => null,
+    );
+    expect(env.jcodemunchAvailable).toBe(true);
+    expect(env.jcodemunchProtocolWarning).toBeUndefined();
+  });
+
+  it('sets a warning on protocol version mismatch but stays available', async () => {
+    const mcpQuery = makeMcpQuery({
+      'uvx jcodemunch-mcp': mcpListReposResponse([{ repo: 'local/my-project' }], '2024-11-05'),
+    });
+
+    const env = await detectEnvironment(
+      '/work/my-project', uvxExec, () => false, () => undefined, mcpQuery, () => null,
+    );
+    expect(env.jcodemunchAvailable).toBe(true);
+    expect(env.jcodemunchCwdIndexed).toBe(true);
+    expect(env.jcodemunchProtocolWarning).toContain('2024-11-05');
+    expect(env.jcodemunchProtocolWarning).toContain('2025-03-26');
+  });
+
+  it('sets no warning when the initialize line is missing or garbled', async () => {
+    const reposJson = JSON.stringify({ repos: [{ repo: 'local/my-project' }] });
+    const onlyToolResponse = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 2,
+      result: { content: [{ type: 'text', text: reposJson }], isError: false },
+    });
+    const mcpQuery = makeMcpQuery({
+      'uvx jcodemunch-mcp': '{garbled init line\n' + onlyToolResponse,
+    });
+
+    const env = await detectEnvironment(
+      '/work/my-project', uvxExec, () => false, () => undefined, mcpQuery, () => null,
+    );
+    expect(env.jcodemunchAvailable).toBe(true);
+    expect(env.jcodemunchProtocolWarning).toBeUndefined();
+  });
+
+  it('callJcodemunchMcpTool fires onWarning on mismatch and still returns the tool text', async () => {
+    const initResponse = JSON.stringify({
+      jsonrpc: '2.0', id: 1, result: { protocolVersion: '2024-11-05' },
+    });
+    const toolResponse = JSON.stringify({
+      jsonrpc: '2.0', id: 2, result: { content: [{ type: 'text', text: '{"success":true}' }] },
+    });
+    const mcpQuery = makeMcpQuery({
+      'jcodemunch-mcp': initResponse + '\n' + toolResponse,
+    });
+
+    const warnings: string[] = [];
+    const result = await callJcodemunchMcpTool(
+      'jcodemunch-mcp', [], 'index_folder', { path: '/work' }, mcpQuery, 60_000,
+      (msg) => warnings.push(msg),
+    );
+
+    expect(result).toBe('{"success":true}');
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('2024-11-05');
   });
 });
 

--- a/tests/session/environment.test.ts
+++ b/tests/session/environment.test.ts
@@ -34,7 +34,7 @@ function makeMcpQuery(responses: Record<string, string | Error | null>): McpQuer
 }
 
 // Helper to build MCP JSON-RPC response for list_repos
-function mcpListReposResponse(repos: Array<{ repo: string }>): string {
+function mcpListReposResponse(repos: Array<{ repo: string; source_root?: string }>): string {
   const reposJson = JSON.stringify({ repos });
   const rpcResponse = {
     jsonrpc: '2.0',
@@ -531,6 +531,74 @@ describe('detectEnvironment with config-registered MCP transport', () => {
 
     expect(env.jcodemunchAvailable).toBe(true);
     expect(env.jcodemunchTransport?.kind).toBe('cli');
+  });
+
+  it('source_root exact-path match wins over ambiguous basenames', async () => {
+    const mcpQuery: McpQueryFn = async (command, args) => {
+      if (command === 'uvx' && args.includes(WHEEL_URL)) {
+        return mcpListReposResponse([
+          { repo: 'local/api', source_root: '/other/checkout/api' },
+          { repo: 'team/api', source_root: '/work/api' },
+        ]);
+      }
+      return null;
+    };
+
+    const env = await detectEnvironment(
+      '/work/api',
+      noBinariesExec,
+      () => false,
+      () => undefined,
+      mcpQuery,
+      () => wheelRegistration,
+    );
+
+    expect(env.jcodemunchCwdIndexed).toBe(true);
+    expect(env.jcodemunchCwdRepo).toBe('team/api');
+    expect(env.jcodemunchKnownRepos).toEqual(['local/api', 'team/api']);
+  });
+
+  it('renamed checkout matches via source_root even when basenames differ', async () => {
+    const mcpQuery: McpQueryFn = async (command, args) => {
+      if (command === 'uvx' && args.includes(WHEEL_URL)) {
+        return mcpListReposResponse([
+          { repo: 'org/upstream-name', source_root: '/work/my-fork' },
+        ]);
+      }
+      return null;
+    };
+
+    const env = await detectEnvironment(
+      '/work/my-fork',
+      noBinariesExec,
+      () => false,
+      () => undefined,
+      mcpQuery,
+      () => wheelRegistration,
+    );
+
+    expect(env.jcodemunchCwdIndexed).toBe(true);
+    expect(env.jcodemunchCwdRepo).toBe('org/upstream-name');
+  });
+
+  it('falls back to strict basename equality when source_root is absent', async () => {
+    const mcpQuery: McpQueryFn = async (command, args) => {
+      if (command === 'uvx' && args.includes(WHEEL_URL)) {
+        return mcpListReposResponse([{ repo: 'local/test-rig' }, { repo: 'local/rig' }]);
+      }
+      return null;
+    };
+
+    const env = await detectEnvironment(
+      '/home/jerome/projects/rig',
+      noBinariesExec,
+      () => false,
+      () => undefined,
+      mcpQuery,
+      () => wheelRegistration,
+    );
+
+    expect(env.jcodemunchCwdRepo).toBe('local/rig');
   });
 
   it('a throwing registrationLookup never breaks detection', async () => {

--- a/tests/session/environment.test.ts
+++ b/tests/session/environment.test.ts
@@ -65,6 +65,34 @@ describe('detectEnvironment', () => {
     expect(env.rtkPath).toBe('/usr/local/bin/rtk');
   });
 
+  it('captures the rtk version when the probe succeeds', async () => {
+    const exec = makeExec({
+      'which rtk': '/opt/homebrew/bin/rtk',
+      'rtk --version': 'rtk 0.39.0\n',
+      'which jcodemunch-mcp': new Error('not found'),
+      'which jcodemunch': new Error('not found'),
+      'which uvx': new Error('not found'),
+    });
+
+    const env = await detectEnvironment('/fake/cwd', exec, () => false, () => undefined, makeMcpQuery({}), () => null);
+    expect(env.rtkAvailable).toBe(true);
+    expect(env.rtkVersion).toBe('0.39.0');
+  });
+
+  it('rtk version probe failure leaves rtk available with null version', async () => {
+    const exec = makeExec({
+      'which rtk': '/opt/homebrew/bin/rtk',
+      // no 'rtk --version' key — makeExec throws for it
+      'which jcodemunch-mcp': new Error('not found'),
+      'which jcodemunch': new Error('not found'),
+      'which uvx': new Error('not found'),
+    });
+
+    const env = await detectEnvironment('/fake/cwd', exec, () => false, () => undefined, makeMcpQuery({}), () => null);
+    expect(env.rtkAvailable).toBe(true);
+    expect(env.rtkVersion).toBeNull();
+  });
+
   it('detects rtk unavailable when which fails', async () => {
     const exec = makeExec({
       'which rtk': new Error('not found'),

--- a/tests/session/metrics.test.ts
+++ b/tests/session/metrics.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   captureMetricsBaseline,
   captureGraphifyStats,
@@ -42,6 +42,63 @@ describe('captureMetricsBaseline', () => {
     });
     const baseline = captureMetricsBaseline(exec);
     expect(baseline).toEqual({ totalSaved: 0, capturedAt: expect.any(Number) });
+  });
+});
+
+describe('stats-capture exec timeouts', () => {
+  const REPORT_TEXT =
+    '40994 nodes · 129501 edges · 439 communities detected\nExtraction: 42% EXTRACTED · 58% INFERRED · 0% AMBIGUOUS';
+
+  it('passes a 10s timeout to the GRAPH_REPORT.md read', () => {
+    const exec = vi.fn((cmd: string) => {
+      if (cmd.includes('GRAPH_REPORT.md')) return REPORT_TEXT;
+      throw new Error(`unexpected: ${cmd}`);
+    });
+
+    captureGraphifyStatsViaReport('/proj', exec);
+    expect(exec).toHaveBeenCalledWith(
+      expect.stringContaining('GRAPH_REPORT.md'),
+      expect.objectContaining({ timeout: 10_000 }),
+    );
+  });
+
+  it('passes a 30s timeout to the graphify benchmark fallback', () => {
+    const exec = vi.fn((cmd: string) => {
+      if (cmd.includes('GRAPH_REPORT.md')) throw new Error('no report');
+      if (cmd.includes('graphify benchmark')) return 'Graph: 1,000 nodes, 2,000 edges';
+      throw new Error(`unexpected: ${cmd}`);
+    });
+
+    captureGraphifyStatsViaReport('/proj', exec);
+    expect(exec).toHaveBeenCalledWith(
+      expect.stringContaining('graphify benchmark'),
+      expect.objectContaining({ timeout: 30_000 }),
+    );
+  });
+
+  it('passes a 120s timeout to the external graph build', () => {
+    const exec = vi.fn((cmd: string) => {
+      if (cmd.startsWith('test -f')) throw new Error('absent');
+      if (cmd.includes('graphify update')) return '';
+      if (cmd.includes('GRAPH_REPORT.md')) return REPORT_TEXT;
+      throw new Error(`unexpected: ${cmd}`);
+    });
+
+    captureExternalGraphifyStats('/ext/proj', exec);
+    expect(exec).toHaveBeenCalledWith(
+      expect.stringContaining('graphify update'),
+      expect.objectContaining({ timeout: 120_000 }),
+    );
+  });
+
+  it('passes a 10s timeout to rtk gain', () => {
+    const exec = vi.fn(() => JSON.stringify({ summary: { total_saved: 1 } }));
+
+    captureMetricsBaseline(exec);
+    expect(exec).toHaveBeenCalledWith(
+      'rtk gain --format json',
+      expect.objectContaining({ timeout: 10_000 }),
+    );
   });
 });
 

--- a/tests/session/metrics.test.ts
+++ b/tests/session/metrics.test.ts
@@ -102,6 +102,77 @@ describe('stats-capture exec timeouts', () => {
   });
 });
 
+describe('captureGraphifyStatsViaReport warnings', () => {
+  const HEALTHY_REPORT =
+    '40994 nodes · 129501 edges · 439 communities detected\nExtraction: 42% EXTRACTED · 58% INFERRED · 0% AMBIGUOUS';
+
+  it('emits no warnings for a healthy report', () => {
+    const onWarn = vi.fn();
+    const exec = vi.fn((cmd: string) => {
+      if (cmd.includes('GRAPH_REPORT.md')) return HEALTHY_REPORT;
+      throw new Error(`unexpected: ${cmd}`);
+    });
+
+    const stats = captureGraphifyStatsViaReport('/proj', exec, onWarn);
+    expect(stats?.nodes).toBe(40994);
+    expect(onWarn).not.toHaveBeenCalled();
+  });
+
+  it('warns when the report is present but unparseable, then tries the benchmark', () => {
+    const onWarn = vi.fn();
+    const exec = vi.fn((cmd: string) => {
+      if (cmd.includes('GRAPH_REPORT.md')) return 'TOTALLY NEW REPORT FORMAT';
+      if (cmd.includes('graphify benchmark')) return 'Graph: 1,000 nodes, 2,000 edges';
+      throw new Error(`unexpected: ${cmd}`);
+    });
+
+    const stats = captureGraphifyStatsViaReport('/proj', exec, onWarn);
+    expect(stats?.nodes).toBe(1000);
+    expect(onWarn).toHaveBeenCalledWith(expect.stringContaining('unparseable'));
+  });
+
+  it('warns when the benchmark fallback is used (confidence breakdown lost)', () => {
+    const onWarn = vi.fn();
+    const exec = vi.fn((cmd: string) => {
+      if (cmd.includes('GRAPH_REPORT.md')) throw new Error('no report');
+      if (cmd.includes('graphify benchmark')) return 'Graph: 1,000 nodes, 2,000 edges';
+      throw new Error(`unexpected: ${cmd}`);
+    });
+
+    const stats = captureGraphifyStatsViaReport('/proj', exec, onWarn);
+    expect(stats?.nodes).toBe(1000);
+    expect(onWarn).toHaveBeenCalledWith(expect.stringContaining('benchmark fallback'));
+  });
+
+  it('warns when confidence percentages do not sum to ~100 but still returns stats', () => {
+    const onWarn = vi.fn();
+    const exec = vi.fn((cmd: string) => {
+      if (cmd.includes('GRAPH_REPORT.md')) {
+        return '10 nodes · 20 edges · 3 communities detected\nExtraction: 40% EXTRACTED · 40% INFERRED · 10% AMBIGUOUS';
+      }
+      throw new Error(`unexpected: ${cmd}`);
+    });
+
+    const stats = captureGraphifyStatsViaReport('/proj', exec, onWarn);
+    expect(stats).not.toBeNull();
+    expect(stats?.extractedPct).toBe(40);
+    expect(onWarn).toHaveBeenCalledWith(expect.stringContaining('sum to 90'));
+  });
+
+  it('accepts rounding slack in the percentage sum (98-102)', () => {
+    const onWarn = vi.fn();
+    const exec = vi.fn((cmd: string) => {
+      if (cmd.includes('GRAPH_REPORT.md')) {
+        return '10 nodes · 20 edges · 3 communities detected\nExtraction: 33% EXTRACTED · 33% INFERRED · 33% AMBIGUOUS';
+      }
+      throw new Error(`unexpected: ${cmd}`);
+    });
+
+    captureGraphifyStatsViaReport('/proj', exec, onWarn);
+    expect(onWarn).not.toHaveBeenCalled();
+  });
+});
+
 describe('incrementMetric', () => {
   it('detects rtk usage from Bash tool with rtk command', () => {
     const result = incrementMetric('Bash', { command: 'rtk git status' });

--- a/tests/session/metrics.test.ts
+++ b/tests/session/metrics.test.ts
@@ -43,6 +43,39 @@ describe('captureMetricsBaseline', () => {
     const baseline = captureMetricsBaseline(exec);
     expect(baseline).toEqual({ totalSaved: 0, capturedAt: expect.any(Number) });
   });
+
+  it.each([
+    ['missing total_saved', JSON.stringify({ summary: {} })],
+    ['string total_saved', JSON.stringify({ summary: { total_saved: '5000' } })],
+    ['array payload', JSON.stringify([1, 2])],
+    ['malformed JSON', 'not json'],
+  ])('warns on unexpected schema (%s) and returns zero', (_label, raw) => {
+    const onWarn = vi.fn();
+    const exec = makeExec({ 'rtk gain --format json': raw });
+
+    const baseline = captureMetricsBaseline(exec, onWarn);
+    expect(baseline.totalSaved).toBe(0);
+    expect(onWarn).toHaveBeenCalledTimes(1);
+    expect(onWarn).toHaveBeenCalledWith(expect.stringContaining('unexpected schema'));
+  });
+
+  it('does not warn on a valid payload', () => {
+    const onWarn = vi.fn();
+    const exec = makeExec({
+      'rtk gain --format json': JSON.stringify({ summary: { total_saved: 42 } }),
+    });
+
+    expect(captureMetricsBaseline(exec, onWarn).totalSaved).toBe(42);
+    expect(onWarn).not.toHaveBeenCalled();
+  });
+
+  it('does not warn when rtk itself is absent (exec throws)', () => {
+    const onWarn = vi.fn();
+    const exec = makeExec({ 'rtk gain --format json': new Error('not found') });
+
+    expect(captureMetricsBaseline(exec, onWarn).totalSaved).toBe(0);
+    expect(onWarn).not.toHaveBeenCalled();
+  });
 });
 
 describe('stats-capture exec timeouts', () => {

--- a/tests/session/permissions-self-check.test.ts
+++ b/tests/session/permissions-self-check.test.ts
@@ -3,12 +3,29 @@ import { checkPermissionsReadiness } from '../../src/session/permissions-self-ch
 import { REQUIRED_PERMISSIONS } from '../../src/cli/permissions.js';
 
 const PROJECT = '/tmp/fake-project';
+const HOME = '/tmp/fake-home';
 const SETTINGS_PATH = `${PROJECT}/.claude/settings.json`;
+const LOCAL_SETTINGS_PATH = `${PROJECT}/.claude/settings.local.json`;
+const USER_SETTINGS_PATH = `${HOME}/.claude/settings.json`;
 
 function makeReader(contents: string): (path: string, enc: string) => string {
   return (path) => {
     if (path === SETTINGS_PATH) return contents;
     throw new Error(`unexpected read: ${path}`);
+  };
+}
+
+// Multi-scope reader: maps exact paths to file contents.
+function makeFiles(files: Record<string, string>): {
+  readFile: (path: string, enc: string) => string;
+  existsCheck: (path: string) => boolean;
+} {
+  return {
+    readFile: (path) => {
+      if (path in files) return files[path];
+      throw new Error(`unexpected read: ${path}`);
+    },
+    existsCheck: (path) => path in files,
   };
 }
 
@@ -27,6 +44,7 @@ describe('checkPermissionsReadiness', () => {
       PROJECT,
       makeReader(JSON.stringify(settings)),
       makeExists([SETTINGS_PATH]),
+      HOME,
     );
     expect(result).toEqual({ status: 'ok' });
   });
@@ -36,6 +54,7 @@ describe('checkPermissionsReadiness', () => {
       PROJECT,
       makeReader(''),
       makeExists([]),
+      HOME,
     );
     expect(result).toEqual({ status: 'no_settings', fixCommand: 'rig init --force' });
   });
@@ -45,6 +64,7 @@ describe('checkPermissionsReadiness', () => {
       PROJECT,
       makeReader('{ not valid json'),
       makeExists([SETTINGS_PATH]),
+      HOME,
     );
     expect(result.status).toBe('no_settings');
   });
@@ -59,13 +79,14 @@ describe('checkPermissionsReadiness', () => {
       PROJECT,
       makeReader(JSON.stringify(settings)),
       makeExists([SETTINGS_PATH]),
+      HOME,
     );
     expect(result.status).toBe('missing');
     if (result.status === 'missing') {
       expect(result.missing).toContain('Read(/tmp/rig-session-*.json)');
       expect(result.missing).toContain('Bash(ls /tmp/rig-session-*)');
       expect(result.missing).not.toContain('mcp__jcodemunch__*');
-      expect(result.fixCommand).toBe('rig init --force');
+      expect(result.fixCommand).toBe('rig init --broad-permissions');
     }
   });
 
@@ -75,6 +96,7 @@ describe('checkPermissionsReadiness', () => {
       PROJECT,
       makeReader(JSON.stringify(settings)),
       makeExists([SETTINGS_PATH]),
+      HOME,
     );
     expect(result.status).toBe('missing');
     if (result.status === 'missing') {
@@ -90,6 +112,7 @@ describe('checkPermissionsReadiness', () => {
       PROJECT,
       makeReader(JSON.stringify(settings)),
       makeExists([SETTINGS_PATH]),
+      HOME,
     );
     expect(result.status).toBe('missing');
   });
@@ -100,6 +123,7 @@ describe('checkPermissionsReadiness', () => {
       PROJECT,
       makeReader(JSON.stringify(settings)),
       makeExists([SETTINGS_PATH]),
+      HOME,
     );
     expect(result.status).toBe('missing');
   });
@@ -114,7 +138,58 @@ describe('checkPermissionsReadiness', () => {
       PROJECT,
       makeReader(JSON.stringify(settings)),
       makeExists([SETTINGS_PATH]),
+      HOME,
     );
+    expect(result).toEqual({ status: 'ok' });
+  });
+
+  // Claude Code merges permissions across scopes — entries satisfied at user
+  // or local scope must not be reported missing (marketplace false positive).
+  it('returns ok when project has deny-only and user settings carry the allow entries', () => {
+    const { readFile, existsCheck } = makeFiles({
+      [SETTINGS_PATH]: JSON.stringify({ permissions: { allow: [], deny: ['Read(**/secrets/**)'] } }),
+      [USER_SETTINGS_PATH]: JSON.stringify({ permissions: { allow: [...REQUIRED_PERMISSIONS] } }),
+    });
+
+    const result = checkPermissionsReadiness(PROJECT, readFile, existsCheck, HOME);
+    expect(result).toEqual({ status: 'ok' });
+  });
+
+  it('returns ok when entries are split across project, local, and user scopes', () => {
+    const [first, second, ...rest] = [...REQUIRED_PERMISSIONS];
+    const { readFile, existsCheck } = makeFiles({
+      [SETTINGS_PATH]: JSON.stringify({ permissions: { allow: [first] } }),
+      [LOCAL_SETTINGS_PATH]: JSON.stringify({ permissions: { allow: [second] } }),
+      [USER_SETTINGS_PATH]: JSON.stringify({ permissions: { allow: rest } }),
+    });
+
+    const result = checkPermissionsReadiness(PROJECT, readFile, existsCheck, HOME);
+    expect(result).toEqual({ status: 'ok' });
+  });
+
+  it('still reports entries missing from every scope', () => {
+    const { readFile, existsCheck } = makeFiles({
+      [SETTINGS_PATH]: JSON.stringify({ permissions: { allow: ['mcp__jcodemunch__*'] } }),
+      [USER_SETTINGS_PATH]: JSON.stringify({ permissions: { allow: ['Bash(npx:*)'] } }),
+    });
+
+    const result = checkPermissionsReadiness(PROJECT, readFile, existsCheck, HOME);
+    expect(result.status).toBe('missing');
+    if (result.status === 'missing') {
+      expect(result.missing).not.toContain('mcp__jcodemunch__*');
+      expect(result.missing).not.toContain('Bash(npx:*)');
+      expect(result.missing).toContain('mcp__graphify__*');
+      expect(result.fixCommand).toBe('rig init --broad-permissions');
+    }
+  });
+
+  it('ignores malformed user settings and evaluates remaining scopes', () => {
+    const { readFile, existsCheck } = makeFiles({
+      [SETTINGS_PATH]: JSON.stringify({ permissions: { allow: [...REQUIRED_PERMISSIONS] } }),
+      [USER_SETTINGS_PATH]: '{ not valid json',
+    });
+
+    const result = checkPermissionsReadiness(PROJECT, readFile, existsCheck, HOME);
     expect(result).toEqual({ status: 'ok' });
   });
 });

--- a/tests/session/start.test.ts
+++ b/tests/session/start.test.ts
@@ -803,6 +803,21 @@ describe('handleSessionStart', () => {
       expect(output).toContain('[WARNING] graphify: GRAPH_REPORT.md present but unparseable');
     });
 
+    it('surfaces the build failure reason in session output', async () => {
+      vi.mocked(execSync).mockImplementation((cmd: string) => {
+        if (cmd === 'which rtk') throw new Error('not found');
+        if (cmd === 'which jcodemunch') return '/usr/bin/jcodemunch';
+        if (cmd.includes('list_repos')) return '{"repos":["local/test-project"]}';
+        if (cmd === 'which graphify') return '/usr/local/bin/graphify';
+        if (cmd.includes('graphify update')) throw new Error('recursion depth exceeded');
+        if (cmd.startsWith('test -f')) throw new Error('absent');
+        return '';
+      });
+
+      const output = await handleSessionStart('/home/user/test-project', cache);
+      expect(output).toContain('build failed (recursion depth exceeded)');
+    });
+
     it('renders the rtk version when known', async () => {
       vi.mocked(execSync).mockImplementation((cmd: string) => {
         if (cmd === 'which rtk') return '/opt/homebrew/bin/rtk';

--- a/tests/session/start.test.ts
+++ b/tests/session/start.test.ts
@@ -9,6 +9,15 @@ vi.mock('node:child_process', () => ({
 
 import { execSync } from 'node:child_process';
 
+// Opt out of the production build-wait poll (5s) unless a test exercises it.
+function startSession(
+  cwd: string,
+  c: SessionCache,
+  deps: Parameters<typeof handleSessionStart>[2] = {},
+): Promise<string> {
+  return handleSessionStart(cwd, c, { graphWait: { deadlineMs: 0 }, ...deps });
+}
+
 describe('handleSessionStart', () => {
   let cache: SessionCache;
 
@@ -25,7 +34,7 @@ describe('handleSessionStart', () => {
       return '';
     });
 
-    const output = await handleSessionStart('/home/user/test-project', cache);
+    const output = await startSession('/home/user/test-project', cache);
 
     const env = cache.getEnvironment();
     expect(env).toBeDefined();
@@ -41,7 +50,7 @@ describe('handleSessionStart', () => {
       return '';
     });
 
-    await handleSessionStart('/home/user/test-project', cache);
+    await startSession('/home/user/test-project', cache);
 
     const pyEnv = cache.getPythonEnv();
     expect(pyEnv).toBeDefined();
@@ -62,7 +71,7 @@ describe('handleSessionStart', () => {
       return '';
     });
 
-    await handleSessionStart(tmpDir, cache);
+    await startSession(tmpDir, cache);
 
     const pyEnv = cache.getPythonEnv();
     expect(pyEnv).toBeDefined();
@@ -80,7 +89,7 @@ describe('handleSessionStart', () => {
       return '';
     });
 
-    await handleSessionStart('/home/user/test-project', cache);
+    await startSession('/home/user/test-project', cache);
 
     // Should have called index_folder for the CWD
     expect(execSync).toHaveBeenCalledWith(
@@ -97,7 +106,7 @@ describe('handleSessionStart', () => {
       return '';
     });
 
-    await handleSessionStart('/home/user/test-project', cache);
+    await startSession('/home/user/test-project', cache);
 
     // Should NOT have called index_folder — already indexed
     const calls = vi.mocked(execSync).mock.calls.map(c => c[0] as string);
@@ -111,7 +120,7 @@ describe('handleSessionStart', () => {
       return '';
     });
 
-    await handleSessionStart('/home/user/test-project', cache);
+    await startSession('/home/user/test-project', cache);
 
     const calls = vi.mocked(execSync).mock.calls.map(c => c[0] as string);
     expect(calls.find(c => c.includes('index_folder'))).toBeUndefined();
@@ -125,7 +134,7 @@ describe('handleSessionStart', () => {
       return '';
     });
 
-    const output = await handleSessionStart('/home/user/test-project', cache);
+    const output = await startSession('/home/user/test-project', cache);
     expect(output).toContain('rtk');
     expect(output).toContain('jcodemunch');
     expect(output).toContain('indexed');
@@ -139,7 +148,7 @@ describe('handleSessionStart', () => {
       return '';
     });
 
-    const output = await handleSessionStart('/home/user/test-project', cache);
+    const output = await startSession('/home/user/test-project', cache);
     expect(output).toContain('using-git-worktrees');
   });
 
@@ -151,7 +160,7 @@ describe('handleSessionStart', () => {
       return '';
     });
 
-    const output = await handleSessionStart('/home/user/test-project', cache);
+    const output = await startSession('/home/user/test-project', cache);
     expect(output).not.toContain('using-git-worktrees');
   });
 
@@ -163,7 +172,7 @@ describe('handleSessionStart', () => {
       return '';
     });
 
-    const output = await handleSessionStart('/home/user/test-project', cache);
+    const output = await startSession('/home/user/test-project', cache);
     expect(output).toContain('WARNING');
     expect(output).toContain('rtk');
     expect(output).toContain('install');
@@ -176,7 +185,7 @@ describe('handleSessionStart', () => {
       return '';
     });
 
-    const output = await handleSessionStart('/home/user/test-project', cache);
+    const output = await startSession('/home/user/test-project', cache);
     expect(output).toContain('WARNING');
     expect(output).toContain('jcodemunch');
     expect(output).toContain('install');
@@ -190,7 +199,7 @@ describe('handleSessionStart', () => {
       return '';
     });
 
-    const output = await handleSessionStart('/home/user/test-project', cache);
+    const output = await startSession('/home/user/test-project', cache);
     expect(output).toContain('rtk');
     expect(output).toContain('jcodemunch');
     // Should contain two warnings
@@ -206,7 +215,7 @@ describe('handleSessionStart', () => {
       return '';
     });
 
-    const output = await handleSessionStart('/home/user/test-project', cache);
+    const output = await startSession('/home/user/test-project', cache);
     // The tool-missing warnings (rtk/jcodemunch) should not appear when both are present.
     expect(output).not.toContain('rtk is not installed');
     expect(output).not.toContain('jcodemunch was not detected');
@@ -220,7 +229,7 @@ describe('handleSessionStart', () => {
       return '';
     });
 
-    const output = await handleSessionStart('/home/user/test-project', cache);
+    const output = await startSession('/home/user/test-project', cache);
     expect(output).toContain('When spawning subagents');
     expect(output).toContain('mcp__jcodemunch__search_text');
     expect(output).toContain('mcp__jcodemunch__get_file_tree');
@@ -234,7 +243,7 @@ describe('handleSessionStart', () => {
       return '';
     });
 
-    const output = await handleSessionStart('/home/user/test-project', cache);
+    const output = await startSession('/home/user/test-project', cache);
     expect(output).not.toContain('When spawning subagents');
     expect(output).not.toContain('mcp__jcodemunch__');
   });
@@ -247,7 +256,7 @@ describe('handleSessionStart', () => {
       return '';
     });
 
-    const output = await handleSessionStart('/home/user/test-project', cache);
+    const output = await startSession('/home/user/test-project', cache);
     expect(output).toContain('scout');
     expect(output).toContain('subagent_type');
     expect(output).toContain('Explore');
@@ -260,7 +269,7 @@ describe('handleSessionStart', () => {
       return '';
     });
 
-    const output = await handleSessionStart('/home/user/test-project', cache);
+    const output = await startSession('/home/user/test-project', cache);
     expect(output).not.toContain('scout');
   });
 
@@ -273,13 +282,13 @@ describe('handleSessionStart', () => {
     });
 
     // First call — tool-missing warnings present
-    const output1 = await handleSessionStart('/home/user/test-project', cache);
+    const output1 = await startSession('/home/user/test-project', cache);
     expect(output1).toContain('rtk is not installed');
     expect(output1).toContain('jcodemunch was not detected');
 
     // Second call — tool-missing warnings suppressed by toolsWarned flag
     // (the permissions warning is independent and may still fire)
-    const output2 = await handleSessionStart('/home/user/test-project', cache);
+    const output2 = await startSession('/home/user/test-project', cache);
     expect(output2).not.toContain('rtk is not installed');
     expect(output2).not.toContain('jcodemunch was not detected');
   });
@@ -292,7 +301,7 @@ describe('handleSessionStart', () => {
       return '';
     });
 
-    const output = await handleSessionStart('/home/user/test-project', cache);
+    const output = await startSession('/home/user/test-project', cache);
     // Default config has no_mocks: block, which should appear in active rules
     expect(output).toContain('Active enforcement');
     expect(output).toContain('no_mocks');
@@ -319,7 +328,7 @@ describe('handleSessionStart', () => {
       '    full_accounting: silent',
     ].join('\n'));
 
-    const output = await handleSessionStart(configDir, cache);
+    const output = await startSession(configDir, cache);
     expect(output).not.toContain('Active enforcement');
 
     rmSync(configDir, { recursive: true });
@@ -346,7 +355,7 @@ describe('handleSessionStart', () => {
       '    full_accounting: advise',
     ].join('\n'));
 
-    const output = await handleSessionStart(configDir, cache);
+    const output = await startSession(configDir, cache);
     expect(output).toContain('Active enforcement');
     expect(output).toContain('no_mocks (block)');
     expect(output).toContain('full_accounting (advise)');
@@ -383,7 +392,7 @@ describe('handleSessionStart', () => {
         return '';
       });
 
-      const output = await handleSessionStart(tmpDir, cache);
+      const output = await startSession(tmpDir, cache);
       expect(output).toContain('graphify: available');
       expect(output).toContain('3 nodes');
       expect(output).toContain('2 edges');
@@ -401,7 +410,7 @@ describe('handleSessionStart', () => {
         return '';
       });
 
-      const output = await handleSessionStart('/home/user/test-project', cache);
+      const output = await startSession('/home/user/test-project', cache);
       expect(output).toContain('graphify: not found');
       expect(output).not.toContain('nodes');
     });
@@ -424,7 +433,7 @@ describe('handleSessionStart', () => {
         return '';
       });
 
-      const output = await handleSessionStart(tmpDir, cache);
+      const output = await startSession(tmpDir, cache);
       expect(output).toContain('mcp__graphify__query_graph');
       expect(output).toContain('mcp__graphify__god_nodes');
       expect(output).toContain('mcp__graphify__get_community');
@@ -441,7 +450,7 @@ describe('handleSessionStart', () => {
         return '';
       });
 
-      const output = await handleSessionStart('/home/user/test-project', cache);
+      const output = await startSession('/home/user/test-project', cache);
       expect(output).toContain('HINT');
       expect(output).toContain('graphify');
     });
@@ -469,7 +478,7 @@ describe('handleSessionStart', () => {
         return '';
       });
 
-      await handleSessionStart(tmpDir, cache);
+      await startSession(tmpDir, cache);
       const baseline = cache.getMetricsBaseline();
       expect(baseline?.graphifyStats).toBeDefined();
       const entries = Object.entries(baseline!.graphifyStats!);
@@ -497,7 +506,7 @@ describe('handleSessionStart', () => {
         return '';
       });
 
-      await handleSessionStart('/home/user/test-project', cache);
+      await startSession('/home/user/test-project', cache);
       const baseline = cache.getMetricsBaseline();
       expect(baseline).toBeDefined();
       expect(baseline!.totalSaved).toBe(5000000);
@@ -520,7 +529,7 @@ describe('handleSessionStart', () => {
         return '';
       });
 
-      await handleSessionStart('/home/user/test-project', cache);
+      await startSession('/home/user/test-project', cache);
       const baseline = cache.getMetricsBaseline();
       expect(baseline?.graphifyStats).toBeDefined();
       const entries = Object.entries(baseline!.graphifyStats!);
@@ -539,7 +548,7 @@ describe('handleSessionStart', () => {
         return '';
       });
 
-      await handleSessionStart('/home/user/test-project', cache);
+      await startSession('/home/user/test-project', cache);
       const baseline = cache.getMetricsBaseline();
       expect(baseline!.totalSaved).toBe(6000000);
     });
@@ -562,7 +571,7 @@ describe('handleSessionStart', () => {
         return '';
       });
 
-      const output = await handleSessionStart('/home/user/big-project', cache);
+      const output = await startSession('/home/user/big-project', cache);
       expect(output).toContain('WARNING');
       expect(output).toContain('file limit');
       expect(output).toContain('max_folder_files');
@@ -585,7 +594,7 @@ describe('handleSessionStart', () => {
         return '';
       });
 
-      const output = await handleSessionStart('/home/user/small-project', cache);
+      const output = await startSession('/home/user/small-project', cache);
       expect(output).not.toContain('file limit');
     });
   });
@@ -709,7 +718,7 @@ describe('handleSessionStart', () => {
         return '';
       });
 
-      const output = await handleSessionStart('/home/user/test-project', cache);
+      const output = await startSession('/home/user/test-project', cache);
       expect(output).toContain('jcodemunch: available (cli)');
       expect(output).toContain('CWD indexed: local/test-project');
     });
@@ -723,7 +732,7 @@ describe('handleSessionStart', () => {
         return '';
       });
 
-      const output = await handleSessionStart('/home/user/test-project', cache);
+      const output = await startSession('/home/user/test-project', cache);
       expect(output).toContain('CWD not indexed (auto-index failed');
       expect(output).toContain('mcp__jcodemunch__index_folder');
     });
@@ -737,7 +746,7 @@ describe('handleSessionStart', () => {
         return null;
       };
 
-      const output = await handleSessionStart('/work/proj', cache, {
+      const output = await startSession('/work/proj', cache, {
         exec: noBinariesExec,
         existsCheck: () => false,
         statCheck: () => undefined,
@@ -754,7 +763,7 @@ describe('handleSessionStart', () => {
     it('not-installed warning mentions checking the MCP registration', async () => {
       vi.mocked(execSync).mockImplementation(() => { throw new Error('not found'); });
 
-      const output = await handleSessionStart('/home/user/test-project', cache, {
+      const output = await startSession('/home/user/test-project', cache, {
         exec: () => { throw new Error('not found'); },
         existsCheck: () => false,
         statCheck: () => undefined,
@@ -770,7 +779,7 @@ describe('handleSessionStart', () => {
     it('warns about orphaned index data when detection fails but ~/.code-index has dbs', async () => {
       vi.mocked(execSync).mockImplementation(() => { throw new Error('not found'); });
 
-      const output = await handleSessionStart('/home/user/test-project', cache, {
+      const output = await startSession('/home/user/test-project', cache, {
         exec: () => { throw new Error('not found'); },
         existsCheck: () => false,
         statCheck: () => undefined,
@@ -795,12 +804,37 @@ describe('handleSessionStart', () => {
         return '';
       });
 
-      const output = await handleSessionStart('/home/user/test-project', cache, {
+      const output = await startSession('/home/user/test-project', cache, {
         existsCheck: (p) => p.endsWith('graph.json'),
         statCheck: () => ({ size: 5000 }),
       });
 
       expect(output).toContain('[WARNING] graphify: GRAPH_REPORT.md present but unparseable');
+    });
+
+    it('recovers when the graph lands shortly after graphify update returns (build-output race)', async () => {
+      let landed = false;
+      vi.mocked(execSync).mockImplementation((cmd: string) => {
+        if (cmd === 'which rtk') throw new Error('not found');
+        if (cmd === 'which jcodemunch') throw new Error('not found');
+        if (cmd === 'which graphify') return '/usr/local/bin/graphify';
+        if (cmd.includes('GRAPH_REPORT.md')) return '10 nodes · 20 edges · 3 communities detected';
+        return '';
+      });
+
+      const output = await startSession('/home/user/test-project', cache, {
+        existsCheck: (p) => p.endsWith('graph.json') && landed,
+        statCheck: () => (landed ? { size: 5000 } : undefined),
+        graphWait: {
+          deadlineMs: 5000,
+          intervalMs: 250,
+          // The graph "lands" during the second poll interval
+          sleep: () => { landed = true; },
+        },
+      });
+
+      expect(output).toContain('graphify: available');
+      expect(output).not.toContain('build failed');
     });
 
     it('surfaces the build failure reason in session output', async () => {
@@ -814,7 +848,7 @@ describe('handleSessionStart', () => {
         return '';
       });
 
-      const output = await handleSessionStart('/home/user/test-project', cache);
+      const output = await startSession('/home/user/test-project', cache);
       expect(output).toContain('build failed (recursion depth exceeded)');
     });
 
@@ -827,7 +861,7 @@ describe('handleSessionStart', () => {
         return '';
       });
 
-      const output = await handleSessionStart('/home/user/test-project', cache);
+      const output = await startSession('/home/user/test-project', cache);
       expect(output).toContain('rtk: available (/opt/homebrew/bin/rtk, v0.39.0)');
     });
 
@@ -841,7 +875,7 @@ describe('handleSessionStart', () => {
         return '';
       });
 
-      const output = await handleSessionStart('/home/user/test-project', cache);
+      const output = await startSession('/home/user/test-project', cache);
       expect(output).toContain('graphify 0.6.2 is outside the tested range');
     });
 
@@ -855,14 +889,14 @@ describe('handleSessionStart', () => {
         return '';
       });
 
-      const output = await handleSessionStart('/home/user/test-project', cache);
+      const output = await startSession('/home/user/test-project', cache);
       expect(output).not.toContain('outside the tested range');
     });
 
     it('does not warn about orphaned index data when ~/.code-index is absent', async () => {
       vi.mocked(execSync).mockImplementation(() => { throw new Error('not found'); });
 
-      const output = await handleSessionStart('/home/user/test-project', cache, {
+      const output = await startSession('/home/user/test-project', cache, {
         exec: () => { throw new Error('not found'); },
         existsCheck: () => false,
         statCheck: () => undefined,

--- a/tests/session/start.test.ts
+++ b/tests/session/start.test.ts
@@ -784,6 +784,25 @@ describe('handleSessionStart', () => {
       expect(output).toContain('claude mcp list');
     });
 
+    it('renders a warning when GRAPH_REPORT.md is unparseable', async () => {
+      vi.mocked(execSync).mockImplementation((cmd: string) => {
+        if (cmd === 'which rtk') throw new Error('not found');
+        if (cmd === 'which jcodemunch') return '/usr/bin/jcodemunch';
+        if (cmd.includes('list_repos')) return '{"repos":["local/test-project"]}';
+        if (cmd === 'which graphify') return '/usr/local/bin/graphify';
+        if (cmd.includes('GRAPH_REPORT.md')) return 'TOTALLY NEW REPORT FORMAT';
+        if (cmd.includes('graphify benchmark')) throw new Error('no benchmark');
+        return '';
+      });
+
+      const output = await handleSessionStart('/home/user/test-project', cache, {
+        existsCheck: (p) => p.endsWith('graph.json'),
+        statCheck: () => ({ size: 5000 }),
+      });
+
+      expect(output).toContain('[WARNING] graphify: GRAPH_REPORT.md present but unparseable');
+    });
+
     it('renders the rtk version when known', async () => {
       vi.mocked(execSync).mockImplementation((cmd: string) => {
         if (cmd === 'which rtk') return '/opt/homebrew/bin/rtk';

--- a/tests/session/start.test.ts
+++ b/tests/session/start.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { handleSessionStart } from '../../src/session/start.js';
+import { handleSessionStart, detectAndIndex } from '../../src/session/start.js';
 import { SessionCache } from '../../src/session/cache.js';
+import type { ExecFn, McpQueryFn } from '../../src/session/environment.js';
 
 vi.mock('node:child_process', () => ({
   execSync: vi.fn(),
@@ -168,7 +169,7 @@ describe('handleSessionStart', () => {
     expect(output).toContain('install');
   });
 
-  it('warns when jcodemunch is not installed', async () => {
+  it('warns when jcodemunch was not detected', async () => {
     vi.mocked(execSync).mockImplementation((cmd: string) => {
       if (cmd === 'which rtk') return '/usr/bin/rtk';
       if (cmd === 'which jcodemunch') throw new Error('not found');
@@ -208,7 +209,7 @@ describe('handleSessionStart', () => {
     const output = await handleSessionStart('/home/user/test-project', cache);
     // The tool-missing warnings (rtk/jcodemunch) should not appear when both are present.
     expect(output).not.toContain('rtk is not installed');
-    expect(output).not.toContain('jcodemunch is not installed');
+    expect(output).not.toContain('jcodemunch was not detected');
   });
 
   it('emits subagent delegation instructions when jcodemunch available', async () => {
@@ -274,13 +275,13 @@ describe('handleSessionStart', () => {
     // First call — tool-missing warnings present
     const output1 = await handleSessionStart('/home/user/test-project', cache);
     expect(output1).toContain('rtk is not installed');
-    expect(output1).toContain('jcodemunch is not installed');
+    expect(output1).toContain('jcodemunch was not detected');
 
     // Second call — tool-missing warnings suppressed by toolsWarned flag
     // (the permissions warning is independent and may still fire)
     const output2 = await handleSessionStart('/home/user/test-project', cache);
     expect(output2).not.toContain('rtk is not installed');
-    expect(output2).not.toContain('jcodemunch is not installed');
+    expect(output2).not.toContain('jcodemunch was not detected');
   });
 
   it('emits active enforcement rules when rules are not all silent', async () => {
@@ -586,6 +587,217 @@ describe('handleSessionStart', () => {
 
       const output = await handleSessionStart('/home/user/small-project', cache);
       expect(output).not.toContain('file limit');
+    });
+  });
+
+  describe('transport reuse and output states', () => {
+    const WHEEL_URL =
+      'https://github.com/jgravelle/jcodemunch-mcp/releases/download/v1.108.20/jcodemunch_mcp-1.108.20-py3-none-any.whl';
+    const wheelRegistration = {
+      command: 'uvx',
+      args: ['--from', WHEEL_URL, 'jcodemunch-mcp'],
+      source: 'user' as const,
+    };
+
+    const noBinariesExec: ExecFn = (cmd: string) => {
+      if (cmd === 'which uvx') return '/opt/homebrew/bin/uvx';
+      throw new Error(`not found: ${cmd}`);
+    };
+
+    function listReposResponse(
+      repos: Array<{ repo: string; source_root?: string }>,
+      protocolVersion = '2025-03-26',
+    ): string {
+      const init = JSON.stringify({ jsonrpc: '2.0', id: 1, result: { protocolVersion } });
+      const tool = JSON.stringify({
+        jsonrpc: '2.0',
+        id: 2,
+        result: { content: [{ type: 'text', text: JSON.stringify({ repos }) }], isError: false },
+      });
+      return init + '\n' + tool;
+    }
+
+    function toolCallResponse(payload: object): string {
+      const init = JSON.stringify({ jsonrpc: '2.0', id: 1, result: { protocolVersion: '2025-03-26' } });
+      const tool = JSON.stringify({
+        jsonrpc: '2.0',
+        id: 2,
+        result: { content: [{ type: 'text', text: JSON.stringify(payload) }] },
+      });
+      return init + '\n' + tool;
+    }
+
+    it('detectAndIndex reuses the config transport verbatim for MCP auto-index', async () => {
+      const indexCalls: Array<{ command: string; args: string[] }> = [];
+      const mcpQuery: McpQueryFn = async (command, args, messages) => {
+        if (messages.some(m => m.includes('index_folder'))) {
+          indexCalls.push({ command, args });
+          return toolCallResponse({ success: true, repo: 'org/proj' });
+        }
+        if (command === 'uvx' && args.includes(WHEEL_URL)) {
+          return listReposResponse([]);
+        }
+        return null;
+      };
+
+      const { env, autoIndex } = await detectAndIndex(
+        '/work/proj', noBinariesExec, () => false, () => undefined, mcpQuery, () => wheelRegistration,
+      );
+
+      expect(autoIndex).toBe('succeeded');
+      expect(env.jcodemunchCwdIndexed).toBe(true);
+      expect(env.jcodemunchCwdRepo).toBe('org/proj');
+      expect(indexCalls[0]).toEqual({
+        command: 'uvx',
+        args: ['--from', WHEEL_URL, 'jcodemunch-mcp'],
+      });
+    });
+
+    it('detectAndIndex reports failed when the index attempt yields nothing', async () => {
+      const mcpQuery: McpQueryFn = async (command, args, messages) => {
+        if (messages.some(m => m.includes('index_folder'))) return null;
+        if (command === 'uvx' && args.includes(WHEEL_URL)) return listReposResponse([]);
+        return null;
+      };
+
+      const { autoIndex } = await detectAndIndex(
+        '/work/proj', noBinariesExec, () => false, () => undefined, mcpQuery, () => wheelRegistration,
+      );
+
+      expect(autoIndex).toBe('failed');
+    });
+
+    it('detectAndIndex reports not_needed when CWD is already indexed', async () => {
+      const mcpQuery: McpQueryFn = async (command, args) => {
+        if (command === 'uvx' && args.includes(WHEEL_URL)) {
+          return listReposResponse([{ repo: 'org/proj', source_root: '/work/proj' }]);
+        }
+        return null;
+      };
+
+      const { autoIndex, env } = await detectAndIndex(
+        '/work/proj', noBinariesExec, () => false, () => undefined, mcpQuery, () => wheelRegistration,
+      );
+
+      expect(env.jcodemunchCwdIndexed).toBe(true);
+      expect(autoIndex).toBe('not_needed');
+    });
+
+    it('detectAndIndex routes CLI auto-index through the injectable exec', async () => {
+      const seen: string[] = [];
+      const exec: ExecFn = (cmd: string) => {
+        seen.push(cmd);
+        if (cmd === 'which jcodemunch') return '/usr/bin/jcodemunch';
+        if (cmd.includes('list_repos')) return '{"repos":[]}';
+        if (cmd.includes('index_folder')) return JSON.stringify({ success: true, repo: 'local/proj' });
+        throw new Error(`not found: ${cmd}`);
+      };
+
+      const { autoIndex } = await detectAndIndex(
+        '/work/proj', exec, () => false, () => undefined, async () => null, () => null,
+      );
+
+      expect(autoIndex).toBe('succeeded');
+      expect(seen.some(c => c.includes('index_folder'))).toBe(true);
+    });
+
+    it('renders cli transport and indexed state', async () => {
+      vi.mocked(execSync).mockImplementation((cmd: string) => {
+        if (cmd === 'which rtk') return '/usr/bin/rtk';
+        if (cmd === 'which jcodemunch') return '/usr/bin/jcodemunch';
+        if (cmd.includes('list_repos')) return '{"repos":["local/test-project"]}';
+        return '';
+      });
+
+      const output = await handleSessionStart('/home/user/test-project', cache);
+      expect(output).toContain('jcodemunch: available (cli)');
+      expect(output).toContain('CWD indexed: local/test-project');
+    });
+
+    it('renders auto-index failure guidance when indexing fails', async () => {
+      vi.mocked(execSync).mockImplementation((cmd: string) => {
+        if (cmd === 'which rtk') throw new Error('not found');
+        if (cmd === 'which jcodemunch') return '/usr/bin/jcodemunch';
+        if (cmd.includes('list_repos')) return '{"repos":[]}';
+        if (cmd.includes('index_folder')) throw new Error('index failed');
+        return '';
+      });
+
+      const output = await handleSessionStart('/home/user/test-project', cache);
+      expect(output).toContain('CWD not indexed (auto-index failed');
+      expect(output).toContain('mcp__jcodemunch__index_folder');
+    });
+
+    it('renders config transport detail and protocol mismatch warning', async () => {
+      vi.mocked(execSync).mockImplementation(() => '');
+      const mcpQuery: McpQueryFn = async (command, args) => {
+        if (command === 'uvx' && args.includes(WHEEL_URL)) {
+          return listReposResponse([{ repo: 'org/proj', source_root: '/work/proj' }], '2024-11-05');
+        }
+        return null;
+      };
+
+      const output = await handleSessionStart('/work/proj', cache, {
+        exec: noBinariesExec,
+        existsCheck: () => false,
+        statCheck: () => undefined,
+        mcpQuery,
+        registrationLookup: () => wheelRegistration,
+        readdir: () => { throw new Error('no dir'); },
+      });
+
+      expect(output).toContain('available (mcp via user config: uvx --from');
+      expect(output).toContain('[WARNING] jcodemunch MCP protocol version mismatch');
+      expect(output).toContain('2024-11-05');
+    });
+
+    it('not-installed warning mentions checking the MCP registration', async () => {
+      vi.mocked(execSync).mockImplementation(() => { throw new Error('not found'); });
+
+      const output = await handleSessionStart('/home/user/test-project', cache, {
+        exec: () => { throw new Error('not found'); },
+        existsCheck: () => false,
+        statCheck: () => undefined,
+        mcpQuery: async () => null,
+        registrationLookup: () => null,
+        readdir: () => { throw new Error('no dir'); },
+      });
+
+      expect(output).toContain('jcodemunch: not found');
+      expect(output).toContain('claude mcp list');
+    });
+
+    it('warns about orphaned index data when detection fails but ~/.code-index has dbs', async () => {
+      vi.mocked(execSync).mockImplementation(() => { throw new Error('not found'); });
+
+      const output = await handleSessionStart('/home/user/test-project', cache, {
+        exec: () => { throw new Error('not found'); },
+        existsCheck: () => false,
+        statCheck: () => undefined,
+        mcpQuery: async () => null,
+        registrationLookup: () => null,
+        readdir: () => ['franklywatson-claude-rig.db', 'config.jsonc'],
+        homeDir: '/home/user',
+      });
+
+      expect(output).toContain('index data found at ~/.code-index');
+      expect(output).toContain('claude mcp list');
+    });
+
+    it('does not warn about orphaned index data when ~/.code-index is absent', async () => {
+      vi.mocked(execSync).mockImplementation(() => { throw new Error('not found'); });
+
+      const output = await handleSessionStart('/home/user/test-project', cache, {
+        exec: () => { throw new Error('not found'); },
+        existsCheck: () => false,
+        statCheck: () => undefined,
+        mcpQuery: async () => null,
+        registrationLookup: () => null,
+        readdir: () => { throw new Error('ENOENT'); },
+        homeDir: '/home/user',
+      });
+
+      expect(output).not.toContain('index data found');
     });
   });
 });

--- a/tests/session/start.test.ts
+++ b/tests/session/start.test.ts
@@ -784,6 +784,19 @@ describe('handleSessionStart', () => {
       expect(output).toContain('claude mcp list');
     });
 
+    it('renders the rtk version when known', async () => {
+      vi.mocked(execSync).mockImplementation((cmd: string) => {
+        if (cmd === 'which rtk') return '/opt/homebrew/bin/rtk';
+        if (cmd === 'rtk --version') return 'rtk 0.39.0';
+        if (cmd === 'which jcodemunch') return '/usr/bin/jcodemunch';
+        if (cmd.includes('list_repos')) return '{"repos":["local/test-project"]}';
+        return '';
+      });
+
+      const output = await handleSessionStart('/home/user/test-project', cache);
+      expect(output).toContain('rtk: available (/opt/homebrew/bin/rtk, v0.39.0)');
+    });
+
     it('warns when graphify version is outside the tested range', async () => {
       vi.mocked(execSync).mockImplementation((cmd: string) => {
         if (cmd === 'which rtk') throw new Error('not found');

--- a/tests/session/start.test.ts
+++ b/tests/session/start.test.ts
@@ -784,6 +784,34 @@ describe('handleSessionStart', () => {
       expect(output).toContain('claude mcp list');
     });
 
+    it('warns when graphify version is outside the tested range', async () => {
+      vi.mocked(execSync).mockImplementation((cmd: string) => {
+        if (cmd === 'which rtk') throw new Error('not found');
+        if (cmd === 'which jcodemunch') return '/usr/bin/jcodemunch';
+        if (cmd.includes('list_repos')) return '{"repos":["local/test-project"]}';
+        if (cmd === 'which graphify') return '/usr/local/bin/graphify';
+        if (cmd === 'graphify --version') return 'graphify 0.6.2';
+        return '';
+      });
+
+      const output = await handleSessionStart('/home/user/test-project', cache);
+      expect(output).toContain('graphify 0.6.2 is outside the tested range');
+    });
+
+    it('does not warn when graphify version is inside the tested range', async () => {
+      vi.mocked(execSync).mockImplementation((cmd: string) => {
+        if (cmd === 'which rtk') throw new Error('not found');
+        if (cmd === 'which jcodemunch') return '/usr/bin/jcodemunch';
+        if (cmd.includes('list_repos')) return '{"repos":["local/test-project"]}';
+        if (cmd === 'which graphify') return '/usr/local/bin/graphify';
+        if (cmd === 'graphify --version') return 'graphify 0.7.18';
+        return '';
+      });
+
+      const output = await handleSessionStart('/home/user/test-project', cache);
+      expect(output).not.toContain('outside the tested range');
+    });
+
     it('does not warn about orphaned index data when ~/.code-index is absent', async () => {
       vi.mocked(execSync).mockImplementation(() => { throw new Error('not found'); });
 


### PR DESCRIPTION
## Summary

A full audit of rig's external-tool integrations (jcodemunch, graphify, rtk) found a shared root cause: rig guessed how external tools are invoked and regex-parsed their human-readable output, with no version awareness and mostly silent failure. One bug was live and total — jcodemunch detection failed on a healthy machine because the fallback ran bare `uvx jcodemunch-mcp`, but the package is distributed as a GitHub release wheel; the real MCP registration is `uvx --from <wheel-url> jcodemunch-mcp`. Result: no auto-index, no router advisories, scout degraded, `/savings` reported `jmCalls: 0`.

This PR implements the approved integration-reliability plan across 18 commits, one per task.

### Workstream A — jcodemunch detection redesign

- **New `src/session/claude-config.ts`**: reads the registered MCP server command from Claude Code's own config (`~/.claude.json` local scope → `.mcp.json` project scope → `~/.claude.json` user scope). Detection now uses ground truth instead of guessing the invocation.
- Detection chain consults the registration after the CLI check and before PATH/uvx guessing; the winning transport is recorded on `Environment.jcodemunchTransport`.
- Session-start auto-index **reuses the detected transport verbatim** — the duplicated (and equally buggy) `resolveJcodemunchMcpTransport()` is deleted.
- CWD↔repo matching uses exact `source_root` path equality before basename fallback (disambiguates same-basename repos, survives renamed checkouts).
- MCP protocol version mismatches warn without blocking (`MCP_PROTOCOL_VERSION` is now one constant, not two string literals).
- Three-state output: `available (cli)` / `available (mcp via user config: ...)` / `not found`; failed auto-index renders a manual-recovery hint; orphaned `~/.code-index` data with failed detection points at `claude mcp list`.

### Workstream B — graphify hardening

- A valid `graph.json` on disk means `ready` even when the CLI is off the hook PATH (was a false negative that triggered doomed rebuilds for `~/.local/bin` installs).
- `.rebuild.lock` handling with mtime staleness: graphify leaves locks behind after completed builds — graph newer than lock = ready, lock newer = building.
- Build failures preserve `errorReason` (timeout vs AST recursion vs missing CLI are very different fixes). Also fixes a stale-reference bug where the rendered status line never reflected the session-start build outcome.
- Every stats-capture exec is now timeout-bounded (report read 10s, benchmark 30s, build 120s, rtk gain 10s) — a hung child can no longer freeze a hook.
- Stats parse validation with surfaced warnings: unparseable report (format drift), benchmark fallback (confidence breakdown lost), confidence percentages not summing to ~100.
- Version handshake: warns outside the tested range (>=0.7.0 <0.8.0), never gates.
- `Bash(graphify update <dir>)` now triggers external-dir stats capture — **and fixes a production gap**: the deployed hook template called `handlePostToolUse` without `execFn`, so the entire external-directory graphify stats branch was dead code in every installed hook.
- Pure refactor (last): graphify on-disk layout centralized in `src/constants.ts` (path helpers + placeholder threshold, previously duplicated); entire suite passes with zero test edits.

### Workstream C — rtk hardening

- `rtk gain --format json` schema validation: format drift now warns instead of silently zeroing the savings baseline; rtk-absent stays silent (already covered by the not-installed warning).
- rtk version recorded at detection and rendered in session output.
- Diagnostic log for unexpected rewrite failures (`/tmp/rig-rtk-rewrite-failures.log`): exit 1/2 are rtk's expected decline contract and stay silent; signals, ENOENT, and odd exit codes get JSON lines. `RIG_DEBUG` logs declines too. Null-fallthrough behavior unchanged.
- **Flag pre-check deliberately excluded**, with live evidence: `rtk rewrite` rewrites `grep -P` and `find -exec` (exit 0), but execution fails loudly — `rtk find` says "Use find directly" (exit 1), `rtk grep -P` errors "invalid option" (exit 2). No silent degradation; a rig-side flag list would go stale. Upstream note: `rtk grep` delegates to BSD `/usr/bin/grep` rather than the PATH grep, so flags that work natively can fail post-rewrite.

## Deliberate test changes

- `environment.test.ts:417`-area "absent when which graphify fails" flips to `ready` — it was written with graph-present fakes and the new semantics are the point of the fix; the absent case is covered separately.
- Four existing detection tests gained an explicit null `registrationLookup` stub: their premise is "nothing installed," which the real-config default now violates on any machine with a working registration.
- "jcodemunch is not installed" assertions updated to the new "was not detected" wording.

## Test plan

- [x] 1098 tests passing (65 new), `npm run lint` clean
- [x] Coverage 96.65% statements / 91.19% branches (gates: 80/75)
- [x] **Live end-to-end on the machine that exhibited the bug**: cleared `/tmp/rig-session-*`, ran the real session-start hook — output shows `jcodemunch: available (mcp via user config: uvx --from https://github.com/jgravelle/...)`, `CWD indexed: franklywatson/claude-rig`, rtk `v0.39.0`, graph stats rendered; session cache records the config transport verbatim
- [x] post-tool-use hook smoke test with a failing external `graphify update`: exit 0, stderr quiet
- [x] `rtk rewrite` decline-contract evidence recorded (see Workstream C)

🤖 Generated with [Claude Code](https://claude.com/claude-code)