### PR TITLE
fix: untrack accidentally-committed node_modules symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-node_modules/
+# no trailing slash: must also match a stray node_modules symlink, not just the directory
+node_modules
 dist/
 coverage/
 *.js.map

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/jerome/tools/skills/claude-rig/node_modules


### PR DESCRIPTION
PR #38's worktree build symlinked node_modules; `.gitignore`'s trailing-slash pattern matches directories only, so `git add -A` swept the symlink into `e5461ff`. Anyone checking out master gets a dangling/self-pointing symlink in place of node_modules — locally this broke every npx-based hook until reinstall. Untracks it and drops the trailing slash so symlinks are ignored too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)