### PR TITLE
feat: /savings includes Headroom context-layer stats when initialized

### DIFF
--- a/src/session/headroom.ts
+++ b/src/session/headroom.ts
@@ -1,0 +1,66 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import type { ExecFn } from './environment.js';
+
+/**
+ * Headroom (context-compression proxy) detection.
+ *
+ * `available` — the headroom CLI is on PATH.
+ * `initialized` — Claude Code is configured to route through the headroom
+ * proxy for this project: either the `headroom-init-claude` hook marker or a
+ * localhost `ANTHROPIC_BASE_URL` appears in any settings scope (project
+ * settings.json, project settings.local.json, user ~/.claude/settings.json).
+ *
+ * Initialized-without-available is reported as such (stale config after an
+ * uninstall) so callers can explain missing perf data instead of hiding it.
+ */
+export interface HeadroomDetection {
+  available: boolean;
+  initialized: boolean;
+}
+
+const HEADROOM_HOOK_MARKER = 'headroom-init-claude';
+const LOCAL_PROXY_PATTERN = /^https?:\/\/(127\.0\.0\.1|localhost)(:\d+)?/;
+
+export function detectHeadroom(
+  cwd: string,
+  exec: ExecFn,
+  readFile: (path: string) => string = (p) => readFileSync(p, 'utf-8'),
+  existsCheck: (path: string) => boolean = existsSync,
+  homeDir: string = homedir(),
+): HeadroomDetection {
+  let available = false;
+  try {
+    exec('which headroom');
+    available = true;
+  } catch {
+    // Not on PATH
+  }
+
+  const settingsPaths = [
+    join(cwd, '.claude', 'settings.json'),
+    join(cwd, '.claude', 'settings.local.json'),
+    join(homeDir, '.claude', 'settings.json'),
+  ];
+  const initialized = settingsPaths.some((path) => settingsShowHeadroom(path, readFile, existsCheck));
+
+  return { available, initialized };
+}
+
+function settingsShowHeadroom(
+  path: string,
+  readFile: (path: string) => string,
+  existsCheck: (path: string) => boolean,
+): boolean {
+  try {
+    if (!existsCheck(path)) return false;
+    const raw = readFile(path);
+    if (raw.includes(HEADROOM_HOOK_MARKER)) return true;
+    const parsed = JSON.parse(raw) as { env?: { ANTHROPIC_BASE_URL?: unknown } };
+    const baseUrl = parsed?.env?.ANTHROPIC_BASE_URL;
+    return typeof baseUrl === 'string' && LOCAL_PROXY_PATTERN.test(baseUrl);
+  } catch {
+    return false;
+  }
+}

--- a/src/session/metrics.ts
+++ b/src/session/metrics.ts
@@ -164,6 +164,51 @@ export function captureMetricsBaseline(
   return { totalSaved: 0, capturedAt: Date.now() };
 }
 
