### PR TITLE
fix: restore rtk routing in long sessions and honor rtk's exit-3 Ask verdict

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -101,10 +101,17 @@ on the Grep tool.
 
 ### rtk rewrite diagnostics
 
-`rtk rewrite` declines commands it can't handle via exit 1 (no rewrite) or
-exit 2 (denied) — both fall through silently to rig's own rules by design.
-Anything else (unexpected exit codes, signals, ENOENT) is appended as a JSON
-line to `/tmp/rig-rtk-rewrite-failures.log` so silent fallthroughs are
+`rtk rewrite` follows a four-code permission protocol (rtk
+`src/hooks/rewrite_cmd.rs`): exit 0 + stdout = rewrite (safe to auto-allow),
+exit 1 = no RTK equivalent, exit 2 = deny rule matched, exit 3 + stdout =
+"Ask" verdict (rewrite valid, must not be auto-allowed). Rig uses exit-0 and
+exit-3 rewrites identically because it never auto-allows — the hook emits
+`updatedInput` without a `permissionDecision`, so Claude Code's own
+permission flow applies to the rewritten command. Exits 1 and 2 fall through
+silently to rig's own rules by design (stdout is never used on exit 2).
+Anything outside the protocol (exit 3 without output, other exit codes,
+signals, ENOENT) is appended as a JSON line to
+`/tmp/rig-rtk-rewrite-failures.log` so silent fallthroughs are
 debuggable in the field. Set `RIG_DEBUG=1` to log expected declines too.
 Compound commands (pipes, `&&`, `;`) skip the rewrite entirely — the router
 cannot safely rewrite one segment of a pipeline.

