### PR TITLE
Fix rig init --force config reset; sync docs with integration-reliability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,14 +39,14 @@ All types in `src/types.ts`. Important ones:
 
 - Config via `.harness.yaml` (YAML, layered merge with base + local)
 - Environment detection uses injectable `ExecFn` for testability
-- Session cache has 30-min TTL, file-backed in /tmp (cross-process persistence)
+- Session cache: 4-hour env TTL, file-backed in /tmp keyed by (cwd, session id); scout cache has a separate 30-min TTL
 - All hooks read JSON from stdin, write JSON to stdout (Claude Code hook protocol)
 - Skill templates use `{{VAR}}` substitution via `renderTemplate()`
 - Enforcement levels: block (exit 2), advise (print + exit 0), silent (log + exit 0)
 
 ## Testing
 
-- 290+ tests in `tests/` mirroring `src/` structure
+- 1100+ tests in `tests/` mirroring `src/` structure
 - Vitest with v8 coverage provider
 - Coverage gate: 80% statements/functions/lines, 75% branches
 - No mocks for environment detection -- use injectable `ExecFn`

--- a/README.md
+++ b/README.md
@@ -27,7 +27,10 @@ Built from the [agentic-patterns](https://github.com/franklywatson/agentic-patte
 - Node.js 18+
 - [superpowers](https://github.com/obra/superpowers) -- base skills framework (required; all skill chain skills wrap `superpowers:*` skills)
 - [rtk](https://github.com/franklywatson/rtk) -- token-optimized command proxy (strongly recommended; tool router redirects `grep`/`find`/`cat` through rtk when available)
-- [jcodemunch](https://github.com/franklywatson/jcodemunch) -- indexed code search MCP server (strongly recommended; powers the scout agent and tool router fallback). Detected via PATH or, failing that, the MCP server command registered in Claude Code's own config (`claude mcp list`) -- wheel-URL `uvx --from` installs work out of the box.
+- [jcodemunch](https://github.com/franklywatson/jcodemunch) -- indexed code search MCP server
+  (strongly recommended; powers the scout agent and tool router fallback). Detected via PATH or,
+  failing that, the MCP server command registered in Claude Code's own config (`claude mcp list`)
+  -- wheel-URL `uvx --from` installs work out of the box.
 - [graphify](https://github.com/safishamsi/graphify) -- knowledge graph builder
   (recommended; auto-builds graphs at session start and provides god nodes,
   module communities, and dependency path queries that complement jcodemunch's

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Built from the [agentic-patterns](https://github.com/franklywatson/agentic-patte
 - Node.js 18+
 - [superpowers](https://github.com/obra/superpowers) -- base skills framework (required; all skill chain skills wrap `superpowers:*` skills)
 - [rtk](https://github.com/franklywatson/rtk) -- token-optimized command proxy (strongly recommended; tool router redirects `grep`/`find`/`cat` through rtk when available)
-- [jcodemunch](https://github.com/franklywatson/jcodemunch) -- indexed code search MCP server (strongly recommended; powers the scout agent and tool router fallback)
+- [jcodemunch](https://github.com/franklywatson/jcodemunch) -- indexed code search MCP server (strongly recommended; powers the scout agent and tool router fallback). Detected via PATH or, failing that, the MCP server command registered in Claude Code's own config (`claude mcp list`) -- wheel-URL `uvx --from` installs work out of the box.
 - [graphify](https://github.com/safishamsi/graphify) -- knowledge graph builder
   (recommended; auto-builds graphs at session start and provides god nodes,
   module communities, and dependency path queries that complement jcodemunch's
@@ -185,7 +185,7 @@ standalone (no phase prerequisite). `debug+` mandates scout context harvesting.
 
 ```bash
 npm install
-npm test         # vitest, 240+ tests
+npm test         # vitest, 1100+ tests
 npm run build    # TypeScript compile
 npm run lint     # type-check only
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,6 +99,16 @@ rule array, so `findMatchingRule` returns the native-specific rule first. This p
 circular advice where the router would suggest "use Grep" when the agent is already
 on the Grep tool.
 
+### rtk rewrite diagnostics
+
+`rtk rewrite` declines commands it can't handle via exit 1 (no rewrite) or
+exit 2 (denied) — both fall through silently to rig's own rules by design.
+Anything else (unexpected exit codes, signals, ENOENT) is appended as a JSON
+line to `/tmp/rig-rtk-rewrite-failures.log` so silent fallthroughs are
+debuggable in the field. Set `RIG_DEBUG=1` to log expected declines too.
+Compound commands (pipes, `&&`, `;`) skip the rewrite entirely — the router
+cannot safely rewrite one segment of a pipeline.
+
 ---
 
 ## Layer 2: Enforcement Pipeline
@@ -283,6 +293,19 @@ main project and external directories referenced during cross-repo indexing.
 If graphify is not installed, the scout agent falls back to jcodemunch-only
 analysis (symbol search without relationship data).
 
+**Build-state reliability:** a valid `graph.json` (>1KB) means `ready` even
+when the graphify CLI is off the hook PATH — the CLI is only needed for
+rebuilding. graphify leaves `.rebuild.lock` behind after completed builds, so
+detection compares mtimes: graph newer than lock = ready (stale lock), lock
+newer = building. `graphify update` can return before `graph.json` lands, so
+session-start polls up to 5s for the output instead of caching a false
+failure, and a cached `failed` state is re-validated against the disk before
+being trusted. Build failures carry an `errorReason` (timeout vs AST
+recursion vs missing CLI), rendered as `build failed (<reason>)` at session
+start. Stats capture is timeout-bounded and warns on `GRAPH_REPORT.md`
+format drift; building a graph via `Bash(graphify update <dir>)` also
+triggers per-project stats capture in the PostToolUse hook.
+
 **Confidence levels:** Graph edges carry confidence labels — `EXTRACTED`
 (verified by AST analysis), `INFERRED` (heuristic), `AMBIGUOUS`. Session-start
 reports these percentages (e.g., "90% EXTRACTED, 10% INFERRED") so agents can
@@ -314,18 +337,44 @@ Loads `.harness.yaml` with layered merge (base config + local override). `getEnf
 ### Session (`src/session/`)
 
 `detectEnvironment()` checks for rtk, jcodemunch, graphify, and other tools via
-injectable `ExecFn`. `SessionCache` with 30-min TTL persists to
-`/tmp/rig-session-{cwd-hash}.json` for cross-process state sharing between hook
-invocations. Environment detection results, edited file tracking, phase, metrics
-baseline (including per-project graphify stats keyed by directory path), tool call
-counters, and a `toolsWarned` flag all persist. `handleSessionStart()` auto-indexes
-the project, captures a metrics baseline on first session, emits active enforcement
-rules from `.harness.yaml` (so skill templates can reference them dynamically),
-captures graphify graph stats for the CWD project when available, and emits a
-one-time warning if rtk or jcodemunch are not installed (suppressed for the rest
-of the session via the `toolsWarned` cache flag). A `[HINT]` is emitted when
-graphify is not installed. `SessionCache` provides `getGraphifyStats(dir)` and
-`setGraphifyStats(dir, stats)` accessors for per-directory graphify data.
+injectable `ExecFn`. `SessionCache` with a 4-hour env TTL persists to
+`/tmp/rig-session-{hash}.json` (hash of cwd + session id) for cross-process
+state sharing between hook invocations. Environment detection results, edited
+file tracking, phase, metrics baseline (including per-project graphify stats
+keyed by directory path), tool call counters, and a `toolsWarned` flag all
+persist. Deleting `/tmp/rig-session-*.json` forces immediate re-detection.
+
+**jcodemunch detection** (`environment.ts` + `claude-config.ts`) resolves a
+working transport in priority order:
+
+1. `jcodemunch` CLI binary on PATH
+2. **The MCP server command registered in Claude Code's own config** —
+   `~/.claude.json` (local scope `projects[cwd].mcpServers`, then user scope)
+   and `<cwd>/.mcp.json` (project scope). This is ground truth: it handles
+   installs a PATH probe can never find, e.g. `uvx --from <wheel-url>
+   jcodemunch-mcp` from a GitHub release.
+3. `jcodemunch-mcp` binary on PATH
+4. Bare `uvx jcodemunch-mcp` (PyPI installs only)
+
+The winning transport is recorded on `Environment.jcodemunchTransport` and
+reused verbatim for session-start auto-indexing — it is never re-derived.
+CWD-to-repo matching prefers exact `source_root` paths from `list_repos`,
+falling back to strict basename equality. The MCP `initialize` response's
+`protocolVersion` is validated (warn-only), and rtk/graphify versions are
+probed for diagnostics (graphify warns outside its tested range).
+
+`handleSessionStart()` auto-indexes the project through the detected
+transport, captures a metrics baseline on first session (with `rtk gain`
+schema validation — format drift warns instead of silently zeroing savings),
+emits active enforcement rules from `.harness.yaml` (so skill templates can
+reference them dynamically), captures graphify graph stats for the CWD
+project when available (parse-drift and benchmark-fallback warnings
+surfaced), and emits a one-time warning if rtk or jcodemunch are not
+detected — including a pointer to `claude mcp list` and an orphaned-index
+warning when `~/.code-index` holds data but no transport works. A `[HINT]`
+is emitted when graphify is not installed. `SessionCache` provides
+`getGraphifyStats(dir)` and `setGraphifyStats(dir, stats)` accessors for
+per-directory graphify data.
 
 ### CLI (`src/cli/`)
 
@@ -401,6 +450,14 @@ Key design decisions:
   this is intentional (opt-in rather than silently granting broad access).
 - **First-occurrence advisory suppression**: The tool router advises jcodemunch/scout
   once per intent type per session via `hasAdvised()`. If the agent ignores the first
-  advisory, it receives no further reminders for that session. The jcodemunch detection
-  fix (uvx support) ensures the advisory fires in the first place; suppression
-  behavior itself is tracked for future work (periodic re-advisory or escalating urgency).
+  advisory, it receives no further reminders for that session. Config-registration
+  detection ensures the advisory fires in the first place; suppression behavior
+  itself is tracked for future work (periodic re-advisory or escalating urgency).
+  For deterministic routing (demos, strict projects), set the `tool_routing`
+  rules to `block` in `.harness.yaml` — blocks cannot be ignored.
+- **Cache fragmentation across cwd/session-id**: session cache files are keyed
+  by (cwd, session id), so hooks running from a subdirectory or a subagent
+  context write advisory state and savings counters to separate files. The
+  practical effects are an occasional repeated advisory and `/savings`
+  under-counting work done in those contexts. Aggregation is tracked as
+  future work.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,6 +18,9 @@ Strongly recommended:
 - [jcodemunch](https://github.com/franklywatson/jcodemunch) -- indexed code
   search MCP server. Powers the scout agent for cross-repo indexing and
   serves as the tool router's fallback for `grep`/`find`/`cat` redirection.
+  Rig detects it via PATH or via the MCP server command registered in Claude
+  Code's config -- if session-start reports it as not detected despite a
+  working install, check `claude mcp list` for the registration.
   Note: jcodemunch indexes up to 2000 files per folder by default. For
   larger projects, increase `max_folder_files` in `~/.code-index/config.jsonc`.
   Rig emits a `[WARNING]` at session start when files are skipped.
@@ -195,7 +198,7 @@ When a Claude Code session starts, the session-start hook:
 1. Detects available tools (rtk, jcodemunch, graphify)
 2. Auto-indexes the project via jcodemunch if not already indexed
 3. Captures graphify graph stats (nodes, edges, communities) when available
-4. Caches results for the session (30-min TTL)
+4. Caches results for the session (4-hour env TTL; delete `/tmp/rig-session-*.json` to force immediate re-detection)
 
 ## Re-initialize
 
@@ -213,6 +216,7 @@ Remove the generated files:
 
 ```bash
 rm -rf .claude/hooks/ .claude/skills/ .claude/agents/scout.md .harness.yaml
+rm -f /tmp/rig-session-*.json /tmp/rig-rtk-rewrite-failures.log
 ```
 
 Then remove hook registrations from `.claude/settings.json`. The `init` command added entries under `hooks.PreToolUse` and `hooks.PostToolUse` and `hooks.SessionStart` -- remove those arrays.

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -97,8 +97,10 @@ export async function initCommand(projectDir: string, options: InitOptions): Pro
   }
 
   // Write default config
+  // .harness.yaml carries user enforcement policy — never reset it on --force;
+  // a template refresh must not change what the user chose to enforce.
   const configPath = join(projectDir, '.harness.yaml');
-  if (!existsSync(configPath) || options.force) {
+  if (!existsSync(configPath)) {
     writeFileSync(configPath, yamlStringify(DEFAULT_CONFIG, { lineWidth: 0 }));
   }
 

--- a/tests/cli/init.test.ts
+++ b/tests/cli/init.test.ts
@@ -108,6 +108,23 @@ describe('initCommand', () => {
     expect(after).toContain('brain+');
   });
 
+  it('preserves a customized .harness.yaml on --force (documented contract)', async () => {
+    // getting-started.md: --force "overwrites existing hook and skill
+    // templates but preserves your .harness.yaml config". Enforcement
+    // settings are user policy — a template refresh must never reset them.
+    await initCommand(tempDir, { force: false });
+    const configPath = join(tempDir, '.harness.yaml');
+    const customized = readFileSync(configPath, 'utf-8').replace(
+      'native_grep: advise',
+      'native_grep: block',
+    );
+    writeFileSync(configPath, customized);
+
+    await initCommand(tempDir, { force: true });
+
+    expect(readFileSync(configPath, 'utf-8')).toContain('native_grep: block');
+  });
+
   it('updates settings.json with hook registrations', async () => {
     // Create a minimal settings.json (need .claude dir first)
     const claudeDir = join(tempDir, '.claude');


### PR DESCRIPTION
## Summary

Follow-up to #27, fixing one contract violation found during a docs audit and bringing the docs in line with the merged changes.

### Code fix: `rig init --force` no longer resets `.harness.yaml`

`getting-started.md` promises that `--force` "overwrites existing hook and skill templates but **preserves your `.harness.yaml` config**" — but `init.ts` overwrote it with defaults. Observed live: re-initializing a project silently reset its enforcement settings. Enforcement config is user policy; `--force` now refreshes templates only and writes `.harness.yaml` solely when absent. New regression test pins the documented contract.

### Docs: drifted claims corrected

- Session env cache TTL is **4 hours** (`ENV_TTL_MS`), not 30 minutes — only the scout cache is 30 min; three docs conflated them
- Test counts (290+/240+ → 1100+)
- Stale "uvx support fix" framing replaced with config-registration detection

### Docs: #27's behavior documented

- jcodemunch detection chain (CLI → **Claude-config MCP registration** → binary → uvx), transport reuse for auto-index, protocol/version probes, `claude mcp list` troubleshooting pointer
- graphify build-state reliability: CLI-absent reads, `.rebuild.lock` mtime semantics, build-output polling, `errorReason` surfacing, stats timeouts and drift warnings, `Bash(graphify update)` stats trigger
- rtk rewrite diagnostics log (`/tmp/rig-rtk-rewrite-failures.log`, `RIG_DEBUG`)
- Known limitations refreshed: block-level routing guidance for deterministic demos, cwd/session-id cache fragmentation
- Uninstall covers `/tmp` cache files and the diagnostics log

## Test plan

- [x] 1108 tests passing (1 new regression test for the --force contract), lint clean
- [x] Docs CI (markdown lint, link integrity, CLAUDE.md line limit) validates the prose changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)