### PR TITLE
fix: graphify MCP fix-command -- separator; document Headroom auto-detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,20 @@ compression seam:
 - Trial per-invocation with `headroom wrap claude --no-context-tool` (skips the rtk hook), or
 - Install durably with `headroom init claude`, which configures only the proxy and does not touch rtk.
 
-Read savings as two separate layers: rig's `/savings` reports tool-layer savings
-(rtk/jcodemunch), Headroom's `perf` reports context-layer compression. Do not add
-them together -- they overlap at the rtk boundary.
+Rig detects Headroom automatically: when the proxy is configured for a project
+(`headroom init claude` hook marker or a localhost `ANTHROPIC_BASE_URL` in any
+settings scope), session start reports it and `/savings` pulls in `headroom perf`
+data as a separate **context layer** line:
+
+```
+[rig] Session Savings
+  rtk: 1.2M saved (42 calls, +340K this session)
+  jcodemunch: 85K saved (23 queries, 150M total all-time)
+  headroom: 40K saved (context layer -- 42 requests, 40% compression, 78% cache hits; not summed with tool-layer savings)
+```
+
+The layers overlap at the rtk boundary, so rig reports them side by side and
+never adds them together.
 
 ## Quick start
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -363,6 +363,15 @@ falling back to strict basename equality. The MCP `initialize` response's
 `protocolVersion` is validated (warn-only), and rtk/graphify versions are
 probed for diagnostics (graphify warns outside its tested range).
 
+**Headroom detection** (`headroom.ts`): session start records whether the
+[Headroom](https://github.com/chopratejas/headroom) compression proxy is
+configured for the project (`headroom-init-claude` hook marker or a localhost
+`ANTHROPIC_BASE_URL` in project, local, or user settings scope) as
+`Environment.headroomInitialized`. When set, the `/savings` skill runs
+`headroom perf --format json` (timeout-bounded, schema-validated) and reports
+context-layer compression on its own line — never summed with tool-layer
+savings, which it overlaps at the rtk boundary.
+
 `handleSessionStart()` auto-indexes the project through the detected
 transport, captures a metrics baseline on first session (with `rtk gain`
 schema validation — format drift warns instead of silently zeroing savings),

--- a/src/session/graphify-self-check.ts
+++ b/src/session/graphify-self-check.ts
@@ -141,5 +141,8 @@ function isRegisteredWithClaude(exec: ExecFn): boolean {
  * explicit args works for a quick fix instruction.
  */
 function buildMcpAddCommand(pythonPath: string, graphJsonPath: string): string {
-  return `claude mcp add graphify ${pythonPath} -m graphify.serve ${graphJsonPath}`;
+  // The -- separator is required: without it claude mcp add parses the
+  // server command's -m flag as its own option ("error: unknown option '-m'").
+  // -s local keeps the registration on this machine without touching .mcp.json.
+  return `claude mcp add graphify -s local -- ${pythonPath} -m graphify.serve ${graphJsonPath}`;
 }

--- a/tests/session/graphify-self-check.test.ts
+++ b/tests/session/graphify-self-check.test.ts
@@ -146,6 +146,9 @@ describe('checkGraphifyMcpReadiness — cli_only_not_registered', () => {
     if (result.status === 'cli_only_not_registered') {
       expect(result.fixCommand).toContain('claude mcp add');
       expect(result.fixCommand).toContain('graphify');
+      // Without the -- separator, claude mcp add parses the server's -m flag
+      // as its own option and fails with "error: unknown option '-m'"
+      expect(result.fixCommand).toMatch(/claude mcp add graphify -s local -- \S+ -m graphify\.serve/);
     }
   });
 


### PR DESCRIPTION
## Summary

Two small follow-ups:

1. **Bug (field-reported):** the `cli_only_not_registered` fix command from `graphify-self-check.ts` was `claude mcp add graphify <python> -m graphify.serve <graph>` — which fails with `error: unknown option '-m'` because `claude mcp add` parses the server's `-m` as its own flag. Now generates `claude mcp add graphify -s local -- <python> -m graphify.serve <graph>` (verified working against the real CLI; `-s local` keeps the registration machine-local without writing `.mcp.json` into the repo). Test asserts the separator so it can't regress.

2. **Docs:** #29's Headroom section merged before #30's feature landed — the README and architecture docs now describe the auto-detection (`headroomInitialized` from hook marker or localhost `ANTHROPIC_BASE_URL` across settings scopes) and the `/savings` context-layer line, with an example report.

## Test plan

- [x] 1122 tests passing, lint clean, markdownlint clean
- [x] The corrected command shape was run live to register graphify for forgd-granola-live-aaa-agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)