--- a/src/router/hook.ts
+++ b/src/router/hook.ts
@@ -28,11 +28,24 @@ const defaultWriteDiag = (line: string): void => {
 };
 
 /**
- * Build the default ExecRewriteFn. Exit codes 1 (no rewrite) and 2 (denied)
- * are rtk's expected decline contract and stay silent; anything else —
- * unexpected exit codes, signals, ENOENT — is appended as a JSON line to
- * the diagnostic log so silent fallthroughs become debuggable in the field.
- * Set RIG_DEBUG to log expected declines too. Null-fallthrough is unchanged.
+ * Build the default ExecRewriteFn implementing rtk's rewrite exit-code
+ * protocol (rtk src/hooks/rewrite_cmd.rs):
+ *
+ *   0 + stdout  rewrite, safe to auto-allow
+ *   1           no RTK equivalent — pass through
+ *   2           deny rule matched — pass through (never use stdout)
+ *   3 + stdout  "Ask" verdict — rewrite valid, but must not be auto-allowed
+ *
+ * rig never auto-allows (the hook emits updatedInput without a
+ * permissionDecision, so Claude Code's own permission flow applies to the
+ * rewritten command), which makes exit 3 equivalent to exit 0 here. rtk maps
+ * commands without an explicit allow rule — notably all git commands — to
+ * Ask, so dropping exit-3 output would lose the most common rewrites.
+ *
+ * Anything outside the protocol — exit 3 without output, other exit codes,
+ * signals, ENOENT — is appended as a JSON line to the diagnostic log so
+ * silent fallthroughs become debuggable in the field. Set RIG_DEBUG to log
+ * expected declines too. Null-fallthrough is unchanged.
  */
 export function makeDefaultExecRewrite(
   writeDiag: (line: string) => void = defaultWriteDiag,
@@ -47,7 +60,21 @@ export function makeDefaultExecRewrite(
       });
       return result.trim() || null;
     } catch (err) {
-      const e = err as { status?: number; signal?: string; code?: string; stderr?: unknown };
+      const e = err as { status?: number; signal?: string; code?: string; stdout?: unknown; stderr?: unknown };
+
+      // Exit 3 = rtk's "Ask" verdict: the rewrite is on stdout.
+      if (e?.status === 3) {
+        const stdout =
+          typeof e.stdout === 'string'
+            ? e.stdout
+            : Buffer.isBuffer(e.stdout)
+              ? e.stdout.toString('utf-8')
+              : '';
+        const rewritten = stdout.trim();
+        if (rewritten) return rewritten;
+        // Exit 3 without output violates the protocol — fall through to diag.
+      }
+
       const expectedDecline = e?.status === 1 || e?.status === 2;
       if (!expectedDecline || process.env.RIG_DEBUG) {
         const stderr =

--- a/src/session/cache.ts
+++ b/src/session/cache.ts
@@ -210,14 +210,15 @@ export class SessionCache {
       const raw = readFileSync(path, 'utf-8');
       const data = JSON.parse(raw) as SessionCacheFile;
 
-      // Restore environment, checking TTL
+      // Restore environment unconditionally as last-known-good. The TTL is
+      // reported via isEnvironmentStale() so SessionStart re-detects, but the
+      // env is never dropped here: clearing it made hooks fall back to
+      // defaultEnv() (everything unavailable) and silently disabled rtk and
+      // jcodemunch routing for the remainder of any session older than the
+      // TTL. A stale rtkPath degrades gracefully — the spawn fails and the
+      // command falls through unrewritten.
       if (data.environment) {
-        if (Date.now() - data.environment.detectedAt > ENV_TTL_MS) {
-          // Stale — clear environment but keep other fields
-          this.environment = undefined;
-        } else {
-          this.environment = data.environment;
-        }
+        this.environment = data.environment;
       }
 
       // Restore edited files

--- a/tests/eval/config-override-eval.test.ts
+++ b/tests/eval/config-override-eval.test.ts
@@ -79,6 +79,10 @@ describe('Context Eval: config override routing', () => {
         cache,
         config,
         scenario.cwd,
+        // Declining mock: without it, rtk-enabled scenarios spawn the real
+        // rtkPath, polluting /tmp/rig-rtk-rewrite-failures.log and making
+        // outcomes depend on whether rtk exists on the host.
+        { execRewrite: () => null },
       );
 
       const parsed = parseResult(actual);

--- a/tests/eval/session-state-eval.test.ts
+++ b/tests/eval/session-state-eval.test.ts
@@ -49,7 +49,7 @@ const SESSION_STATE_SCENARIOS: SessionStateScenario[] = [
   },
   {
     id: 'state_stale_env',
-    description: 'cat with stale environment (5h old) → allow (env cleared, cat rule advises)',
+    description: 'cat with stale environment (5h old, no tools) → advise (stale env retained as last-known-good)',
     toolCall: { tool: 'Bash', args: { command: 'cat src/main.py' } },
     setupCache: (cache) => {
       cache.setEnvironment({
@@ -149,7 +149,9 @@ describe('Context Eval: session state routing', () => {
         cache,
         config,
         scenario.cwd,
-        { existsCheck: (p) => p.startsWith('/project/.venv/bin/') },
+        // Declining execRewrite mock: keeps rtk-enabled scenarios off the
+        // real binary (no /tmp diag pollution, no host dependence).
+        { existsCheck: (p) => p.startsWith('/project/.venv/bin/'), execRewrite: () => null },
       );
 
       const parsed = parseResult(actual);

--- a/tests/integration/rtk-contract.test.ts
+++ b/tests/integration/rtk-contract.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { makeDefaultExecRewrite } from '../../src/router/hook.js';
+
+/**
+ * Contract-drift detector for the installed rtk binary.
+ *
+ * rig depends on rtk's rewrite exit-code protocol (rtk src/hooks/rewrite_cmd.rs):
+ *
+ *   0 + stdout  rewrite, safe to auto-allow
+ *   1           no RTK equivalent
+ *   2           deny rule matched
+ *   3 + stdout  "Ask" verdict — rewrite valid, must not be auto-allowed
+ *
+ * This drifted once already: rtk 0.39.0 introduced exit 3 for Ask/Default
+ * verdicts (which covers all git commands), and rig silently dropped every
+ * git rewrite in the field until the diag log surfaced it. These tests probe
+ * the real binary so the next protocol change fails at dev/CI time instead.
+ *
+ * Skipped entirely when rtk is not on PATH (e.g. bare CI runners).
+ */
+
+function rtkPath(): string | null {
+  const result = spawnSync('which', ['rtk'], { encoding: 'utf-8' });
+  const path = result.status === 0 ? result.stdout.trim() : '';
+  return path || null;
+}
+
+const RTK = rtkPath();
+const KNOWN_EXIT_CODES = [0, 1, 2, 3];
+
+function rewrite(command: string): { status: number | null; stdout: string } {
+  const result = spawnSync(RTK!, ['rewrite', command], {
+    encoding: 'utf-8',
+    timeout: 10_000,
+  });
+  return { status: result.status, stdout: (result.stdout ?? '').trim() };
+}
+
+describe.skipIf(!RTK)('rtk rewrite exit-code contract (installed binary)', () => {
+  it('exits within the known protocol codes for representative commands', () => {
+    const probes = [
+      'grep -r "TODO" src/',
+      'cat src/main.ts',
+      'git status',
+      'git log --oneline -5',
+      'find . -name "*.ts"',
+      'npm test', // expected: no RTK equivalent
+    ];
+    for (const cmd of probes) {
+      const { status } = rewrite(cmd);
+      expect(
+        KNOWN_EXIT_CODES,
+        `rtk rewrite "${cmd}" exited ${status} — protocol drift; update makeDefaultExecRewrite and this test`,
+      ).toContain(status);
+    }
+  });
+
+  it('produces a rewrite on stdout whenever it exits 0 or 3', () => {
+    for (const cmd of ['grep -r "TODO" src/', 'cat src/main.ts', 'git status']) {
+      const { status, stdout } = rewrite(cmd);
+      if (status === 0 || status === 3) {
+        expect(stdout, `rtk rewrite "${cmd}" exited ${status} but printed no rewrite`).not.toBe('');
+        expect(stdout.startsWith('rtk '), `rewrite of "${cmd}" was "${stdout}"`).toBe(true);
+      }
+    }
+  });
+
+  it('produces no rewrite on exit 1 (no RTK equivalent)', () => {
+    const { status, stdout } = rewrite('npm test');
+    if (status === 1) {
+      expect(stdout).toBe('');
+    }
+  });
+
+  it('makeDefaultExecRewrite recovers a git rewrite end-to-end', () => {
+    // The field regression: git maps to rtk's Ask verdict (exit 3 + stdout).
+    // rig must still use that rewrite.
+    const diagLines: string[] = [];
+    const execRewrite = makeDefaultExecRewrite(line => diagLines.push(line));
+    const result = execRewrite(RTK!, ['rewrite', 'git status']);
+
+    expect(result).toBe('rtk git status');
+    expect(diagLines).toEqual([]);
+  });
+
+  it('makeDefaultExecRewrite recovers a grep rewrite end-to-end', () => {
+    const diagLines: string[] = [];
+    const execRewrite = makeDefaultExecRewrite(line => diagLines.push(line));
+    const result = execRewrite(RTK!, ['rewrite', 'grep -r "TODO" src/']);
+
+    expect(result).not.toBeNull();
+    expect(result!.startsWith('rtk grep')).toBe(true);
+    expect(diagLines).toEqual([]);
+  });
+});

--- a/tests/router/hook.test.ts
+++ b/tests/router/hook.test.ts
@@ -1,8 +1,11 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { handlePreToolUse } from '../../src/router/hook.js';
-import { SessionCache } from '../../src/session/cache.js';
+import { SessionCache, sessionCachePath } from '../../src/session/cache.js';
 import type { Environment, HarnessConfig, PythonEnv } from '../../src/types.js';
 import { DEFAULT_CONFIG } from '../../src/config.js';
+import { mkdtempSync, rmSync, unlinkSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 function makeEnv(overrides: Partial<Environment> = {}): Environment {
   return {
@@ -50,9 +53,11 @@ describe('handlePreToolUse', () => {
     expect(result).toContain('Edit');
   });
 
-  it('advises rtk for grep when rtk available', () => {
+  it('advises rtk for grep when rtk available but rewrite declines', () => {
     cache.setEnvironment(makeEnv({ rtkAvailable: true, rtkPath: '/usr/bin/rtk' }));
-    const result = handlePreToolUse('Bash', { command: 'grep -r pattern .' }, cache, config);
+    // Declining mock: without it this test spawned the real rtkPath and only
+    // passed because the spawn failed (ENOENT), polluting the field diag log.
+    const result = handlePreToolUse('Bash', { command: 'grep -r pattern .' }, cache, config, undefined, () => null);
     expect(result).not.toBeNull();
     expect(result).toContain('rtk');
   });
@@ -324,5 +329,55 @@ describe('scout_explore advisory', () => {
     expect(result).not.toBeNull();
     expect(result).toContain('BLOCK');
     expect(result).toContain('scout');
+  });
+});
+
+describe('handlePreToolUse with file-backed cache (long-running session)', () => {
+  // Regression for the field failure where a >4h session lost its cached
+  // environment: SessionCache.load() cleared the stale env, handlePreToolUse
+  // fell back to defaultEnv() (rtkAvailable: false), and every rtk rewrite
+  // silently stopped for the rest of the session. The hook must keep routing
+  // on the last-known-good environment.
+  let testCwd: string;
+  let config: HarnessConfig;
+
+  beforeEach(() => {
+    testCwd = mkdtempSync(join(tmpdir(), 'rig-hook-test-'));
+    config = structuredClone(DEFAULT_CONFIG);
+  });
+
+  afterEach(() => {
+    const path = sessionCachePath(testCwd);
+    if (existsSync(path)) unlinkSync(path);
+    rmSync(testCwd, { recursive: true, force: true });
+  });
+
+  it('still rewrites via rtk after the env TTL expires mid-session', () => {
+    // Session-start persisted the environment 5 hours ago
+    const writer = new SessionCache(testCwd);
+    writer.setEnvironment(makeEnv({
+      rtkAvailable: true,
+      rtkPath: '/usr/bin/rtk',
+      detectedAt: Date.now() - 5 * 60 * 60 * 1000,
+    }));
+
+    // A later hook invocation loads the cache from disk
+    const cache = new SessionCache(testCwd);
+    const execRewrite = vi.fn(() => 'rtk grep -r pattern .');
+    const result = handlePreToolUse(
+      'Bash',
+      { command: 'grep -r pattern .' },
+      cache,
+      config,
+      testCwd,
+      execRewrite,
+    );
+
+    expect(execRewrite).toHaveBeenCalled();
+    expect(result).toEqual({
+      type: 'rewrite',
+      command: 'rtk grep -r pattern .',
+      original: 'grep -r pattern .',
+    });
   });
 });

--- a/tests/router/rewrite.test.ts
+++ b/tests/router/rewrite.test.ts
@@ -48,6 +48,56 @@ describe('makeDefaultExecRewrite diagnostics', () => {
     expect(writeDiag).not.toHaveBeenCalled();
   });
 
+  // rtk rewrite exit-code protocol (src/hooks/rewrite_cmd.rs in rtk):
+  //   0 + stdout  rewrite, safe to auto-allow
+  //   1           no RTK equivalent
+  //   2           deny rule matched
+  //   3 + stdout  "Ask" — rewrite valid, but the hook must not auto-allow.
+  // rig never auto-allows (it emits updatedInput without permissionDecision),
+  // so an exit-3 rewrite is used exactly like an exit-0 rewrite. Field bug:
+  // rtk maps git commands to Ask (Default verdict), so dropping exit-3 output
+  // silently lost every git rewrite.
+  it('uses the stdout rewrite on exit 3 (rtk Ask verdict) without diagnostics', () => {
+    const writeDiag = vi.fn();
+    const rewrite = makeDefaultExecRewrite(
+      writeDiag,
+      execError({ status: 3, stdout: 'rtk git status' }),
+    );
+
+    expect(rewrite('/usr/bin/rtk', ['rewrite', 'git status'])).toBe('rtk git status');
+    expect(writeDiag).not.toHaveBeenCalled();
+  });
+
+  it('handles Buffer stdout on exit 3', () => {
+    const writeDiag = vi.fn();
+    const rewrite = makeDefaultExecRewrite(
+      writeDiag,
+      execError({ status: 3, stdout: Buffer.from('rtk git log --oneline\n') }),
+    );
+
+    expect(rewrite('/usr/bin/rtk', ['rewrite', 'git log --oneline'])).toBe('rtk git log --oneline');
+    expect(writeDiag).not.toHaveBeenCalled();
+  });
+
+  it('logs exit 3 with empty stdout as a fallthrough', () => {
+    const writeDiag = vi.fn();
+    const rewrite = makeDefaultExecRewrite(writeDiag, execError({ status: 3, stdout: '' }));
+
+    expect(rewrite('/usr/bin/rtk', ['rewrite', 'git status'])).toBeNull();
+    expect(writeDiag).toHaveBeenCalledTimes(1);
+  });
+
+  it('never uses stdout on exit 2 (deny rule)', () => {
+    const writeDiag = vi.fn();
+    const rewrite = makeDefaultExecRewrite(
+      writeDiag,
+      execError({ status: 2, stdout: 'rtk rm -rf /' }),
+    );
+
+    expect(rewrite('/usr/bin/rtk', ['rewrite', 'rm -rf /'])).toBeNull();
+    expect(writeDiag).not.toHaveBeenCalled();
+  });
+
   it('logs unexpected exit codes with stderr context', () => {
     const writeDiag = vi.fn();
     const rewrite = makeDefaultExecRewrite(

--- a/tests/session/cache.test.ts
+++ b/tests/session/cache.test.ts
@@ -248,15 +248,41 @@ describe('SessionCache (file-backed)', () => {
     expect(cache2.getPythonEnv()!.uvAvailable).toBe(true);
   });
 
-  it('clears stale environment on load', () => {
+  it('retains stale environment on load as last-known-good', () => {
+    // Regression: long-running sessions (>4h) used to lose their environment
+    // on load, silently disabling all rtk/jcodemunch routing until the next
+    // SessionStart. The stale env must be retained — tool availability rarely
+    // changes mid-session, and a wrong rtkPath degrades gracefully (spawn
+    // fails, command falls through). Staleness is reported via
+    // isEnvironmentStale() so SessionStart still re-detects.
     const cache = new SessionCache(testCwd);
-    cache.setEnvironment(makeEnv({ detectedAt: Date.now() - 5 * 60 * 60 * 1000 }));
+    cache.setEnvironment(makeEnv({
+      rtkAvailable: true,
+      rtkPath: '/usr/bin/rtk',
+      detectedAt: Date.now() - 5 * 60 * 60 * 1000,
+    }));
     const path = sessionCachePath(testCwd);
     trackPath(path);
 
-    // Load into new instance — stale env should be cleared
     const cache2 = new SessionCache(testCwd);
-    expect(cache2.getEnvironment()).toBeUndefined();
+    expect(cache2.getEnvironment()).toBeDefined();
+    expect(cache2.getEnvironment()!.rtkAvailable).toBe(true);
+    expect(cache2.getEnvironment()!.rtkPath).toBe('/usr/bin/rtk');
+    expect(cache2.isEnvironmentStale()).toBe(true);
+  });
+
+  it('retains a days-old environment on load', () => {
+    const cache = new SessionCache(testCwd);
+    cache.setEnvironment(makeEnv({
+      rtkAvailable: true,
+      rtkPath: '/usr/bin/rtk',
+      detectedAt: Date.now() - 3 * 24 * 60 * 60 * 1000,
+    }));
+    trackPath(sessionCachePath(testCwd));
+
+    const cache2 = new SessionCache(testCwd);
+    expect(cache2.getEnvironment()?.rtkAvailable).toBe(true);
+    expect(cache2.isEnvironmentStale()).toBe(true);
   });
 
   it('preserves fresh environment on load', () => {


### PR DESCRIPTION
## Problem

Field report: zero rtk usage through the harness despite rig installed — `/savings` showed `rtk: +0 this session` while the session ran 15+ hours and executed 25 plain `git` commands, bare `grep`/`cat`/`ls`, none rewritten. Root-caused to two stacked bugs.

### Bug 1: env TTL expiry permanently disables routing mid-session

`SessionCache.load()` cleared the cached environment once it aged past the 4h TTL. Only the SessionStart hook runs detection, so every PreToolUse invocation in a >4h session fell back to `defaultEnv()` (`rtkAvailable: false`) — all rtk rewrites and jcodemunch advisories silently stopped for the rest of the session. Evidence: the session's cache file had `environment: null` persisted.

### Bug 2: rig drops rtk's exit-3 "Ask" rewrites — losing all git commands

rtk's rewrite protocol (`src/hooks/rewrite_cmd.rs`) is a four-code permission protocol:

| Exit | Stdout | Meaning |
|------|--------|---------|
| 0 | rewrite | Rewrite, safe to auto-allow |
| 1 | none | No RTK equivalent |
| 2 | none | Deny rule matched |
| 3 | rewrite | "Ask" — rewrite valid, must not be auto-allowed |

rtk deliberately maps commands without an explicit allow rule — **all git commands** — to Ask (exit 3). rig only understood 0/1/2 and discarded every exit-3 rewrite, logging it as an anomaly in `/tmp/rig-rtk-rewrite-failures.log`. Since rig never auto-allows (it emits `updatedInput` without a `permissionDecision`), using exit-3 rewrites like exit-0 rewrites is exactly faithful to rtk's reference hook.

## Changes

- `src/session/cache.ts` — retain stale environment as last-known-good on load; `isEnvironmentStale()` still drives SessionStart re-detection
- `src/router/hook.ts` — `makeDefaultExecRewrite` implements the full four-code protocol: exit 3 + stdout is used as a rewrite, exit 2 never uses stdout, exit 3 without output is diag-logged
- `docs/architecture.md` — documents the real rtk contract

## Test suite augmentation

- Long-session regression tests at the cache layer and through the full hook path (a 5h-old persisted cache must still rewrite)
- Exit-code protocol unit tests, including Buffer stdout and deny-with-output edge cases
- New `tests/integration/rtk-contract.test.ts`: probes the **installed** rtk binary's exit codes plus end-to-end `makeDefaultExecRewrite` recovery of `rtk git status` (skipped when rtk absent) — future protocol drift fails at dev/CI time instead of in the field
- Three tests no longer spawn the real rtk path; they previously passed only because the spawn failed (ENOENT) and polluted the field diag log on every `npm test`

## Verification

- 1133/1133 tests pass (49 files), `tsc --noEmit` clean
- `/tmp/rig-rtk-rewrite-failures.log` no longer grows during test runs
- Contract test verified live against rtk 0.39.0

Note: sessions that already persisted `environment: null` regain routing on their next SessionStart (restart/resume); the fix prevents recurrence but cannot resurrect an already-nulled cache mid-session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)