### PR TITLE
chore: 0.5.0 — design-process to docs, agent-loops documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,3 +58,5 @@ All types in `src/types.ts`. Important ones:
 - @docs/getting-started.md -- Installation and usage guide
 - @docs/extending.md -- Custom enforcement checks, skills, and agents
 - @docs/skill-wrapping.md -- Wrapping superpowers skills with project-specific enforcement
+- @docs/agent-loops.md -- Loop-centric development: signal stack, opt-in trajectory, maintainer pattern
+- @docs/design-process.md -- How rig was built (historical reference)

--- a/README.md
+++ b/README.md
@@ -297,35 +297,14 @@ This wires the same guardrails that rig installs for consumers — the tool rout
 intercepts shell commands, the enforcement pipeline runs after edits, and
 `/savings` reports token usage for the session.
 
-## Design process
+## Loop-centric development
 
-Rig was built in seven iterative phases, each evaluated against
-[gstack](https://github.com/garrytan/gstack) — a mature agent skill framework
-used as a reference implementation. The approach was to study gstack's patterns,
-identify patterns worth adopting and avoiding, then build rig with deliberate
-advantages at each layer. The full phase plans and retrospectives are preserved
-in [commit a9ee32f](https://github.com/franklywatson/claude-rig/tree/a9ee32f9b8e78f138aafeb0dd1e13af272c8706e/docs).
-
-| Phase | Layer | Key decision vs gstack |
-| ----- | ----- | ---------------------- |
-| 1 | Foundation | Adopted gstack's injectable env detection; chose hooks over preamble text for enforcement |
-| 2 | Tool Router | Enforceable PreToolUse hooks vs gstack's persuasive preamble routing |
-| 3 | Enforcement | Composable programmatic pipeline vs gstack's monolithic text-based approach |
-| 4 | Scout Agent | Typed `CodebaseMap` vs gstack's unstructured preamble context injection |
-| 5 | Skill Chain | Programmatic state machine wrapping superpowers vs gstack's standalone skill tiers |
-| 6 | CLI Installer | `npx`-first with `/verify-harness` vs gstack's global install, no verification |
-| 7 | CI Guardrails | CI-enforced coverage gates and docs lint vs gstack's in-session-only enforcement |
-
-Every project has different requirements for rigor and oversight. A solo
-prototype needs lighter guardrails than a production system handling financial
-transactions. Some domains demand determinism — non-negotiable rules that can't
-be talked around. Rig lets builders codify their project's non-negotiables as
-enforceable hooks, then rest easy knowing Claude will follow them.
-
-[superpowers](https://github.com/obra/superpowers) and
-[gstack](https://github.com/garrytan/gstack) are excellent tools in their own
-right. Rig doesn't replace them — it complements them by adding a layer of
-programmatic enforcement that preamble-based approaches can't provide.
+Beyond shipping features, rig can steer a project toward a **self-assembling,
+self-maintaining trajectory**: design a layered signal stack during `brain+`,
+order the plan signal-stack-first in `plan+`, execute gate-by-gate with `sdd+`,
+and hand the finished system to an always-on maintainer agent. Strictly opt-in
+— `brain+` only offers it when the project fits. See
+[docs/agent-loops.md](docs/agent-loops.md) for the full model.
 
 ## Extending rig
 

--- a/docs/agent-loops.md
+++ b/docs/agent-loops.md
@@ -1,0 +1,97 @@
+# Agent Loops & the Signal Stack
+
+How rig supports loop-centric development: projects that don't just get built,
+but **self-assemble against their own test signals and stay healthy under an
+always-on maintainer agent**. This is the user-facing guide; the design
+vocabulary the skills load at runtime is installed into
+`.claude/skills/brain-plus/references/agent-loops.md` (and the same file under
+`plan-plus/`) by `rig init`.
+
+The model is strictly **opt-in**. `brain+` assesses fit silently and asks
+once, only when fit signals are present. Declining costs nothing, and nothing
+about the loop is ever enforced by hooks — it is a design trajectory, not a
+rule.
+
+## The model
+
+**Primary system vs subordinate loop.** The primary system is the thing being
+built. It must be complete and operable entirely on its own — human-driveable
+with no dependency on any automation around it. The agentic loop is a
+subordinate layer with one top-level goal, set by you (the orchestrator):
+*self-assemble the primary system from the approved spec, then keep it
+conformant and healthy.* Disabling the loop changes nothing about the primary
+system.
+
+**The signal stack.** Layered test signals, each isolating exactly one failure
+source. Projects include only the layers that apply:
+
+| Layer | What's tested | Signal | A failure here means |
+| ----- | ------------- | ------ | -------------------- |
+| L0 — Deterministic logic | Golden tests: known inputs to exact outputs | binary pass/fail | code regression |
+| L1 — External contract | Read-only probes of third-party APIs | contract diff report | the dependency changed, not us |
+| L2 — Evaluation quality | Calibration harness for model components | drift metrics vs thresholds | model shift or prompt regression |
+| L3 — Integration | Dry-run end-to-end, everything except writes | stage-by-stage trace | wiring/config/auth — the seams |
+| L4 — Production telemetry | Structured metrics from every real run | trend series | input drift vs system drift |
+
+Classic stack/E2E tests are the L3 instrument. Docker services and full-loop
+assertions are instrumentation for whichever layers a feature touches.
+
+**Triangulation.** Cross-layer failure patterns localize faults by
+construction: L2 failing while L0 passes means the model layer moved, not the
+code. L3 failing while L1 passes means our integration broke, not the
+dependency. L4 shifting while L2 is stable means the inputs changed — don't
+"fix" anything. Each opted-in design records its own truth table.
+
+**Two phases, one goal.** *Assembly:* the stack is built first, and the
+assembly process uses it to verify itself as it builds — each stage gated by
+its layer's signal. *Sustain:* a scheduled maintainer agent runs the same
+stack, triangulates, and acts by graduated autonomy — heartbeat when healthy,
+structured diagnosis when degraded, and for code fixes a PR through the same
+CI gates as human work. It never edits the live system directly, and policy
+artifacts (rubrics, thresholds) are flagged, never edited.
+
+## How the skill chain carries it
+
+| Phase | Loop-aware behavior |
+| ----- | ------------------- |
+| `brain+` | Assesses loop fit within its own reasoning (headless/scheduled operation, external contracts, model components, long-lived operation). Asks the opt-in question once when fit. On opt-in, the design gains a signal-stack section, a primary/loop boundary statement, and an autonomy ceiling. |
+| `plan+` | Orders opted-in plans **signal-stack-first**: harness tasks come before or alongside the features they gate. Every task names its gating signal. The maintainer deployment is a late task; rollout gates (credentials, schedules, live writes) are reserved to you. |
+| `sdd+` | Executes the plan via typed subagents (implementer, spec-reviewer, code-reviewer). When the plan defines a signal stack, each task's completion gate is its named signal — the implementer must run it and show output. |
+| `tdd+` | Same gating-signal rule for inline execution. |
+| `verify+` | Runs every applicable layer's signal and reports each layer's result (pass / diff / drift / trace). |
+
+The maintainer agent itself is deliberately **not** shipped as a rig template:
+its schedule, tools (e.g., a repo as a tool with a vault-held token), and
+rollout gates are deeply project-specific. Rig ships the thinking framework;
+each opted-in project designs its own maintainer during `brain+`. If a common
+shape emerges across projects, a `loop+` skill and maintainer template are the
+natural next iteration.
+
+## When it fits — and when it doesn't
+
+The pattern pays for headless or scheduled systems, systems with external API
+contracts, model/evaluation components, and long-lived operation where drift
+is the dominant failure mode. It does not pay for one-off scripts, interactive
+UI applications, or libraries — `brain+` will not offer it for these.
+
+## How this is tested today
+
+Deterministic coverage lives in `tests/cli/template-content.test.ts` and
+`tests/cli/init.test.ts`: the opt-in question and fit guidance exist in
+`brain+`, the signal-stack-first ordering exists in `plan+`, the gating-signal
+rules exist in `sdd+`/`tdd+`/`verify+`, and `rig init` installs the reference
+into both consuming skills.
+
+What deterministic tests cannot cover is **behavior**: does `brain+` actually
+ask the opt-in question for a fitting project and stay silent for a CLI tool?
+That requires scenario-based evaluation — scripted non-interactive sessions
+(`claude -p`) run against fixture project descriptions, asserting on the
+elicitation behavior and the produced design sections. This eval harness is
+tracked as future work; until it exists, the loop behavior is validated by
+dogfooding on real projects.
+
+## Related
+
+- [architecture.md](architecture.md) — Layer 3 (skill chain) and the typed agents that execute loop plans
+- [skill-wrapping.md](skill-wrapping.md) — how the chain wraps superpowers skills
+- [design-process.md](design-process.md) — how rig itself was built

--- a/docs/design-process.md
+++ b/docs/design-process.md
@@ -1,0 +1,45 @@
+# Design Process
+
+How rig was built, and the philosophy behind it. Moved here from the README;
+this is historical reference, not usage documentation.
+
+## Seven phases against a reference implementation
+
+Rig was built in seven iterative phases, each evaluated against
+[gstack](https://github.com/garrytan/gstack) — a mature agent skill framework
+used as a reference implementation. The approach was to study gstack's patterns,
+identify patterns worth adopting and avoiding, then build rig with deliberate
+advantages at each layer. The full phase plans and retrospectives are preserved
+in [commit a9ee32f](https://github.com/franklywatson/claude-rig/tree/a9ee32f9b8e78f138aafeb0dd1e13af272c8706e/docs).
+
+| Phase | Layer | Key decision vs gstack |
+| ----- | ----- | ---------------------- |
+| 1 | Foundation | Adopted gstack's injectable env detection; chose hooks over preamble text for enforcement |
+| 2 | Tool Router | Enforceable PreToolUse hooks vs gstack's persuasive preamble routing |
+| 3 | Enforcement | Composable programmatic pipeline vs gstack's monolithic text-based approach |
+| 4 | Scout Agent | Typed `CodebaseMap` vs gstack's unstructured preamble context injection |
+| 5 | Skill Chain | Programmatic state machine wrapping superpowers vs gstack's standalone skill tiers |
+| 6 | CLI Installer | `npx`-first with `/verify-harness` vs gstack's global install, no verification |
+| 7 | CI Guardrails | CI-enforced coverage gates and docs lint vs gstack's in-session-only enforcement |
+
+A later cycle (v0.5.0) added typed subagent dispatch and the loop-aware skill
+chain — see the spec and plan under `docs/superpowers/` for that design's
+decision log.
+
+## Philosophy
+
+Every project has different requirements for rigor and oversight. A solo
+prototype needs lighter guardrails than a production system handling financial
+transactions. Some domains demand determinism — non-negotiable rules that can't
+be talked around. Rig lets builders codify their project's non-negotiables as
+enforceable hooks, then rest easy knowing Claude will follow them.
+
+[superpowers](https://github.com/obra/superpowers) and
+[gstack](https://github.com/garrytan/gstack) are excellent tools in their own
+right. Rig doesn't replace them — it complements them by adding a layer of
+programmatic enforcement that preamble-based approaches can't provide.
+
+## Related
+
+- [architecture.md](architecture.md) — the resulting system design
+- [agent-loops.md](agent-loops.md) — the loop-centric operating model added in v0.5.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rig",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rig",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rig",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Agent harness that enforces tool routing, skill chains, and multi-agent discipline in Claude Code",
   "type": "module",
   "main": "dist/cli/index.js",


### PR DESCRIPTION
Bumps version to 0.5.0 following #34.

- Drops the Design Process section from the README (now a historical reference at docs/design-process.md)
- Adds docs/agent-loops.md — the missing user-facing documentation for the loop-centric model (signal stack, triangulation, how each chain phase carries it, fit guidance, current test coverage and the eval-harness gap)
- README gains a short Loop-centric development section pointing at the new doc
- CLAUDE.md doc list updated so both new docs pass the reachability gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)