### PR TITLE
chore: agent turn budgets become runaway backstops; subagent-operations docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ upgrades the three places where process text alone can't reach:
 | | plain superpowers | superpowers through rig |
 | --- | --- | --- |
 | **Enforcement** | Persuasive skill text the agent can rationalize around | PreToolUse/PostToolUse hooks that programmatically block or advise (`.harness.yaml`) |
-| **Subagents** | Every implementer and reviewer dispatched as a general-purpose agent; role and discipline ride inside the prompt | Typed agents in `.claude/agents/`: tool-scoped (reviewers carry no Edit/Write tools), enforcement rules in their system prompt, named in the UI, per-agent turn budgets |
+| **Subagents** | Every implementer and reviewer dispatched as a general-purpose agent; role and discipline ride inside the prompt | Typed agents in `.claude/agents/`: tool-scoped (reviewers carry no Edit/Write tools), enforcement rules in their system prompt, named in the UI, backstop-calibrated turn budgets with partial-status resumption, worktree-isolated implementers (see architecture.md "Subagent operations") |
 | **Trajectory** | The skill chain ends at merge | Opt-in agent-loop trajectory: `brain+`/`plan+` can design a layered signal stack so the system self-assembles gate-by-gate and hands off to an always-on maintainer agent |
 
 The result: the same superpowers workflows, but the review chain is

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -248,6 +248,37 @@ prompts, falling back to general-purpose if the definition is missing.
 `brain+` and `plan+` load `references/agent-loops.md` for the opt-in
 signal-stack / maintainer-loop trajectory.
 
+### Subagent operations
+
+Rig tunes the superpowers workflows for Claude Code's subagent hierarchy —
+the orchestrator session dispatches typed agents, and the operational rules
+below are what make that hierarchy reliable in practice:
+
+- **Turn budgets are runaway backstops, not task estimates.** Each typed
+  agent's `maxTurns` is set 5–10× expected usage (implementer 150, reviewers
+  75/50, scout 30). A cap near expected usage truncates legitimate work
+  silently — the agent's last narration line becomes its "result", which an
+  orchestrator can mistake for completion. Every agent's prompt instructs it
+  to stop at a safe point and report partial status when the budget nears,
+  and truncated agents can be resumed with their context intact.
+- **Code-writing subagents get isolated worktrees.** A long-running
+  implementer shares the checkout's HEAD with the orchestrator — branch
+  state is shared mutable state, and commits land wherever HEAD points at
+  commit time. Dispatch implementers into a worktree; read-only agents
+  (scout, reviewers) don't need isolation.
+- **One implementer at a time per workspace.** Reviewers are read-only and
+  can overlap; implementers cannot.
+- **Enforcement reaches subagents the same way it reaches the orchestrator**:
+  advisories via `additionalContext`, blocks via exit 2, and the typed
+  agents' system prompts instruct reading `.harness.yaml` at runtime.
+
+**Agent teams (forward-looking).** Claude Code's experimental agent-teams
+feature maps naturally onto `sdd+`: genuinely independent plan tasks could
+execute as a team of worktree-isolated implementer teammates sharing a task
+list, with reviewers as teammates and the session as lead. Per the cockpit
+pattern, rig would detect the capability, offer it, and degrade to today's
+sequential dispatch when absent. Tracked as future work; not yet designed.
+
 `debug+` wraps `superpowers:systematic-debugging` with mandatory scout agent
 context harvesting. It maps the affected code area before debugging, ensuring
 the agent has full structural context. Accessible from any phase via `/debug+`.

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/jerome/tools/skills/claude-rig/node_modules

--- a/templates/agents/code-reviewer.md
+++ b/templates/agents/code-reviewer.md
@@ -3,7 +3,7 @@ name: code-reviewer
 description: "Use when dispatched by review+ or sdd+ to review completed work against its plan or requirements. Reviews a git range for plan alignment and code quality. Do not invoke proactively — this agent is dispatched explicitly by the skill chain."
 tools: "mcp__jcodemunch__get_repo_outline,mcp__jcodemunch__get_file_tree,mcp__jcodemunch__get_file_outline,mcp__jcodemunch__search_symbols,mcp__jcodemunch__get_symbol,mcp__jcodemunch__get_symbols,mcp__jcodemunch__search_text,mcp__jcodemunch__list_repos,mcp__graphify__query_graph,mcp__graphify__get_community,mcp__graphify__god_nodes,mcp__graphify__shortest_path,mcp__graphify__graph_stats,Read,Glob,Grep,Bash"
 model: inherit
-maxTurns: 25
+maxTurns: 75
 ---
 
 <!-- rig-generated -->
@@ -90,6 +90,12 @@ trust the rest of the feedback. If you find significant deviations from the
 plan, flag them specifically so the implementer can confirm whether the
 deviation was intentional. If you find issues with the plan itself rather than
 the implementation, say so.
+
+## Turn Budget
+
+Your turn limit is a runaway backstop, not a target. If you are approaching
+it, stop and report partial status: what you reviewed, what remains, and your
+provisional assessment.
 
 ## Output Format
 

--- a/templates/agents/implementer.md
+++ b/templates/agents/implementer.md
@@ -2,7 +2,7 @@
 name: implementer
 description: "Use when dispatched by sdd+ to implement a single plan task: write tests, implement, verify, commit, self-review, report. Do not invoke proactively — this agent is dispatched explicitly by the skill chain."
 model: inherit
