### PR TITLE
chore: bump version to 0.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rig",
-  "version": "0.3.10",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rig",
-      "version": "0.3.10",
+      "version": "0.4.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rig",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Agent harness that enforces tool routing, skill chains, and multi-agent discipline in Claude Code",
   "type": "module",
   "main": "dist/cli/index.js",


### PR DESCRIPTION
Version bump for the 0.4.1 patch release. Includes the rtk routing fixes from #32 (stale-env retention past the 4h TTL, rtk exit-3 Ask-verdict rewrites). Also syncs package-lock.json, which was still at 0.3.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)