+/** Context-layer compression stats from `headroom perf --format json`. */
+export interface HeadroomStats {
+  tokensSaved: number;
+  savingsPct: number;
+  totalRequests: number;
+  cacheHitPct: number;
+}
+
+/**
+ * Capture headroom proxy compression stats for the last 24 hours. These are
+ * context-layer savings — they overlap tool-layer (rtk/jcodemunch) savings at
+ * the boundary and must be reported separately, never summed.
+ */
+export function captureHeadroomStats(
+  exec: ExecFn,
+  onWarn?: (msg: string) => void,
+): HeadroomStats | null {
+  let raw: string;
+  try {
+    raw = exec('headroom perf --format json --hours 24', { timeout: GAIN_TIMEOUT_MS });
+  } catch {
+    // headroom absent or proxy never ran — nothing to report
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (
+      typeof parsed?.tokens_saved === 'number' && Number.isFinite(parsed.tokens_saved) &&
+      typeof parsed?.total_requests === 'number'
+    ) {
+      return {
+        tokensSaved: parsed.tokens_saved,
+        savingsPct: typeof parsed.savings_pct === 'number' ? parsed.savings_pct : 0,
+        totalRequests: parsed.total_requests,
+        cacheHitPct: typeof parsed.cache_hit_pct === 'number' ? parsed.cache_hit_pct : 0,
+      };
+    }
+  } catch {
+    // Fall through — schema warning below
+  }
+  onWarn?.("headroom: 'headroom perf --format json' returned an unexpected schema — context-layer savings unavailable");
+  return null;
+}
+
 export function incrementMetric(
   toolName: string,
   toolInput: Record<string, unknown>,
@@ -213,6 +258,7 @@ export function formatSavingsReport(
   counters: { rtkCalls: number; jmCalls: number; efficientCalls: number; graphifyCalls: number },
   jmStats?: JcodemunchSessionStats | null,
   graphifyStats?: Record<string, GraphifyProjectStats> | null,
+  headroomStats?: HeadroomStats | null,
 ): string {
   const hasBaseline = baseline != null && baseline.totalSaved > 0;
   const lines: string[] = [];
@@ -251,6 +297,14 @@ export function formatSavingsReport(
 
   if (counters.efficientCalls > 0) {
     lines.push(`  efficient tools: ${counters.efficientCalls} calls (Read/Grep/Glob on code files)`);
+  }
+
+  // Context layer — overlaps tool-layer savings at the rtk boundary, so it is
+  // reported as its own line and never added to the totals above.
+  if (headroomStats && headroomStats.totalRequests > 0) {
+    lines.push(
+      `  headroom: ${formatTokens(headroomStats.tokensSaved)} saved (context layer — ${headroomStats.totalRequests} requests, ${Math.round(headroomStats.savingsPct)}% compression, ${Math.round(headroomStats.cacheHitPct)}% cache hits; not summed with tool-layer savings)`,
+    );
   }
 
   if (graphifyStats && Object.keys(graphifyStats).length > 0) {

--- a/src/session/start.ts
+++ b/src/session/start.ts
@@ -13,6 +13,7 @@ import type { WaitForBuildOpts } from '../scout/graph-state.js';
 import { loadConfig } from '../config.js';
 import { checkGraphifyMcpReadiness } from './graphify-self-check.js';
 import { checkPermissionsReadiness } from './permissions-self-check.js';
+import { detectHeadroom } from './headroom.js';
 import { readFileSync, existsSync, readdirSync } from 'node:fs';
 
 interface FileCapWarning {
@@ -47,6 +48,7 @@ export interface SessionStartDeps {
   mcpQuery?: McpQueryFn;
   registrationLookup?: RegistrationLookupFn;
   readdir?: (path: string) => string[];
+  readFile?: (path: string) => string;
   homeDir?: string;
   graphWait?: WaitForBuildOpts;
 }
@@ -67,6 +69,18 @@ export async function handleSessionStart(
   const { env, fileCapHit, autoIndex } = await detectAndIndex(
     cwd, deps.exec, deps.existsCheck, deps.statCheck, deps.mcpQuery, deps.registrationLookup,
   );
+
+  // Headroom (context-compression proxy) is complementary to rig — record
+  // whether it is configured so /savings can include context-layer stats.
+  const headroom = detectHeadroom(
+    cwd,
+    deps.exec ?? ((cmd, opts) => execSync(cmd, { encoding: 'utf-8', ...opts } as Parameters<typeof execSync>[1]) as string),
+    deps.readFile,
+    deps.existsCheck ?? existsSync,
+    deps.homeDir,
+  );
+  env.headroomAvailable = headroom.available;
+  env.headroomInitialized = headroom.initialized;
   cache.setEnvironment(env);
 
   const pyEnv = await detectPythonEnv(cwd);
@@ -138,6 +152,10 @@ export async function handleSessionStart(
     `  jcodemunch: ${describeJcodemunch(env)}`,
     `  graphify: ${describeGraphify(env.graphBuildInfo)}`,
   ];
+
+  if (env.headroomInitialized) {
+    lines.push('  headroom: proxy configured (context-layer compression)');
+  }
 
   if (env.jcodemunchAvailable) {
     if (env.jcodemunchCwdIndexed) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -127,6 +127,8 @@ export interface Environment {
   graphifyGraphPath: string | null;
   graphBuildInfo?: GraphBuildInfo;
   graphifyVersion?: string | null;
+  headroomAvailable?: boolean;
+  headroomInitialized?: boolean;
   detectedAt: number;
 }
 

--- a/templates/skills/savings/SKILL.md
+++ b/templates/skills/savings/SKILL.md
@@ -41,7 +41,16 @@ Report token savings from rtk and jcodemunch usage during this session.
    section in the report (see Output Format below). Alternatively, if graphify
    MCP is available, call `mcp__graphify__graph_stats` to get live stats.
    If graphify is not available, skip graphify reporting.
-6. Format and print the report (see Output Format below). Do NOT write any
+6. For headroom (context-compression proxy): check the session cache file's
+   `environment.headroomInitialized` field. If true, run
+   `headroom perf --format json --hours 24` and read `tokens_saved`,
+   `savings_pct`, `total_requests`, and `cache_hit_pct`. Include the headroom
+   line only when `total_requests > 0`. These are context-layer savings — they
+   overlap tool-layer (rtk/jcodemunch) savings at the boundary, so report them
+   on their own line and NEVER add them to the rtk/jcodemunch numbers. If
+   `headroomInitialized` is false/absent or the command fails, skip headroom
+   reporting.
+7. Format and print the report (see Output Format below). Do NOT write any
    explanatory text before or after the report — output ONLY the report lines.
 
 ## Output Format
@@ -52,8 +61,12 @@ With session data (baseline + delta available), single project:
 [rig] Session Savings
   rtk: X.XM saved (N calls, +XK this session)
   jcodemunch: XK saved (N queries, 150M total all-time)
+  headroom: XK saved (context layer — N requests, X% compression, X% cache hits; not summed with tool-layer savings)
   graphify: N nodes, M edges, K communities (X% EXTRACTED, X% INFERRED, X% AMBIGUOUS)
 ```
+
+The headroom line appears only when the proxy is initialized for this project
+and had requests in the window — omit it otherwise.
 
 With session data, multi-project (scouted external repos):
 

--- a/tests/session/headroom.test.ts
+++ b/tests/session/headroom.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { detectHeadroom } from '../../src/session/headroom.js';
+import type { ExecFn } from '../../src/session/environment.js';
+
+const CWD = '/work/proj';
+const HOME = '/home/user';
+const PROJECT_SETTINGS = `${CWD}/.claude/settings.json`;
+const LOCAL_SETTINGS = `${CWD}/.claude/settings.local.json`;
+const USER_SETTINGS = `${HOME}/.claude/settings.json`;
+
+const headroomOnPath: ExecFn = (cmd) => {
+  if (cmd === 'which headroom') return '/Users/u/.local/bin/headroom';
+  throw new Error(`not found: ${cmd}`);
+};
+const nothingOnPath: ExecFn = () => {
+  throw new Error('not found');
+};
+
+function makeFiles(files: Record<string, string>): {
+  readFile: (p: string) => string;
+  existsCheck: (p: string) => boolean;
+} {
+  return {
+    readFile: (p) => {
+      if (p in files) return files[p];
+      throw new Error(`ENOENT: ${p}`);
+    },
+    existsCheck: (p) => p in files,
+  };
+}
+
+const MARKER_SETTINGS = JSON.stringify({
+  hooks: {
+    SessionStart: [
+      {
+        matcher: 'startup|resume',
+        hooks: [{ type: 'command', command: 'headroom hook --marker headroom-init-claude' }],
+      },
+    ],
+  },
+});
+
+const PROXY_ENV_SETTINGS = JSON.stringify({
+  env: { ANTHROPIC_BASE_URL: 'http://127.0.0.1:8787' },
+});
+
+describe('detectHeadroom', () => {
+  it('reports unavailable and uninitialized when nothing is present', () => {
+    const { readFile, existsCheck } = makeFiles({});
+    const result = detectHeadroom(CWD, nothingOnPath, readFile, existsCheck, HOME);
+    expect(result).toEqual({ available: false, initialized: false });
+  });
+
+  it('detects availability from PATH without initialization', () => {
+    const { readFile, existsCheck } = makeFiles({});
+    const result = detectHeadroom(CWD, headroomOnPath, readFile, existsCheck, HOME);
+    expect(result).toEqual({ available: true, initialized: false });
+  });
+
+  it('detects initialization from the headroom hook marker in project settings', () => {
+    const { readFile, existsCheck } = makeFiles({ [PROJECT_SETTINGS]: MARKER_SETTINGS });
+    const result = detectHeadroom(CWD, headroomOnPath, readFile, existsCheck, HOME);
+    expect(result.initialized).toBe(true);
+  });
+
+  it('detects initialization from a localhost ANTHROPIC_BASE_URL proxy env', () => {
+    const { readFile, existsCheck } = makeFiles({ [LOCAL_SETTINGS]: PROXY_ENV_SETTINGS });
+    const result = detectHeadroom(CWD, headroomOnPath, readFile, existsCheck, HOME);
+    expect(result.initialized).toBe(true);
+  });
+
+  it('detects initialization at user scope (headroom init -g)', () => {
+    const { readFile, existsCheck } = makeFiles({ [USER_SETTINGS]: MARKER_SETTINGS });
+    const result = detectHeadroom(CWD, headroomOnPath, readFile, existsCheck, HOME);
+    expect(result.initialized).toBe(true);
+  });
+
+  it('does not treat a remote ANTHROPIC_BASE_URL as headroom', () => {
+    const settings = JSON.stringify({ env: { ANTHROPIC_BASE_URL: 'https://api.example.com' } });
+    const { readFile, existsCheck } = makeFiles({ [PROJECT_SETTINGS]: settings });
+    const result = detectHeadroom(CWD, headroomOnPath, readFile, existsCheck, HOME);
+    expect(result.initialized).toBe(false);
+  });
+
+  it('ignores malformed settings files', () => {
+    const { readFile, existsCheck } = makeFiles({
+      [PROJECT_SETTINGS]: '{ not valid json',
+      [USER_SETTINGS]: MARKER_SETTINGS,
+    });
+    const result = detectHeadroom(CWD, headroomOnPath, readFile, existsCheck, HOME);
+    expect(result.initialized).toBe(true);
+  });
+
+  it('initialized requires the proxy config even when the binary is absent', () => {
+    // Settings can carry stale headroom config after uninstall — still report
+    // initialized so the savings skill can explain why perf data is missing.
+    const { readFile, existsCheck } = makeFiles({ [PROJECT_SETTINGS]: MARKER_SETTINGS });
+    const result = detectHeadroom(CWD, nothingOnPath, readFile, existsCheck, HOME);
+    expect(result).toEqual({ available: false, initialized: true });
+  });
+});

--- a/tests/session/metrics.test.ts
+++ b/tests/session/metrics.test.ts
@@ -4,6 +4,7 @@ import {
   captureGraphifyStats,
   captureGraphifyStatsViaReport,
   captureExternalGraphifyStats,
+  captureHeadroomStats,
   incrementMetric,
   formatSavingsReport,
   resolveGraphifyStats,
@@ -206,6 +207,50 @@ describe('captureGraphifyStatsViaReport warnings', () => {
   });
 });
 
+describe('captureHeadroomStats', () => {
+  const VALID = JSON.stringify({
+    window_hours: 24,
+    total_requests: 42,
+    total_tokens_before: 100_000,
+    total_tokens_after: 60_000,
+    tokens_saved: 40_000,
+    savings_pct: 40.0,
+    cache_hit_pct: 78.5,
+  });
+
+  it('parses headroom perf JSON with a bounded timeout', () => {
+    const exec = vi.fn(() => VALID);
+    const stats = captureHeadroomStats(exec);
+
+    expect(stats).toEqual({
+      tokensSaved: 40_000,
+      savingsPct: 40.0,
+      totalRequests: 42,
+      cacheHitPct: 78.5,
+    });
+    expect(exec).toHaveBeenCalledWith(
+      expect.stringContaining('headroom perf --format json'),
+      expect.objectContaining({ timeout: 10_000 }),
+    );
+  });
+
+  it('returns null silently when headroom is absent (exec throws)', () => {
+    const onWarn = vi.fn();
+    const stats = captureHeadroomStats(() => { throw new Error('not found'); }, onWarn);
+
+    expect(stats).toBeNull();
+    expect(onWarn).not.toHaveBeenCalled();
+  });
+
+  it('warns on schema drift and returns null', () => {
+    const onWarn = vi.fn();
+    const stats = captureHeadroomStats(() => JSON.stringify({ saved: 'lots' }), onWarn);
+
+    expect(stats).toBeNull();
+    expect(onWarn).toHaveBeenCalledWith(expect.stringContaining('unexpected schema'));
+  });
+});
+
 describe('incrementMetric', () => {
   it('detects rtk usage from Bash tool with rtk command', () => {
     const result = incrementMetric('Bash', { command: 'rtk git status' });
@@ -285,6 +330,33 @@ describe('formatSavingsReport', () => {
     const baseline: MetricsBaseline = { totalSaved: 1000, capturedAt: Date.now() };
     const report = formatSavingsReport(baseline, 1000, { rtkCalls: 0, jmCalls: 0, efficientCalls: 0, graphifyCalls: 0 });
     expect(report).toContain('no token savings');
+  });
+
+  it('appends a clearly-separated headroom context-layer line when stats are present', () => {
+    const baseline: MetricsBaseline = { totalSaved: 1000, capturedAt: Date.now() };
+    const headroom = { tokensSaved: 40_000, savingsPct: 40, totalRequests: 42, cacheHitPct: 78.5 };
+    const report = formatSavingsReport(
+      baseline, 1000,
+      { rtkCalls: 0, jmCalls: 0, efficientCalls: 0, graphifyCalls: 0 },
+      undefined, undefined, headroom,
+    );
+
+    expect(report).toContain('headroom: 40K saved (context layer');
+    expect(report).toContain('42 requests');
+    expect(report).toContain('40% compression');
+    // Per docs: context-layer savings overlap tool-layer savings — never summed
+    expect(report).toContain('not summed');
+  });
+
+  it('omits the headroom line when stats are null or there were no requests', () => {
+    const baseline: MetricsBaseline = { totalSaved: 1000, capturedAt: Date.now() };
+    const counters = { rtkCalls: 0, jmCalls: 0, efficientCalls: 0, graphifyCalls: 0 };
+
+    expect(formatSavingsReport(baseline, 1000, counters, undefined, undefined, null)).not.toContain('headroom');
+    expect(formatSavingsReport(
+      baseline, 1000, counters, undefined, undefined,
+      { tokensSaved: 0, savingsPct: 0, totalRequests: 0, cacheHitPct: 0 },
+    )).not.toContain('headroom');
   });
 
   it('shows jcodemunch available with no queries', () => {

--- a/tests/session/start.test.ts
+++ b/tests/session/start.test.ts
@@ -852,6 +852,29 @@ describe('handleSessionStart', () => {
       expect(output).toContain('build failed (recursion depth exceeded)');
     });
 
+    it('reports headroom when the proxy is configured for this project', async () => {
+      vi.mocked(execSync).mockImplementation((cmd: string) => {
+        if (cmd === 'which rtk') throw new Error('not found');
+        if (cmd === 'which jcodemunch') return '/usr/bin/jcodemunch';
+        if (cmd.includes('list_repos')) return '{"repos":["local/test-project"]}';
+        if (cmd === 'which headroom') return '/usr/local/bin/headroom';
+        return '';
+      });
+      const settingsPath = '/home/user/test-project/.claude/settings.json';
+
+      const output = await startSession('/home/user/test-project', cache, {
+        readFile: (p) => {
+          if (p === settingsPath) {
+            return JSON.stringify({ env: { ANTHROPIC_BASE_URL: 'http://127.0.0.1:8787' } });
+          }
+          throw new Error(`ENOENT: ${p}`);
+        },
+        existsCheck: (p) => p === settingsPath,
+      });
+
+      expect(output).toContain('headroom: proxy configured (context-layer compression)');
+    });
+
     it('renders the rtk version when known', async () => {
       vi.mocked(execSync).mockImplementation((cmd: string) => {
         if (cmd === 'which rtk') return '/opt/homebrew/bin/rtk';


### PR DESCRIPTION
## Summary

When rig detects that Headroom's compression proxy is configured for the current project, `/savings` now pulls in `headroom perf` data as a clearly-separated **context-layer** line.

- **Detection** (`src/session/headroom.ts`): `available` = CLI on PATH; `initialized` = the `headroom-init-claude` hook marker or a localhost `ANTHROPIC_BASE_URL` in any settings scope (project `settings.json`, `settings.local.json`, user `~/.claude/settings.json` — same multi-scope lesson as the permissions self-check). Stale config after an uninstall reports `initialized` without `available`, so the skill can explain missing perf data.
- **Capture** (`captureHeadroomStats`): runs `headroom perf --format json --hours 24`, timeout-bounded and schema-validated — absent headroom stays silent, format drift warns (consistent with the `rtk gain` handling).
- **Reporting**: `formatSavingsReport` + the savings skill template render `headroom: XK saved (context layer — N requests, X% compression, X% cache hits; not summed with tool-layer savings)` only when the proxy is initialized and had requests. Per the README co-existence guidance (#29), context-layer savings overlap tool-layer savings at the rtk boundary and are never added together.
- **Session start** shows `headroom: proxy configured (context-layer compression)` when initialized, and `Environment` carries `headroomAvailable`/`headroomInitialized` in the session cache for the skill to read.

## Test plan

- [x] 1122 tests passing (14 new: detection scopes/markers/malformed-config, capture schema validation, report formatting, session-start rendering), lint clean
- [x] Live verification on this machine: headroom v0.24.0 on PATH but proxy not configured → `headroomAvailable: true, headroomInitialized: false` in the session cache, no spurious output line

🤖 Generated with [Claude Code](https://claude.com/claude-code)