-maxTurns: 50
+maxTurns: 150
 ---
 
 <!-- rig-generated -->
@@ -83,6 +83,12 @@ You MUST run the task's scoped tests and show output before reporting
 completion. A claim without command output is not a completed task. If the
 plan defines a signal stack, the task's named gating signal is the completion
 gate — run it.
+
+## Turn Budget
+
+Your turn limit is a runaway backstop, not a target. If you are approaching
+it, stop at a safe point (commit what is verified), and report partial status:
+what is done, what remains, and where to resume.
 
 ## Report Format
 

--- a/templates/agents/scout.md
+++ b/templates/agents/scout.md
@@ -3,7 +3,7 @@ name: scout
 description: "PROACTIVELY use when starting any non-trivial implementation task, when context about the codebase is needed before making changes, or when the user references unfamiliar code. Context harvesting agent that maps codebase structure using jcodemunch, graphify, and rtk for token-efficient exploration."
 tools: "mcp__jcodemunch__get_repo_outline,mcp__jcodemunch__get_file_tree,mcp__jcodemunch__get_file_outline,mcp__jcodemunch__search_symbols,mcp__jcodemunch__get_symbol,mcp__jcodemunch__get_symbols,mcp__jcodemunch__search_text,mcp__jcodemunch__list_repos,mcp__jcodemunch__index_folder,mcp__graphify__query_graph,mcp__graphify__get_community,mcp__graphify__god_nodes,mcp__graphify__shortest_path,mcp__graphify__graph_stats,Read,Glob,Grep,Bash"
 model: inherit
-maxTurns: 15
+maxTurns: 30
 ---
 
 <!-- rig-generated -->

--- a/templates/agents/spec-reviewer.md
+++ b/templates/agents/spec-reviewer.md
@@ -3,7 +3,7 @@ name: spec-reviewer
 description: "Use when dispatched by review+ or sdd+ to verify an implementation matches its specification — nothing more, nothing less. Do not invoke proactively — this agent is dispatched explicitly by the skill chain."
 tools: "mcp__jcodemunch__get_repo_outline,mcp__jcodemunch__get_file_tree,mcp__jcodemunch__get_file_outline,mcp__jcodemunch__search_symbols,mcp__jcodemunch__get_symbol,mcp__jcodemunch__get_symbols,mcp__jcodemunch__search_text,mcp__jcodemunch__list_repos,mcp__graphify__query_graph,mcp__graphify__get_community,mcp__graphify__god_nodes,mcp__graphify__shortest_path,mcp__graphify__graph_stats,Read,Glob,Grep,Bash"
 model: inherit
-maxTurns: 15
+maxTurns: 50
 ---
 
 <!-- rig-generated -->
@@ -63,6 +63,12 @@ stack/E2E tests, evidence standards).
 You MUST read every file the implementer reports as changed (and check
 `git diff` / `git show` for files they didn't mention) before issuing a
 verdict. Verify by reading code, not by trusting the report.
+
+## Turn Budget
+
+Your turn limit is a runaway backstop, not a target. If you are approaching
+it, stop and report partial status: what you verified, what remains, and your
+provisional verdict.
 
 ## Output Format
 

--- a/tests/cli/template-content.test.ts
+++ b/tests/cli/template-content.test.ts
@@ -41,6 +41,21 @@ describe('agent templates', () => {
     expect(content).toContain('show output before reporting');
     expect(content).toContain('BLOCKED');
   });
+
+  it('agents carry backstop-level turn budgets with partial-status guidance', () => {
+    const budgets: Record<string, number> = {
+      'code-reviewer': 75,
+      'spec-reviewer': 50,
+      'implementer': 150,
+    };
+    for (const [agent, turns] of Object.entries(budgets)) {
+      const content = read(`agents/${agent}.md`);
+      expect(content).toContain(`maxTurns: ${turns}`);
+      expect(content).toContain('runaway backstop');
+      expect(content).toContain('partial status');
+    }
+    expect(read('agents/scout.md')).toContain('maxTurns: 30');
+  });
 });
 
 describe('skill templates — typed dispatch', () => {

--- a/tests/scout/agent-definition.test.ts
+++ b/tests/scout/agent-definition.test.ts
@@ -18,7 +18,7 @@ describe('scout agent definition', () => {
     const frontmatter = content.split('---')[1];
     expect(frontmatter).toContain('name: scout');
     expect(frontmatter).toContain('model: inherit');
-    expect(frontmatter).toContain('maxTurns: 15');
+    expect(frontmatter).toContain('maxTurns: 30');
   });
 
   it('specifies jcodemunch and bash tools', () => {


### PR DESCRIPTION
Recalibrates typed-agent `maxTurns` from task-size budgets to runaway backstops (5–10× expected usage): implementer 50→150, code-reviewer 25→75, spec-reviewer 15→50, scout 15→30. Three typed-agent dispatches truncated silently mid-work today — the cap near expected usage turns legitimate work into silent partial results, with the agent's last narration line masquerading as a report. Each agent's prompt now carries partial-status guidance for when the budget nears.

Also adds the **Subagent operations** section to docs/architecture.md — backstop semantics, worktree isolation for code-writing subagents, one-implementer-at-a-time, enforcement channels reaching subagents, and the forward-looking agent-teams mapping for sdd+ — and points the README's superpowers-comparison table at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)