### PR TITLE
fix: block file_modify in every segment of compound commands

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -114,7 +114,10 @@ signals, ENOENT) is appended as a JSON line to
 `/tmp/rig-rtk-rewrite-failures.log` so silent fallthroughs are
 debuggable in the field. Set `RIG_DEBUG=1` to log expected declines too.
 Compound commands (pipes, `&&`, `;`) skip the rewrite entirely — the router
-cannot safely rewrite one segment of a pipeline.
+cannot safely rewrite one segment of a pipeline. Blocks are different:
+destructive operations (`sed -i`, awk redirects) are detected in **every**
+quote-aware segment of a compound command, so `echo ok && sed -i ...` is
+blocked even though it would never be rewritten.
 
 ---
 

--- a/src/router/intent.ts
+++ b/src/router/intent.ts
@@ -43,6 +43,19 @@ const TOOL_INTENT_MAP: Record<string, IntentType> = {
 };
 
 function classifyBashCommand(command: string): IntentType {
+  // Destructive operations are flagged wherever they appear in a chain — a
+  // sed -i behind `&&`, `;`, or a pipe still modifies files. Scan every
+  // quote-aware segment for file_modify before positional classification.
+  for (const segment of splitCompoundSegments(command)) {
+    const trimmed = segment.trim();
+    for (const { pattern, intent } of BASH_INTENT_PATTERNS) {
+      if (pattern.test(trimmed)) {
+        if (intent === 'file_modify') return 'file_modify';
+        break; // first matching pattern decides this segment
+      }
+    }
+  }
+
   // Only classify the first segment (before any pipe).
   // grep/find/cat on the right side of | is output filtering, not code search.
   const pipeIndex = command.indexOf('|');
@@ -77,6 +90,56 @@ function classifyBashCommand(command: string): IntentType {
   }
 
   return highest;
+}
+
+/**
+ * Split a command into segments on chaining/piping operators (`&&`, `||`,
+ * `;`, `|`) that appear outside quoted strings. Mirrors isCompoundCommand's
+ * quote handling so operators inside quotes never produce false segments.
+ */
+export function splitCompoundSegments(command: string): string[] {
+  const segments: string[] = [];
+  let inSingle = false;
+  let inDouble = false;
+  let start = 0;
+  let i = 0;
+
+  while (i < command.length) {
+    const ch = command[i];
+
+    if (ch === '\'' && !inDouble) {
+      inSingle = !inSingle;
+      i++;
+      continue;
+    }
+    if (ch === '"' && !inSingle) {
+      inDouble = !inDouble;
+      i++;
+      continue;
+    }
+    if (inSingle || inDouble) {
+      i++;
+      continue;
+    }
+
+    if ((ch === '&' && command[i + 1] === '&') || (ch === '|' && command[i + 1] === '|')) {
+      segments.push(command.slice(start, i));
+      i += 2;
+      start = i;
+      continue;
+    }
+    if (ch === ';' || ch === '|') {
+      segments.push(command.slice(start, i));
+      i += 1;
+      start = i;
+      continue;
+    }
+
+    i++;
+  }
+
+  segments.push(command.slice(start));
+  return segments;
 }
 
 /**

--- a/tests/router/intent.test.ts
+++ b/tests/router/intent.test.ts
@@ -89,6 +89,28 @@ describe('classifyIntent', () => {
     it('still classifies grep && grep as text_search', () => {
       expect(classifyIntent('Bash', { command: 'grep "TODO" src/a.ts && grep "FIXME" src/b.ts' })).toBe('text_search');
     });
+
+    it('classifies sed -i after a pass_through segment as file_modify', () => {
+      expect(
+        classifyIntent('Bash', { command: 'echo "const x = 1;" > /tmp/f.ts && sed -i \'\' \'s/x/y/\' /tmp/f.ts' }),
+      ).toBe('file_modify');
+    });
+
+    it('classifies sed -i after a semicolon as file_modify', () => {
+      expect(classifyIntent('Bash', { command: "cd /tmp; sed -i 's/a/b/' file.ts" })).toBe('file_modify');
+    });
+
+    it('classifies sed -i on the right side of a pipe as file_modify', () => {
+      expect(classifyIntent('Bash', { command: "cat list.txt | sed -i 's/a/b/' file.ts" })).toBe('file_modify');
+    });
+
+    it('classifies awk redirect after && as file_modify', () => {
+      expect(classifyIntent('Bash', { command: "mkdir -p out && awk '{print}' a.txt > out/b.txt" })).toBe('file_modify');
+    });
+
+    it('does not classify quoted sed -i text as file_modify', () => {
+      expect(classifyIntent('Bash', { command: 'echo "run sed -i later && sed -i fake"' })).toBe('pass_through');
+    });
   });
 
   describe('Claude tool classification', () => {


### PR DESCRIPTION
The intent classifier early-returned `pass_through` when the first segment of a compound command was benign, so `echo ok && sed -i 's/x/y/' file.ts` bypassed the `file_modify` block that the bare `sed -i` correctly receives. Found live by `/verify-harness` TR3 (v0.5.0 release verification).

- New `splitCompoundSegments()` — quote-aware split on `&&`/`||`/`;`/`|`, mirroring `isCompoundCommand`'s scanning so quoted operators never produce false segments
- `classifyBashCommand()` pre-scans every segment for destructive patterns (`sed -i`, awk redirects) before positional classification; `echo \"sed -i\"` in quotes stays `pass_through`
- rtk rewrite behavior for compounds unchanged (still skipped — can't rewrite one pipeline segment)
- 5 new tests; suite 1155/1155; live-retested the exact bypass command — now blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)