### PR TITLE
feat: configurable branch/PR discipline with isolation strategy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,9 +17,9 @@ npm run lint       # Type-check (tsc --noEmit)
 
 Four-layer middleware:
 
-1. **Tool Router** (`src/router/`) -- PreToolUse hook, intent classification, priority resolution (rtk > jcodemunch > claudeTool > fallback > allow)
-2. **Enforcement** (`src/enforcement/`) -- PostToolUse hook, composable pipeline: stale tests -> test scope -> constitutional -> zero-defect
-3. **Skill Chain** (`src/skills/`) -- Phase tracker validates transitions (brain+ -> plan+ -> tdd+ -> verify+ -> review+)
+1. **Tool Router** (`src/router/`) -- PreToolUse hook: intent classification, priority resolution (rtk > jcodemunch > claudeTool > fallback > allow), test-scope and branch-discipline checks
+2. **Enforcement** (`src/enforcement/`) -- PostToolUse hook, composable pipeline: stale tests -> constitutional -> zero-defect
+3. **Skill Chain** (`src/skills/`) -- Phase tracker validates transitions (brain+ -> plan+ -> tdd+|sdd+ -> verify+ -> review+; debug+ standalone)
 4. **Scout** (`src/scout/`) -- Cross-repo indexing, CodebaseMap formatter, TTL cache
 
 Supporting: `src/config.ts` (YAML config), `src/session/` (environment detection, session cache), `src/cli/` (init command, template renderer)
@@ -28,10 +28,12 @@ Supporting: `src/config.ts` (YAML config), `src/session/` (environment detection
 
 All types in `src/types.ts`. Important ones:
 
-- `IntentType` -- file_read, text_search, file_discovery, file_modify, symbol_search, pass_through
+- `IntentType` -- file_read, text_search, file_discovery, file_modify, symbol_search, scout_explore, pass_through, native_read, native_grep, native_glob, rtk_cat_code
 - `EnforcementLevel` -- block, advise, silent
+- `EnforcementViolation` -- { level, message }; severity is structural, never sniffed from message text
 - `Resolution` -- allow, advise, block
 - `ToolRule` -- match pattern + resolutions per environment priority
+- `WorkflowRules` -- branch_discipline, protected_branches, isolation_strategy
 - `CodebaseMap` -- structure, entryPoints, keyExports, dependencies, languages, symbols
 - `HarnessConfig` -- nested rules with enforcement levels
 
@@ -42,7 +44,7 @@ All types in `src/types.ts`. Important ones:
 - Session cache: 4-hour env TTL, file-backed in /tmp keyed by (cwd, session id); scout cache has a separate 30-min TTL
 - All hooks read JSON from stdin, write JSON to stdout (Claude Code hook protocol)
 - Skill templates use `{{VAR}}` substitution via `renderTemplate()`
-- Enforcement levels: block (exit 2), advise (print + exit 0), silent (log + exit 0)
+- Enforcement levels: block (exit 2), advise (agent-visible additionalContext + exit 0), silent (log + exit 0)
 
 ## Testing
 
@@ -59,4 +61,5 @@ All types in `src/types.ts`. Important ones:
 - @docs/extending.md -- Custom enforcement checks, skills, and agents
 - @docs/skill-wrapping.md -- Wrapping superpowers skills with project-specific enforcement
 - @docs/agent-loops.md -- Loop-centric development: signal stack, opt-in trajectory, maintainer pattern
+- @docs/troubleshooting.md -- Diagnosing permission prompts, cache, and detection issues
 - @docs/design-process.md -- How rig was built (historical reference)

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ rules:
     evidence_only: block
   zero_defect:
     tolerance: strict
-    unrelated_errors: silent     # silent|advise|block — how to handle pre-existing failures
+    unrelated_errors: block      # silent|advise|block — how to handle pre-existing failures
   tool_routing:
     native_read: advise        # advise jcodemunch for Read on code files
     native_grep: advise        # advise jcodemunch for Grep
@@ -229,10 +229,11 @@ rules:
     isolation_strategy: auto   # auto | branch | worktree — auto picks worktree when the tree is dirty
 ```
 
-Each enforcement rule can be `block` (hook exits nonzero), `advise` (prints warning),
-or `silent` (logs only). Active enforcement rules are emitted at session start and
-referenced dynamically by skill templates -- set `no_mocks: silent` to disable
-no-mock enforcement entirely.
+Each enforcement rule can be `block` (hook exits nonzero), `advise` (advisory
+emitted to the agent as `additionalContext`), or `silent` (logs only). Active
+enforcement rules are emitted at session start and referenced dynamically by
+skill templates -- set `no_mocks: silent` to disable no-mock enforcement
+entirely.
 
 ## Skill chain
 
@@ -240,16 +241,19 @@ no-mock enforcement entirely.
 | ----- | ------- | ----- |
 | `brain+` | Ideation and requirements | `superpowers:brainstorming` |
 | `plan+` | Implementation planning | `superpowers:writing-plans` |
-| `tdd+` | Test-driven development | `superpowers:tdd` |
+| `tdd+` | Test-driven development | `superpowers:test-driven-development` |
 | `sdd+` | Subagent-driven plan execution (typed implementer/reviewer agents) | `superpowers:subagent-driven-development` |
-| `verify+` | Installation verification | `superpowers:code-reviewer` |
-| `review+` | Code review | `superpowers:code-reviewer` |
+| `verify+` | Implementation verification | `superpowers:verification-before-completion` |
+| `review+` | Code review | `superpowers:requesting-code-review` |
 | `debug+` | Systematic debugging | `superpowers:systematic-debugging` |
 | `savings` | Session token savings report | -- |
 | `investigate` | Alias for `debug+` | -- |
 
-Skills enforce phase transitions: `tdd+` requires prior `plan+` visit, `verify+`
-requires prior `tdd+` or `sdd+` visit. `sdd+` is a peer of `tdd+` for plans with
+The chain is ordered by convention, with one tracked gate: `verify+` requires a
+prior `tdd+` or `sdd+` visit; every other transition is free (`review+` and
+`debug+` work from any phase). The ordering is carried by each skill's
+procedure text plus the phase tracker's transition rules — no hook blocks an
+out-of-order skill invocation. `sdd+` is a peer of `tdd+` for plans with
 independent tasks -- it executes each task via typed subagents (implementer ->
 spec-reviewer -> code-reviewer). `debug+`, `savings`, and `investigate` are
 standalone (no phase prerequisite). `debug+` mandates scout context harvesting.
@@ -266,7 +270,11 @@ standalone (no phase prerequisite). `debug+` mandates scout context harvesting.
       session-start.ts   # Auto-indexing
   skills/
     brain-plus/          # brain+ skill
+      references/
+        agent-loops.md   # Signal-stack / maintainer-loop design vocabulary
     plan-plus/           # plan+ skill
+      references/
+        agent-loops.md   # Same reference, installed for plan+
     tdd-plus/            # tdd+ skill
     sdd-plus/            # sdd+ skill (typed subagent execution)
     verify-plus/         # verify+ skill
@@ -280,6 +288,7 @@ standalone (no phase prerequisite). `debug+` mandates scout context harvesting.
     code-reviewer.md     # Typed code-quality reviewer (read-only)
     spec-reviewer.md     # Typed spec-compliance reviewer (read-only)
     implementer.md       # Typed task implementer
+.harness.yaml            # Enforcement configuration (project root)
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Rig installs the cockpit into a Claude Code project:
   advises on native Read/Grep/Glob when jcodemunch is indexed; blocks `sed -i` and `rtk cat` on code files
 - **Enforcement Pipeline** -- PostToolUse hooks check stale tests, constitutional rules (real dependencies in stack/E2E tests),
   and zero-defect status (with pre-existing failure classification); a PreToolUse test-scope check redirects full-suite runs
-  to scoped tests during `tdd+`/`sdd+`. Advisories reach the agent as `additionalContext`; blocks exit 2
+  to scoped tests during `tdd+`/`sdd+`, and configurable branch/PR discipline with worktree-aware isolation advice guards
+  commits on protected branches. Advisories reach the agent as `additionalContext`; blocks exit 2
 - **Skill Chain** -- ordered workflow skills: `brain+` -> `plan+` -> `tdd+` -> `verify+` -> `review+`, plus standalone `investigate` and `savings`,
   and `sdd+` for subagent-driven plan execution via typed agents (`code-reviewer`, `spec-reviewer`, `implementer`) installed into `.claude/agents/`
 - **Scout Agent** -- cross-repo indexing agent that builds a typed `CodebaseMap`
@@ -222,6 +223,10 @@ rules:
     native_grep: advise        # advise jcodemunch for Grep
     native_glob: advise        # advise jcodemunch for Glob on code patterns
     rtk_cat_code: block        # block rtk cat on code files
+  workflow:
+    branch_discipline: advise  # block | advise | silent — git commit/push on a protected branch
+    protected_branches: [master, main]
+    isolation_strategy: auto   # auto | branch | worktree — auto picks worktree when the tree is dirty
 ```
 
 Each enforcement rule can be `block` (hook exits nonzero), `advise` (prints warning),

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,7 +56,7 @@ PreToolUse Hook (handlePreToolUse)
 HookResult: { decision, reason } | { type: "rewrite", command }
 ```
 
-**Files:** `src/router/intent.ts`, `src/router/rules.ts`, `src/router/resolver.ts`, `src/router/hook.ts`
+**Files:** `src/router/intent.ts`, `src/router/rules.ts`, `src/router/resolver.ts`, `src/router/hook.ts`, `src/router/branch-discipline.ts`
 
 ### Intent types
 
@@ -118,6 +118,23 @@ cannot safely rewrite one segment of a pipeline. Blocks are different:
 destructive operations (`sed -i`, awk redirects) are detected in **every**
 quote-aware segment of a compound command, so `echo ok && sed -i ...` is
 blocked even though it would never be rewritten.
+
+### Branch discipline (commit-time)
+
+A Step 1.6 check (`src/router/branch-discipline.ts`, between the test-scope
+check and the rewrite steps) intercepts `git commit` and `git push` when the
+live branch is in `rules.workflow.protected_branches`. Like the destructive-op
+blocks, it scans **every** quote-aware compound segment, so
+`cd /tmp && git commit -m "x"` is still caught while `echo "git commit"`
+(quoted) is not. At `advise` level (the default) the recommendation — a
+worktree or a feature branch, resolved by `isolation_strategy` (`auto` picks
+worktree when the working tree is dirty) — reaches the agent **once per
+session** via the agent-visible `additionalContext` channel
+(`hasAdvised('branch_discipline')` suppresses repeats); the commit proceeds.
+At `block` level the command is rejected (exit 2) with remediation text every
+time; `silent` disables the check. It runs before the rewrite steps because a
+block must win over a rewrite. Git probes use the injectable `ExecFn`; any
+git failure (not a repo, git missing) makes the check a no-op.
 
 ---
 
@@ -457,6 +474,18 @@ warning when `~/.code-index` holds data but no transport works. A `[HINT]`
 is emitted when graphify is not installed. `SessionCache` provides
 `getGraphifyStats(dir)` and `setGraphifyStats(dir, stats)` accessors for
 per-directory graphify data.
+
+Session start also runs `checkBranchDiscipline` (`src/session/worktree.ts`):
+when the session opens on a branch listed in
+`rules.workflow.protected_branches` (default `master`/`main`), it emits a
+one-line hint naming the active level and the recommended isolation —
+worktree vs feature branch, resolved by `isolation_strategy` (`worktree` and
+`branch` force the answer; `auto` recommends a worktree when `git status
+--porcelain` shows a dirty tree, a plain branch otherwise). `silent` level
+suppresses the hint; outside a git repo it is a no-op. The same
+`rules.workflow` config drives the tool router's commit-time check (Layer 1,
+Step 1.6). `checkWorktreeSuggestion` remains as a deprecated wrapper over the
+default config.
 
 ### CLI (`src/cli/`)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -306,8 +306,14 @@ below are what make that hierarchy reliable in practice:
   state is shared mutable state, and commits land wherever HEAD points at
   commit time. Dispatch implementers into a worktree; read-only agents
   (scout, reviewers) don't need isolation.
-- **One implementer at a time per workspace.** Reviewers are read-only and
-  can overlap; implementers cannot.
+- **One implementer per branch/worktree — not one globally.** Within a single
+  plan on a single branch, implementers run sequentially: tasks routinely
+  share files and a merge chain, and two writers on one branch race. Across
+  *orthogonal work items* — different branches, disjoint files, no
+  merge-order dependency — implementers may run concurrently, each in its
+  own worktree. The parallelization heuristic: read-only agents (scout,
+  reviewers) are always parallelizable; implementers are parallelizable
+  across branches; serialize only within a branch or across a merge chain.
 - **Enforcement reaches subagents the same way it reaches the orchestrator**:
   advisories via `additionalContext`, blocks via exit 2, and the typed
   agents' system prompts instruct reading `.harness.yaml` at runtime.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,8 +28,23 @@ User types: grep -r "TODO" src/
 PreToolUse Hook (handlePreToolUse)
      |
   +--------------------------------------+
+  | Step 0: Scout explore advisory       |
+  |   Agent(Explore) + jcodemunch ready  |
+  |   -> advise scout subagent           |
+  +--------------------------------------+
+     |
+  +--------------------------------------+
   | Step 1: Resolution blocks            |
   |   file_modify, rtk_cat_code -> block |
+  +--------------------------------------+
+     |
+  +--------------------------------------+
+  | Steps 1.5 + 1.6: Bash preflight      |
+  |   1.5: test scope (tdd+/sdd+ phase)  |
+  |   1.6: branch discipline (git        |
+  |        commit/push, protected branch)|
+  |   collect-then-pick: any block wins  |
+  |   over any advisory                  |
   +--------------------------------------+
      |
   +--------------------------------------+
@@ -46,6 +61,8 @@ PreToolUse Hook (handlePreToolUse)
      |
   +--------------------------------------+
   | Step 4: No match -> pass through     |
+  |   4b: compound command -> skip       |
+  |       advisory (blocks already won)  |
   +--------------------------------------+
      |
   +--------------------------------------+
@@ -53,7 +70,9 @@ PreToolUse Hook (handlePreToolUse)
   |   jcodemunch ready? -> advise jm     |
   +--------------------------------------+
      |
-HookResult: { decision, reason } | { type: "rewrite", command }
+Emitted via hook protocol: advisory -> additionalContext JSON (exit 0)
+                           block    -> stderr + exit 2
+                           rewrite  -> updatedInput JSON (exit 0)
 ```
 
 **Files:** `src/router/intent.ts`, `src/router/rules.ts`, `src/router/resolver.ts`, `src/router/hook.ts`, `src/router/branch-discipline.ts`
@@ -70,6 +89,10 @@ HookResult: { decision, reason } | { type: "rewrite", command }
 | `file_discovery` | Bash `find`, `fd` | jcodemunch `get_file_tree` |
 | `file_read` | Bash `cat`, `head`, `tail` | rtk or jcodemunch `get_symbol` |
 | `file_modify` | Bash `sed -i`, `awk >` | Block, redirect to Edit tool |
+| `scout_explore` | `Agent` tool dispatching the `Explore` subagent | Advise scout subagent (jcodemunch + graphify) |
+
+Git `commit`/`push` interception is not an intent type — it is handled by the
+branch-discipline step (Step 1.6, see "Branch discipline (commit-time)" below).
 
 ### Python environment detection
 
@@ -504,23 +527,25 @@ npx rig init
 initCommand(options)
      |
 copyTemplate() for each:
-  - hooks/pre-tool-use.ts
-  - hooks/post-tool-use.ts
-  - hooks/session-start.ts
-  - skills/brain-plus/SKILL.md
-  - skills/plan-plus/SKILL.md
-  - skills/tdd-plus/SKILL.md
-  - skills/verify-plus/SKILL.md
-  - skills/review-plus/SKILL.md
-  - skills/verify-harness/SKILL.md
-  - skills/savings/SKILL.md
-  - agents/scout.md
+  - hooks: pre-tool-use.ts, post-tool-use.ts, session-start.ts
+  - skills (10): brain-plus, plan-plus, tdd-plus, sdd-plus,
+    verify-plus, review-plus, debug-plus, verify-harness,
+    savings, investigate
+  - agents (4): scout.md, code-reviewer.md, spec-reviewer.md,
+    implementer.md
+  - references: agent-loops.md installed into
+    skills/brain-plus/references/ and skills/plan-plus/references/
      |
 renderTemplate() replaces {{VAR}} placeholders
      |
 updateSettingsJson() registers hooks in .claude/settings.json
      |
 Writes .harness.yaml with default enforcement config
+  (only if absent — never reset, even with --force)
+     |
+Creates graphify-out/ (graph built on demand)
+     |
+Updates .gitignore with the rig-managed section
 ```
 
 ---
@@ -536,15 +561,13 @@ Key design decisions:
 | File-backed cache in /tmp | Cross-process state sharing; hooks are separate processes that need shared state. OS cleans /tmp automatically. |
 | `npx` over global install | Lower barrier, no global package management |
 | Separate `.harness.yaml` over CLAUDE.md injection | Cleaner separation of concerns, version-controllable |
-| Static SKILL.md templates over resolver pipeline | Simpler for 5 skills; resolver pipeline deferred |
+| Static SKILL.md templates over resolver pipeline | Simpler for 10 skills; resolver pipeline deferred |
 
 ---
 
 ## Known limitations
 
 - No auto-test generation for coverage gaps
-- No mode-aware enforcement (same thresholds regardless of workflow phase)
-- No multi-agent specialist review pattern (single review+ pass)
 - No REPO_MODE awareness (solo vs collaborative)
 - jcodemunch silently caps indexing at 2000 files per folder (`max_folder_files`
   in `~/.code-index/config.jsonc`). Session-start emits a `[WARNING]` when files
@@ -560,7 +583,8 @@ Key design decisions:
   reduce this friction. Without the flag, users will see more approval dialogs —
   this is intentional (opt-in rather than silently granting broad access).
 - **First-occurrence advisory suppression**: The tool router advises jcodemunch/scout
-  once per intent type per session via `hasAdvised()`. If the agent ignores the first
+  once per intent type per session via `hasAdvised()` (branch-discipline advisories
+  are also once-per-session). If the agent ignores the first
   advisory, it receives no further reminders for that session. Config-registration
   detection ensures the advisory fires in the first place; suppression behavior
   itself is tracked for future work (periodic re-advisory or escalating urgency).

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -6,18 +6,31 @@ different non-negotiables. This doc covers how to add your own.
 ## Custom enforcement checks
 
 Enforcement checks are composable functions added to the PostToolUse pipeline.
-Each check follows the same signature:
+Each check follows the same signature, returning rig's structured
+`EnforcementViolation` type (`src/types.ts`):
 
 ```typescript
+// rig's EnforcementViolation (src/types.ts). Declare it locally in your
+// check file — the generated hooks load rig from its dist path, not as a
+// package dependency of your project.
+interface EnforcementViolation {
+  level: 'block' | 'advise';
+  message: string;
+}
+
 function checkFoo(
   filePath: string,
   content: string,
   config: HarnessConfig,
-): string | null
+): EnforcementViolation | null
 ```
 
-Return `null` if the check passes, or a violation message if it fails. The
-pipeline collects all violations and reports them together.
+Return `null` if the check passes, or `{ level, message }` if it fails —
+`level` is `'block'` or `'advise'`. Severity is **structural**: the pipeline
+derives the combined result's level from these values and never sniffs message
+text for prefixes like `[BLOCK]` (messages can embed arbitrary tool output,
+including that literal string). Any block-level violation makes the combined
+result block-level; advisory messages are joined and reported together.
 
 ### Example: secrets scanning
 
@@ -35,35 +48,75 @@ const SECRET_PATTERNS = [
 export function checkSecrets(
   filePath: string,
   content: string,
-): string | null {
+): EnforcementViolation | null {
   // Skip non-source files
   if (/\.lock$|\.map$|package-lock\.json/.test(filePath)) return null;
 
   const match = SECRET_PATTERNS.find(p => p.test(content));
   if (!match) return null;
 
-  return [
-    '[BLOCK] Secrets detected',
-    '',
-    `Pattern matched: ${match.source}`,
-    `File: ${filePath}`,
-    '',
-    'Revoke this credential immediately and use environment variables or',
-    'a secrets manager instead of committing secrets to source.',
-  ].join('\n');
+  return {
+    level: 'block',
+    message: [
+      'Secrets detected',
+      '',
+      `Pattern matched: ${match.source}`,
+      `File: ${filePath}`,
+      '',
+      'Revoke this credential immediately and use environment variables or',
+      'a secrets manager instead of committing secrets to source.',
+    ].join('\n'),
+  };
 }
 ```
 
-Wire it into the post-tool-use hook by calling your check alongside the
-built-in ones:
+### Wiring a check into the installed hook
+
+The hook that `rig init` installs (`.claude/hooks/scripts/post-tool-use.ts`)
+does not contain the checks itself — it parses stdin, loads `.harness.yaml`,
+delegates to rig's compiled `handlePostToolUse` (which runs the built-in
+pipeline and returns one merged `EnforcementViolation | null`), and emits the
+result: block → stderr + exit 2, advise → agent-visible `additionalContext`
+JSON. The seam for a custom check is the generated hook script, around that
+`handlePostToolUse` call — run your check there and merge by level:
 
 ```typescript
+// In .claude/hooks/scripts/post-tool-use.ts (the generated file), after:
+//   const result = handlePostToolUse(input.tool_name, input.tool_input,
+//     tracker, cache, config, execFn);
 import { checkSecrets } from './check-secrets.js';
 
-// Inside the Edit/Write handler in post-tool-use.ts:
-const secretsViolation = checkSecrets(filePath, content);
-if (secretsViolation) violations.push(secretsViolation);
+let custom: EnforcementViolation | null = null;
+if (input.tool_name === 'Edit' || input.tool_name === 'Write') {
+  const filePath = String(input.tool_input?.file_path ?? '');
+  const content = String(
+    input.tool_input?.content ?? input.tool_input?.new_string ?? '',
+  );
+  custom = checkSecrets(filePath, content);
+}
+
+// Merge by level: any block wins; otherwise join advisory messages.
+const violations = [result, custom].filter(Boolean) as EnforcementViolation[];
+if (violations.length > 0) {
+  const level = violations.some(v => v.level === 'block') ? 'block' : 'advise';
+  const message = violations.map(v => v.message).join('\n\n');
+  if (level === 'block') {
+    console.error(message);
+    process.exit(2);
+  }
+  console.log(JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: 'PostToolUse',
+      additionalContext: message,
+    },
+  }));
+}
+process.exit(0);
 ```
+
+Note that `rig init --force` regenerates the hook script, so keep your custom
+checks in separate files (like `check-secrets.ts` above) and re-apply the
+wiring after a re-init.
 
 ### Example: version pinning
 
@@ -76,16 +129,19 @@ const LOOSE_VERSION = /"[^"]+":\s*"\^|~|>=|\*|latest|x\./;
 export function checkVersionPinning(
   filePath: string,
   content: string,
-): string | null {
+): EnforcementViolation | null {
   if (filePath !== 'package.json') return null;
   if (!LOOSE_VERSION.test(content)) return null;
 
-  return [
-    '[ADVISE] Unpinned dependency version detected',
-    '',
-    'Use exact versions (e.g., "1.2.3") instead of ranges (^, ~, >=).',
-    'Unpinned versions introduce non-deterministic builds.',
-  ].join('\n');
+  return {
+    level: 'advise',
+    message: [
+      'Unpinned dependency version detected',
+      '',
+      'Use exact versions (e.g., "1.2.3") instead of ranges (^, ~, >=).',
+      'Unpinned versions introduce non-deterministic builds.',
+    ].join('\n'),
+  };
 }
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -171,7 +171,21 @@ rules:
   zero_defect:
     tolerance: strict
     unrelated_errors: silent     # silent|advise|block — how to handle pre-existing failures
+  workflow:
+    branch_discipline: advise    # block | advise | silent — git commit/push on a protected branch
+    protected_branches: [master, main]
+    isolation_strategy: auto     # auto | branch | worktree
 ```
+
+**Branch discipline (`rules.workflow`):** when you commit or push on a branch
+listed in `protected_branches`, rig advises once per session (or blocks, at
+`block` level; `silent` disables the rule entirely). The same rule drives a
+session-start hint when the session opens on a protected branch.
+`isolation_strategy` controls what rig recommends instead: `worktree` or
+`branch` force one answer, while `auto` reads the signals — a dirty working
+tree means a worktree (keeps in-flight work untangled), plan execution favors
+a worktree (the `tdd+`/`sdd+` preflight), and otherwise a plain feature branch
+is enough.
 
 **Levels:**
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,9 +5,9 @@
 - [Claude Code](https://claude.ai/code) CLI installed and configured
 - Node.js 18+
 - [superpowers](https://github.com/obra/superpowers) -- base skills framework.
-  **Required.** Every skill in the chain (`brain+`, `plan+`, `tdd+`,
-  `verify+`, `review+`) wraps a `superpowers:*` skill. Without superpowers
-  installed, the skill chain will not function.
+  **Required.** Every skill in the chain (`brain+`, `plan+`, `tdd+`, `sdd+`,
+  `verify+`, `review+`, `debug+`) wraps a `superpowers:*` skill. Without
+  superpowers installed, the skill chain will not function.
 - A project you want to add guardrails to
 
 Strongly recommended:
@@ -62,7 +62,9 @@ This generates:
 | `.claude/hooks/scripts/post-tool-use.ts` | Enforcement -- stale tests, constitutional, zero-defect |
 | `.claude/hooks/scripts/session-start.ts` | Auto-indexes your project on session start |
 | `.claude/skills/brain-plus/` | Ideation skill |
+| `.claude/skills/brain-plus/references/agent-loops.md` | Signal-stack / maintainer-loop reference |
 | `.claude/skills/plan-plus/` | Planning skill |
+| `.claude/skills/plan-plus/references/agent-loops.md` | Same reference, installed for plan+ |
 | `.claude/skills/tdd-plus/` | Test-driven development skill |
 | `.claude/skills/sdd-plus/` | Subagent-driven plan execution with typed agents |
 | `.claude/skills/verify-plus/` | Verification skill |
@@ -142,10 +144,12 @@ Skills are invoked as slash commands in Claude Code:
 /investigate -> Alias for /debug+
 ```
 
-Skills enforce ordering. You can't run `/tdd+` until you've visited `/plan+`. You can't run
-`/verify+` until you've visited `/tdd+` or `/sdd+`. `/debug+`, `/savings`, and `/investigate` have no
-prerequisites and work from any phase. `/debug+` mandates scout agent context harvesting
-before debugging.
+The chain is ordered by convention rather than hard gates: each skill's procedure
+text points to the next phase, and the phase tracker's transition rules carry one
+prerequisite — `/verify+` requires a prior `/tdd+` or `/sdd+` visit. All other
+transitions are free. `/debug+`, `/savings`, and `/investigate` have no
+prerequisites and work from any phase. `/debug+` mandates scout agent context
+harvesting before debugging.
 
 `/sdd+` is an alternative to `/tdd+` for plans with independent tasks; `/verify+` accepts
 either path. During `/brain+`, projects that fit the agent-loop pattern are offered an
@@ -170,7 +174,7 @@ rules:
     full_accounting: advise
   zero_defect:
     tolerance: strict
-    unrelated_errors: silent     # silent|advise|block — how to handle pre-existing failures
+    unrelated_errors: block      # silent|advise|block — how to handle pre-existing failures
   workflow:
     branch_discipline: advise    # block | advise | silent — git commit/push on a protected branch
     protected_branches: [master, main]
@@ -182,10 +186,11 @@ listed in `protected_branches`, rig advises once per session (or blocks, at
 `block` level; `silent` disables the rule entirely). The same rule drives a
 session-start hint when the session opens on a protected branch.
 `isolation_strategy` controls what rig recommends instead: `worktree` or
-`branch` force one answer, while `auto` reads the signals — a dirty working
-tree means a worktree (keeps in-flight work untangled), plan execution favors
-a worktree (the `tdd+`/`sdd+` preflight), and otherwise a plain feature branch
-is enough.
+`branch` force one answer, while `auto` resolves on a single signal — a dirty
+working tree means a worktree (keeps in-flight work untangled), a clean tree
+means a plain feature branch (`resolveIsolationStrategy`). Separately from the
+config resolver, the `tdd+`/`sdd+` preflight (skill guidance, not config)
+recommends a worktree when the plan is multi-task or the tree is dirty.
 
 **Levels:**
 
@@ -238,6 +243,9 @@ rig init --force
 ```
 
 This overwrites existing hook and skill templates but preserves your `.harness.yaml` config and any custom settings in `.claude/settings.json`.
+`rig init` never rewrites an existing `.harness.yaml`; new rule sections added
+in later releases (e.g. `workflow:`) apply via built-in defaults even when
+absent from your file.
 
 ## Uninstall
 
@@ -250,9 +258,15 @@ rm -f /tmp/rig-session-*.json /tmp/rig-rtk-rewrite-failures.log
 
 Then remove hook registrations from `.claude/settings.json`. The `init` command added entries under `hooks.PreToolUse` and `hooks.PostToolUse` and `hooks.SessionStart` -- remove those arrays.
 
+Also remove the rig-managed block from `.gitignore` (delimited by
+`# --- rig-managed (do not edit below) ---` / `# --- end rig-managed ---`)
+and the `graphify-out/` directory that `rig init` created.
+
 ## Next steps
 
 - Read [docs/architecture.md](architecture.md) for the full system design
 - Read [docs/extending.md](extending.md) to add custom enforcement checks and skills
 - Read [docs/skill-wrapping.md](skill-wrapping.md) to wrap superpowers skills
   with domain-specific enforcement (security, compliance, performance)
+- Read [docs/troubleshooting.md](troubleshooting.md) when permission prompts,
+  cache state, or tool detection misbehave

--- a/docs/skill-wrapping.md
+++ b/docs/skill-wrapping.md
@@ -46,6 +46,7 @@ brain+                           superpowers:brainstorming
 | `requesting-code-review` | Code quality review | Two-stage review (spec + quality), constitutional checklist, typed code-reviewer/spec-reviewer agent dispatch (tool-scoped, no file edits) |
 | `systematic-debugging` | Structured debugging | Scout-harvested context, no phase prerequisite |
 | `subagent-driven-development` | Per-task subagent execution | Typed implementer/spec-reviewer/code-reviewer dispatch via `sdd+`, enforcement rules in each agent's system prompt, signal-stack gating |
+| `using-git-worktrees` | Workspace isolation | Config-gated, strategy-aware advisory (`rules.workflow`): rig recommends worktree vs branch from tree state and plan context |
 
 Without wrapping, superpowers gives you generic process discipline. With
 wrapping, every phase automatically carries your project's non-negotiables --

--- a/docs/skill-wrapping.md
+++ b/docs/skill-wrapping.md
@@ -232,8 +232,9 @@ just `git push` and hope.
 
 ## Scenario 6: Wrapping unwrapped superpowers skills
 
-Rig wraps 6 of 14 superpowers skills. The remaining 8 are available for
-wrapping with project-specific context:
+Rig wraps eight superpowers skills out of the box (the table above). The rest
+of the superpowers catalog is available for wrapping with project-specific
+context:
 
 ### debug+ (wraps `superpowers:systematic-debugging`)
 

--- a/docs/superpowers/plans/2026-06-12-branch-discipline.md
+++ b/docs/superpowers/plans/2026-06-12-branch-discipline.md
@@ -1,0 +1,371 @@
+# Branch/PR Discipline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Configurable branch/PR discipline — session-start nudge with worktree-vs-branch strategy, once-per-session commit-time advisory (or block), and skill-chain propagation. Spec: `docs/superpowers/specs/2026-06-12-branch-discipline-design.md`.
+
+**Architecture:** New `rules.workflow` config section; `checkWorktreeSuggestion` evolves into config-aware `checkBranchDiscipline`; a new `src/router/branch-discipline.ts` module wires into `handlePreToolUse` (no IntentType changes); template prose + docs.
+
+**Tech Stack:** TypeScript, vitest, injectable `ExecFn` (no mocks).
+
+**Sequencing:** Execute AFTER the enforcement-visibility PR merges (shared hook seam + advisory channel). Task 0 rebases.
+
+## Constitutional Rules for This Plan
+
+Active enforcement: `evidence_only: block`, `zero_defect.unrelated_errors: block`, `no_mocks: advise`, `conditional_assert: block`, `empty_test: block`, `stale_tests: advise`.
+
+- Show command output before claiming any step done
+- Every source change ships with test changes in the same task
+
+## Mock Policy
+
+Stack/E2E (real deps): none — CLI middleware; tests use injectable `ExecFn` and temp dirs per repo convention. Unit tests: no mocking frameworks needed.
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/types.ts` | Modify | `WorkflowRules` interface; `HarnessConfig.rules.workflow` |
+| `src/config.ts` | Modify | `DEFAULT_CONFIG.rules.workflow`; `mergeConfigs` workflow spread |
+| `src/session/worktree.ts` | Modify | `checkBranchDiscipline(cwd, exec, config)` (keep `checkWorktreeSuggestion` as thin deprecated wrapper) |
+| `src/session/start.ts` | Modify | Call site passes `config` |
+| `src/router/branch-discipline.ts` | Create | Commit-time check: detect git commit/push across compound segments, resolve branch+strategy, advise/block |
+| `src/router/hook.ts` | Modify | Wire check into `handlePreToolUse` |
+| `templates/skills/tdd-plus/SKILL.md`, `templates/skills/sdd-plus/SKILL.md` | Modify | Preflight isolation line |
+| `templates/skills/review-plus/SKILL.md` | Modify | PR-preference completion pointer |
+| `tests/session/worktree.test.ts`, `tests/config/*.test.ts`, `tests/router/branch-discipline.test.ts` (new), `tests/hooks/*`, `tests/cli/template-content.test.ts` | Tests | Per-task below |
+| README.md, docs/getting-started.md, docs/architecture.md, docs/skill-wrapping.md | Modify | Spec §8 |
+
+---
+
+### Task 0: Rebase onto post-visibility master
+
+**Files:** none
+
+- [ ] Step 1: Confirm the enforcement-visibility PR is merged: `gh pr list --state merged --limit 3`
+- [ ] Step 2: `git checkout feat/branch-discipline && git rebase master`
+- [ ] Step 3: `npm test` — all pass. Identify the advisory-emission helper that PR introduced (read `templates/hooks/pre-tool-use.ts` and `src/router/hook.ts` for how advise-level output is emitted agent-visibly) — Task 3 reuses it.
+
+### Task 1: Config — `rules.workflow`
+
+**Files:**
+- Modify: `src/types.ts` (after `ZeroDefectRules`, ~line 207), `src/config.ts` (DEFAULT_CONFIG ~line 47, mergeConfigs ~line 77)
+- Test: `tests/config/config.test.ts` (or the existing config test file — locate with `ls tests/config* tests/*config*`)
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+  it('defaults workflow rules: advise, master/main, auto strategy', async () => {
+    const config = await loadConfig('/nonexistent/.harness.yaml');
+    expect(config.rules.workflow?.branch_discipline).toBe('advise');
+    expect(config.rules.workflow?.protected_branches).toEqual(['master', 'main']);
+    expect(config.rules.workflow?.isolation_strategy).toBe('auto');
+  });
+
+  it('merges partial workflow overrides onto defaults', () => {
+    const merged = mergeConfigs(structuredClone(DEFAULT_CONFIG), {
+      rules: { workflow: { branch_discipline: 'block' } },
+    } as HarnessConfig);
+    expect(merged.rules.workflow?.branch_discipline).toBe('block');
+    expect(merged.rules.workflow?.protected_branches).toEqual(['master', 'main']);
+  });
+```
+
+- [ ] **Step 2:** `npx vitest run tests/config*` → FAIL (workflow undefined / type error)
+- [ ] **Step 3: Implement.** `src/types.ts`:
+
+```typescript
+export interface WorkflowRules {
+  branch_discipline?: EnforcementLevel;
+  protected_branches?: string[];
+  isolation_strategy?: 'auto' | 'branch' | 'worktree';
+}
+```
+
+Add `workflow?: WorkflowRules;` to `HarnessConfig.rules`. `src/config.ts` DEFAULT_CONFIG gains:
+
+```typescript
+    workflow: {
+      branch_discipline: 'advise',
+      protected_branches: ['master', 'main'],
+      isolation_strategy: 'auto',
+    },
+```
+
+`mergeConfigs` gains (note: array override replaces, consistent with object-spread semantics):
+
+```typescript
+      workflow: { ...(base.rules.workflow ?? {}), ...override.rules.workflow } as WorkflowRules,
+```
+
+- [ ] **Step 4:** tests pass; `npm run lint` clean
+- [ ] **Step 5:** `git add src/types.ts src/config.ts tests/ && git commit -m "feat: workflow.branch_discipline config rules"`
+
+### Task 2: Session-start — `checkBranchDiscipline`
+
+**Files:**
+- Modify: `src/session/worktree.ts`, `src/session/start.ts:206`
+- Test: `tests/session/worktree.test.ts`
+
+- [ ] **Step 1: Write failing tests** (extend existing file; `makeExec` helper exists). Matrix:
+
+```typescript
+import { checkBranchDiscipline } from '../../src/session/worktree.js';
+import { DEFAULT_CONFIG } from '../../src/config.js';
+
+function cfg(level: string, strategy = 'auto', branches = ['master', 'main']) {
+  const c = structuredClone(DEFAULT_CONFIG);
+  c.rules.workflow = { branch_discipline: level as never, protected_branches: branches, isolation_strategy: strategy as never };
+  return c;
+}
+
+describe('checkBranchDiscipline', () => {
+  it('silent level suppresses the hint entirely', () => {
+    const exec = makeExec({ 'git branch --show-current': 'master', 'git status --porcelain': '' });
+    expect(checkBranchDiscipline('/p', exec, cfg('silent'))).toBe('');
+  });
+
+  it('advise on protected branch with clean tree recommends a feature branch', () => {
+    const exec = makeExec({ 'git branch --show-current': 'master', 'git status --porcelain': '' });
+    const out = checkBranchDiscipline('/p', exec, cfg('advise'));
+    expect(out).toContain('master');
+    expect(out).toContain('branch discipline');
+    expect(out).toContain('feature branch');
+    expect(out).toContain('PR');
+  });
+
+  it('auto strategy recommends worktree when tree is dirty', () => {
+    const exec = makeExec({ 'git branch --show-current': 'main', 'git status --porcelain': ' M src/a.ts\n' });
+    const out = checkBranchDiscipline('/p', exec, cfg('advise'));
+    expect(out).toContain('using-git-worktrees');
+  });
+
+  it('worktree strategy always recommends worktree', () => {
+    const exec = makeExec({ 'git branch --show-current': 'master', 'git status --porcelain': '' });
+    expect(checkBranchDiscipline('/p', exec, cfg('advise', 'worktree'))).toContain('using-git-worktrees');
+  });
+
+  it('respects custom protected_branches', () => {
+    const exec = makeExec({ 'git branch --show-current': 'develop', 'git status --porcelain': '' });
+    expect(checkBranchDiscipline('/p', exec, cfg('advise', 'auto', ['develop']))).toContain('develop');
+  });
+
+  it('returns empty on feature branch and outside git repos', () => {
+    const exec = makeExec({ 'git branch --show-current': 'feat/x', 'git status --porcelain': '' });
+    expect(checkBranchDiscipline('/p', exec, cfg('advise'))).toBe('');
+    const noGit = makeExec({ 'git branch --show-current': new Error('not a repo') });
+    expect(checkBranchDiscipline('/p', noGit, cfg('advise'))).toBe('');
+  });
+});
+```
+
+Keep existing `checkWorktreeSuggestion` tests passing (it becomes a wrapper calling `checkBranchDiscipline` with DEFAULT_CONFIG).
+
+- [ ] **Step 2:** RED run
+- [ ] **Step 3: Implement** in `src/session/worktree.ts`:
+
+```typescript
+import type { HarnessConfig } from '../types.js';
+import { DEFAULT_CONFIG } from '../config.js';
+
+export type ExecFn = (cmd: string) => string;
+
+export function checkBranchDiscipline(cwd: string, exec: ExecFn, config: HarnessConfig): string {
+  const wf = config.rules.workflow ?? DEFAULT_CONFIG.rules.workflow!;
+  const level = wf.branch_discipline ?? 'advise';
+  if (level === 'silent') return '';
+  const protectedBranches = wf.protected_branches ?? ['master', 'main'];
+  try {
+    const branch = exec('git branch --show-current').trim();
+    if (!protectedBranches.includes(branch)) return '';
+    const strategy = resolveIsolationStrategy(wf.isolation_strategy ?? 'auto', exec);
+    const isolation = strategy === 'worktree'
+      ? 'a worktree (/using-git-worktrees) — keeps in-flight work untangled'
+      : 'a feature branch';
+    return `[rig] On ${branch} — branch discipline active (${level}): start feature work on ${isolation}, finish with a PR.`;
+  } catch {
+    return ''; // Not a git repo or git not available
+  }
+}
+
+function resolveIsolationStrategy(strategy: 'auto' | 'branch' | 'worktree', exec: ExecFn): 'branch' | 'worktree' {
+  if (strategy !== 'auto') return strategy;
+  try {
+    return exec('git status --porcelain').trim() ? 'worktree' : 'branch';
+  } catch {
+    return 'branch';
+  }
+}
+
+/** @deprecated use checkBranchDiscipline — kept for compatibility */
+export function checkWorktreeSuggestion(cwd: string, exec: ExecFn): string {
+  return checkBranchDiscipline(cwd, exec, DEFAULT_CONFIG);
+}
+```
+
+Update `src/session/start.ts:206` to `checkBranchDiscipline(cwd, (cmd) => execSync(...), config)` (config is in scope — used at line 201). Adjust any existing worktree tests asserting old wording (they assert `toContain('master')` / `toContain('using-git-worktrees')` — the clean-tree default now says "feature branch"; update those expectations to the new contract, e.g. dirty-exec fixtures where worktree wording is asserted).
+
+- [ ] **Step 4:** GREEN + `npx vitest run tests/session/` all pass
+- [ ] **Step 5:** Commit `feat: config-aware branch discipline hint with isolation strategy`
+
+### Task 3: Commit-time check (PreToolUse)
+
+**Files:**
+- Create: `src/router/branch-discipline.ts`
+- Modify: `src/router/hook.ts` (wire into `handlePreToolUse`)
+- Test: `tests/router/branch-discipline.test.ts` (new)
+
+- [ ] **Step 1: Write failing tests** — new file, follow `tests/router/hook.test.ts` fixture style (SessionCache + config + ExecFn injection; read that file first):
+
+Required cases:
+1. `git commit -m "x"` on master, level advise → returns advisory result containing 'master', 'branch discipline', the strategy recommendation, and `rules.workflow.branch_discipline`; second call returns null (`hasAdvised('branch_discipline')`)
+2. `cd /tmp && git commit -m "x"` on master → still detected (compound segment)
+3. `git push` on main, level block → block result with remediation text
+4. `git commit` on `feat/x` → null
+5. `echo "git commit"` (quoted) → null
+6. `git status` / `git diff` → null (only commit/push)
+7. level silent → null
+8. not a git repo (exec throws) → null
+
+- [ ] **Step 2:** RED run
+- [ ] **Step 3: Implement** `src/router/branch-discipline.ts`:
+
+```typescript
+import { splitCompoundSegments } from './intent.js';
+import type { HarnessConfig } from '../types.js';
+import type { SessionCache } from '../session/cache.js';
+
+export type ExecFn = (cmd: string) => string;
+
+const GIT_WRITE_PATTERN = /^\s*git\s+(commit|push)\b/;
+
+export interface BranchDisciplineResult {
+  level: 'advise' | 'block';
+  message: string;
+}
+
+export function checkBranchDisciplineCommand(
+  command: string,
+  config: HarnessConfig,
+  cache: SessionCache,
+  exec: ExecFn,
+): BranchDisciplineResult | null {
+  const wf = config.rules.workflow;
+  const level = wf?.branch_discipline ?? 'advise';
+  if (level === 'silent') return null;
+  if (!splitCompoundSegments(command).some(s => GIT_WRITE_PATTERN.test(s.trim()))) return null;
+
+  let branch: string;
+  try {
+    branch = exec('git branch --show-current').trim();
+  } catch {
+    return null;
+  }
+  const protectedBranches = wf?.protected_branches ?? ['master', 'main'];
+  if (!protectedBranches.includes(branch)) return null;
+
+  if (level === 'advise') {
+    if (cache.hasAdvised('branch_discipline')) return null;
+    cache.markAdvised('branch_discipline');
+    const strategy = resolveStrategy(wf?.isolation_strategy ?? 'auto', exec);
+    const isolation = strategy === 'worktree'
+      ? 'a worktree (/using-git-worktrees)'
+      : 'a feature branch';
+    return {
+      level: 'advise',
+      message:
+        `[ADVISE] Branch discipline: committing on ${branch}. ` +
+        `Consider ${isolation} and finishing with a PR. ` +
+        `(rules.workflow.branch_discipline — set to silent to disable)`,
+    };
+  }
+
+  return {
+    level: 'block',
+    message:
+      `[BLOCK] Branch discipline: direct ${branch} commits are blocked by config. ` +
+      `Create a feature branch (or worktree via /using-git-worktrees) and open a PR. ` +
+      `(rules.workflow.branch_discipline: block — set to advise/silent to relax)`,
+  };
+}
+
+function resolveStrategy(strategy: 'auto' | 'branch' | 'worktree', exec: ExecFn): 'branch' | 'worktree' {
+  if (strategy !== 'auto') return strategy;
+  try {
+    return exec('git status --porcelain').trim() ? 'worktree' : 'branch';
+  } catch {
+    return 'branch';
+  }
+}
+```
+
+(Adjust `markAdvised` to the actual SessionCache method name — check `src/session/cache.ts:138`.) Wire into `handlePreToolUse` in `src/router/hook.ts` for Bash commands, after the resolution-block step and before rtk rewrite; emit advise via the agent-visible channel the enforcement-visibility PR established, and block via the existing block path. Match the existing return-shape conventions in hook.ts.
+
+- [ ] **Step 4:** GREEN; then e2e: extend `tests/hooks/` pre-tool-use test with one advisory case and one block case (set config in the temp fixture's `.harness.yaml`)
+- [ ] **Step 5:** Commit `feat: commit-time branch discipline advisory/block in tool router`
+
+### Task 4: Skill-chain prose
+
+**Files:**
+- Modify: `templates/skills/tdd-plus/SKILL.md`, `templates/skills/sdd-plus/SKILL.md` (Phase A), `templates/skills/review-plus/SKILL.md` (Skill Chain section)
+- Test: `tests/cli/template-content.test.ts`
+
+- [ ] **Step 1: Failing tests** in the loop-aware describe block:
+
+```typescript
+  it('tdd+ and sdd+ carry the branch-discipline preflight', () => {
+    for (const skill of ['tdd-plus', 'sdd-plus']) {
+      const content = read(`skills/${skill}/SKILL.md`);
+      expect(content).toContain('branch discipline');
+      expect(content).toContain('isolated workspace');
+    }
+  });
+
+  it('review+ prefers a PR when branch discipline is active', () => {
+    expect(read('skills/review-plus/SKILL.md')).toContain('gh pr create');
+  });
+```
+
+- [ ] **Step 2:** RED
+- [ ] **Step 3:** Add to tdd-plus and sdd-plus Phase A (numbered step, exact text):
+
+```markdown
+N. If branch discipline is active (see session-start output) and you are on a
+   protected branch, create an isolated workspace before implementing — a
+   worktree (`superpowers:using-git-worktrees`) when the plan is multi-task or
+   the working tree is dirty, a plain feature branch otherwise.
+```
+
+Add to review-plus Skill Chain section:
+
+```markdown
+- If branch discipline is active, finish with a PR (`gh pr create` via
+  `superpowers:finishing-a-development-branch`) rather than a local merge.
+```
+
+- [ ] **Step 4:** GREEN
+- [ ] **Step 5:** Commit `feat: branch-discipline preflight and PR pointers in skill templates`
+
+### Task 5: Documentation (spec §8)
+
+**Files:** README.md, docs/getting-started.md, docs/architecture.md, docs/skill-wrapping.md
+
+- [ ] Step 1: README Configuration yaml block gains the `workflow:` section (3 keys, comments for levels/strategies); one sentence in "What it does" Enforcement bullet: ", and configurable branch/PR discipline with worktree-aware isolation advice".
+- [ ] Step 2: getting-started "Configure enforcement": add the workflow block to the sample yaml + a short paragraph explaining levels, `protected_branches`, and `auto` strategy signals (dirty tree → worktree; plan execution → worktree; else branch).
+- [ ] Step 3: architecture.md: session-layer paragraph replaces the worktree-hint description with `checkBranchDiscipline` semantics; tool-router section documents the commit-time step (advise once per session via the agent-visible channel; block honors config); note compound-segment scanning.
+- [ ] Step 4: skill-wrapping.md table gains: `| \`using-git-worktrees\` | Workspace isolation | Config-gated, strategy-aware advisory (\`rules.workflow\`): rig recommends worktree vs branch from tree state and plan context |`
+- [ ] Step 5: `npm run lint:md` → 0 errors. Commit `docs: branch discipline configuration and advisory mechanics`
+
+### Task 6: Full verification + PR
+
+- [ ] Step 1: `npm test` (all pass, coverage gate holds), `npm run lint`, `npm run lint:md`, `npm run build`
+- [ ] Step 2: Live smoke: `rig init` dogfood refresh; confirm session cache + hint behavior unchanged for default config
+- [ ] Step 3: Push branch, `gh pr create` (title: "feat: configurable branch/PR discipline with isolation strategy"). Do not merge — report PR URL.
+
+## Verification (overall → spec §10)
+
+1. AC1 — Task 2 matrix (silent off-switch; level/strategy-aware hint)
+2. AC2 — Task 3 cases 1/3/4 (+e2e)
+3. AC3 — Task 2 dirty/clean tests
+4. AC4 — Task 4 content tests
+5. AC5 — Task 5 + Task 6 gates

--- a/docs/superpowers/specs/2026-06-12-branch-discipline-design.md
+++ b/docs/superpowers/specs/2026-06-12-branch-discipline-design.md
@@ -1,0 +1,159 @@
+# Branch/PR Discipline with Isolation Strategy — Design
+
+**Date:** 2026-06-12
+**Status:** Approved
+**Depends on:** the enforcement-visibility fix (advise output via
+`hookSpecificOutput.additionalContext`) — this feature's advisories ride that
+channel and touch the same hook templates, so it lands after that PR merges.
+
+## 1. Problem statement
+
+Nothing in rig steers the agent toward working in branches and finishing with
+PRs. The only related mechanism is `checkWorktreeSuggestion`
+(`src/session/worktree.ts`), an unconditional one-shot session-start hint with
+no config gate, no PR guidance, no commit-time presence, and no strategy
+awareness. Users who want branch discipline as their default have no lever;
+users who don't want the existing hint have no off switch.
+
+The discipline must never be forced: configurable, advisory by default,
+blocking only by explicit choice.
+
+## 2. Decision log (design Q&A, 2026-06-12)
+
+1. **Full lever set** — one rule with three levels covering session start,
+   commit time, and skill-chain propagation.
+2. **Default `advise`** — preserves today's unconditional hint behavior while
+   adding `silent` as the new escape hatch and `block` for strict teams.
+3. **Worktree selection rolled in as a strategy** — the nudge recommends
+   *how* to isolate (plain branch vs `/using-git-worktrees`), with an `auto`
+   mode that picks per situation from cheap signals.
+4. **Docs are in scope** — worktree usage and the advisory mechanics must be
+   documented across README, getting-started, and architecture.
+
+## 3. Configuration
+
+```yaml
+rules:
+  workflow:
+    branch_discipline: advise      # silent | advise | block
+    protected_branches: [master, main]
+    isolation_strategy: auto       # auto | branch | worktree
+```
+
+- `branch_discipline` controls **whether** rig nudges (and whether commit-time
+  enforcement blocks). Default `advise`.
+- `protected_branches` — branches the discipline applies to. Default
+  `[master, main]` (matches the current `MAIN_BRANCHES` set).
+- `isolation_strategy` controls **what** the nudge recommends:
+  - `branch` — always a plain feature branch
+  - `worktree` — always `/using-git-worktrees`
+  - `auto` (default) — worktree when the working tree is dirty
+    (`git status --porcelain` non-empty at advisory time) or when the context
+    is plan execution (`tdd+`/`sdd+` preflight); plain branch otherwise
+- Absent `workflow` key → defaults apply; existing `.harness.yaml` files need
+  no migration. `HarnessConfig` and `DEFAULT_CONFIG` extended accordingly.
+
+## 4. Seam 1 — session start
+
+`checkWorktreeSuggestion` evolves into `checkBranchDiscipline(cwd, exec,
+config)` in `src/session/worktree.ts` (file may rename to
+`branch-discipline.ts`; keep a re-export if anything else imports it):
+
+- Level `silent` → no output (new capability).
+- On a protected branch, level `advise`/`block` → emit a hint naming the level,
+  the resolved isolation strategy, and the PR expectation, e.g.:
+
+  > `[rig] On master — branch discipline active (advise): start feature work
+  > on a feature branch, finish with a PR. Working tree has uncommitted
+  > changes — /using-git-worktrees recommended so in-flight work stays
+  > untangled.`
+
+- Strategy resolution for `auto` at emission time: dirty tree → worktree;
+  clean → branch. The emission is part of the "active enforcement rules"
+  block, so every plus-skill inherits awareness for free.
+
+## 5. Seam 2 — commit time (PreToolUse)
+
+New Bash intent detection for `git commit` and `git push`:
+
+- Scanned across **all** quote-aware compound segments via
+  `splitCompoundSegments` — `cd x && git commit ...` is detected (lesson from
+  the v0.5.0 TR3 finding applied from day one).
+- On match, the hook resolves the current branch live
+  (`git branch --show-current` via the injectable `ExecFn`) — executed only
+  when the command is actually a commit/push, never cached (branches change
+  mid-session).
+- Current branch protected:
+  - `advise` → once-per-session agent-visible advisory (via
+    `hasAdvised('branch_discipline')` and the `additionalContext` channel):
+    names the branch, the recommended strategy with its reason, and the config
+    key.
+  - `block` → exit 2 with the reason and the pointer to
+    `rules.workflow.branch_discipline` to relax it.
+- Pushing a feature branch is never flagged — only operations while *on* a
+  protected branch. Explicit refspec pushes (`git push origin HEAD:master`)
+  are out of scope for v1 and noted as future hardening.
+- Strategy only shapes advisory text; `block` blocks regardless of strategy.
+
+## 6. Seam 3 — skill chain
+
+- The session-start emission propagates the rule generically (templates
+  already load active enforcement rules).
+- `tdd+` and `sdd+` Phase A gain a preflight line: "If branch discipline is
+  active and you're on a protected branch, create an isolated workspace before
+  implementing — a worktree (`superpowers:using-git-worktrees`) when the plan
+  is multi-task or the working tree is dirty, a plain feature branch
+  otherwise."
+- `review+`'s completion pointer prefers "finish with a PR (`gh pr create`)
+  via `superpowers:finishing-a-development-branch`" over local merge when the
+  rule is active.
+
+## 7. What this feature never does
+
+No auto-created branches or worktrees, no auto-opened PRs, no blocking at the
+default level. `block` is the only enforcing level and exists solely by
+explicit user configuration.
+
+## 8. Documentation (in scope, required)
+
+- **README**: Configuration section gains the `workflow` block with level and
+  strategy semantics; the skill-chain/feature prose mentions branch discipline
+  and worktree strategy in one paragraph.
+- **docs/getting-started.md**: "Configure enforcement" section documents the
+  three levels, `protected_branches`, `isolation_strategy` semantics (with the
+  `auto` signals), and shows the default config block.
+- **docs/architecture.md**: session layer documents `checkBranchDiscipline`
+  (replacing the current worktree-hint description); tool router intent table
+  gains the git commit/push row with its advise/block resolution; the
+  advisory-mechanics paragraph explains once-per-session suppression and the
+  agent-visible channel.
+- **docs/skill-wrapping.md**: the superpowers-vs-rig table row for
+  `using-git-worktrees` (generic isolation discipline → config-gated,
+  strategy-aware advisory integration).
+
+## 9. Testing
+
+- Unit (injectable `ExecFn`, no mocks, per repo convention):
+  - config: defaults, absent-key behavior, level/strategy parsing
+  - `checkBranchDiscipline`: level × branch × strategy × dirty/clean matrix
+  - intent: `git commit`/`git push` detection incl. compound segments and
+    quoted-string negatives
+  - resolver/hook: advise once-per-session suppression; block path; feature
+    branches never flagged
+- Template-content tests: tdd+/sdd+ preflight line; review+ PR pointer.
+- E2E hook tests mirroring the existing tests/hooks patterns for both the
+  advisory JSON emission and the block exit code.
+- Docs lint (`npm run lint:md`) and the docs CI gates cover §8.
+
+## 10. Acceptance criteria
+
+1. Default config emits the same spirit of session-start hint as today, now
+   level-aware and strategy-aware; `silent` suppresses it entirely.
+2. With `advise`, a `git commit` on master produces exactly one agent-visible
+   advisory per session; with `block`, the commit is rejected with remediation
+   text; feature-branch commits are never touched.
+3. `auto` strategy demonstrably recommends worktree on a dirty tree and branch
+   on a clean one (unit-tested via ExecFn).
+4. tdd+/sdd+/review+ templates carry the preflight and PR-pointer prose
+   (template-content tests).
+5. All docs in §8 updated; full suite, coverage gate, lint, and docs CI green.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rig",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rig",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rig",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Agent harness that enforces tool routing, skill chains, and multi-agent discipline in Claude Code",
   "type": "module",
   "main": "dist/cli/index.js",

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ import type {
   StaleTestRules,
   TestScopeRules,
   ZeroDefectRules,
+  WorkflowRules,
 } from './types.js';
 
 export const DEFAULT_CONFIG: HarnessConfig = {
@@ -46,6 +47,11 @@ export const DEFAULT_CONFIG: HarnessConfig = {
       tolerance: 'strict',
       unrelated_errors: 'block',
     },
+    workflow: {
+      branch_discipline: 'advise',
+      protected_branches: ['master', 'main'],
+      isolation_strategy: 'auto',
+    },
     enforcement: {
       default_level: 'advise',
     },
@@ -74,6 +80,7 @@ export function mergeConfigs(base: HarnessConfig, override: HarnessConfig): Harn
       stale_tests: { ...(base.rules.stale_tests ?? {}), ...override.rules.stale_tests } as StaleTestRules,
       test_scope: { ...(base.rules.test_scope ?? {}), ...override.rules.test_scope } as TestScopeRules,
       zero_defect: { ...(base.rules.zero_defect ?? {}), ...override.rules.zero_defect } as ZeroDefectRules,
+      workflow: { ...(base.rules.workflow ?? {}), ...override.rules.workflow } as WorkflowRules,
       enforcement: { ...(base.rules.enforcement ?? {}), ...override.rules.enforcement } as { default_level: EnforcementLevel },
     },
   };

--- a/src/router/branch-discipline.ts
+++ b/src/router/branch-discipline.ts
@@ -31,6 +31,10 @@ export function checkBranchDisciplineCommand(
   if (level === 'silent') return null;
   if (!splitCompoundSegments(command).some(s => GIT_WRITE_PATTERN.test(s.trim()))) return null;
 
+  // A consumed once-per-session advisory must cost zero subprocesses, so the
+  // suppression check runs before any git probe.
+  if (level === 'advise' && cache.hasAdvised('branch_discipline')) return null;
+
   let branch: string;
   try {
     branch = exec('git branch --show-current').trim();
@@ -41,7 +45,6 @@ export function checkBranchDisciplineCommand(
   if (!protectedBranches.includes(branch)) return null;
 
   if (level === 'advise') {
-    if (cache.hasAdvised('branch_discipline')) return null;
     cache.markAdvised('branch_discipline');
     const strategy = resolveIsolationStrategy(wf?.isolation_strategy ?? WORKFLOW_DEFAULTS.isolation_strategy, exec);
     const isolation = strategy === 'worktree'
@@ -50,7 +53,7 @@ export function checkBranchDisciplineCommand(
     return {
       level: 'advise',
       message:
-        `[ADVISE] Branch discipline: committing on ${branch}. ` +
+        `[ADVISE] Branch discipline: committing or pushing on ${branch}. ` +
         `Consider ${isolation} and finishing with a PR. ` +
         `(rules.workflow.branch_discipline — set to silent to disable)`,
     };
@@ -59,7 +62,7 @@ export function checkBranchDisciplineCommand(
   return {
     level: 'block',
     message:
-      `[BLOCK] Branch discipline: direct ${branch} commits are blocked by config. ` +
+      `[BLOCK] Branch discipline: direct ${branch} commits/pushes are blocked by config. ` +
       `Create a feature branch (or worktree via /using-git-worktrees) and open a PR. ` +
       `(rules.workflow.branch_discipline: block — set to advise/silent to relax)`,
   };

--- a/src/router/branch-discipline.ts
+++ b/src/router/branch-discipline.ts
@@ -4,7 +4,10 @@ import type { SessionCache } from '../session/cache.js';
 
 export type ExecFn = (cmd: string) => string;
 
-const GIT_WRITE_PATTERN = /^\s*git\s+(commit|push)\b/;
+// Tolerates git global options before the subcommand (`git -c user.email=x
+// commit`, `git -C /path push`, `git --no-pager commit`): each option is a
+// flag token optionally followed by an `=value` or a separate value argument.
+const GIT_WRITE_PATTERN = /^\s*git\s+(?:-[-\w]+(?:[= ]\S+)?\s+)*(commit|push)\b/;
 
 export interface BranchDisciplineResult {
   level: 'advise' | 'block';

--- a/src/router/branch-discipline.ts
+++ b/src/router/branch-discipline.ts
@@ -1,0 +1,73 @@
+import { splitCompoundSegments } from './intent.js';
+import type { HarnessConfig } from '../types.js';
+import type { SessionCache } from '../session/cache.js';
+
+export type ExecFn = (cmd: string) => string;
+
+const GIT_WRITE_PATTERN = /^\s*git\s+(commit|push)\b/;
+
+export interface BranchDisciplineResult {
+  level: 'advise' | 'block';
+  message: string;
+}
+
+/**
+ * Commit-time branch discipline check (PreToolUse). Scans every quote-aware
+ * compound segment of a Bash command for `git commit` / `git push`, resolves
+ * the live branch via the injectable ExecFn, and — when on a protected
+ * branch — advises once per session (or blocks, per
+ * `rules.workflow.branch_discipline`).
+ */
+export function checkBranchDisciplineCommand(
+  command: string,
+  config: HarnessConfig,
+  cache: SessionCache,
+  exec: ExecFn,
+): BranchDisciplineResult | null {
+  const wf = config.rules.workflow;
+  const level = wf?.branch_discipline ?? 'advise';
+  if (level === 'silent') return null;
+  if (!splitCompoundSegments(command).some(s => GIT_WRITE_PATTERN.test(s.trim()))) return null;
+
+  let branch: string;
+  try {
+    branch = exec('git branch --show-current').trim();
+  } catch {
+    return null; // Not a git repo or git not available
+  }
+  const protectedBranches = wf?.protected_branches ?? ['master', 'main'];
+  if (!protectedBranches.includes(branch)) return null;
+
+  if (level === 'advise') {
+    if (cache.hasAdvised('branch_discipline')) return null;
+    cache.markAdvised('branch_discipline');
+    const strategy = resolveStrategy(wf?.isolation_strategy ?? 'auto', exec);
+    const isolation = strategy === 'worktree'
+      ? 'a worktree (/using-git-worktrees)'
+      : 'a feature branch';
+    return {
+      level: 'advise',
+      message:
+        `[ADVISE] Branch discipline: committing on ${branch}. ` +
+        `Consider ${isolation} and finishing with a PR. ` +
+        `(rules.workflow.branch_discipline — set to silent to disable)`,
+    };
+  }
+
+  return {
+    level: 'block',
+    message:
+      `[BLOCK] Branch discipline: direct ${branch} commits are blocked by config. ` +
+      `Create a feature branch (or worktree via /using-git-worktrees) and open a PR. ` +
+      `(rules.workflow.branch_discipline: block — set to advise/silent to relax)`,
+  };
+}
+
+function resolveStrategy(strategy: 'auto' | 'branch' | 'worktree', exec: ExecFn): 'branch' | 'worktree' {
+  if (strategy !== 'auto') return strategy;
+  try {
+    return exec('git status --porcelain').trim() ? 'worktree' : 'branch';
+  } catch {
+    return 'branch';
+  }
+}

--- a/src/router/branch-discipline.ts
+++ b/src/router/branch-discipline.ts
@@ -1,8 +1,7 @@
 import { splitCompoundSegments } from './intent.js';
 import type { HarnessConfig } from '../types.js';
 import type { SessionCache } from '../session/cache.js';
-
-export type ExecFn = (cmd: string) => string;
+import { resolveIsolationStrategy, WORKFLOW_DEFAULTS, type ExecFn } from '../session/worktree.js';
 
 // Tolerates git global options before the subcommand (`git -c user.email=x
 // commit`, `git -C /path push`, `git --no-pager commit`): each option is a
@@ -28,7 +27,7 @@ export function checkBranchDisciplineCommand(
   exec: ExecFn,
 ): BranchDisciplineResult | null {
   const wf = config.rules.workflow;
-  const level = wf?.branch_discipline ?? 'advise';
+  const level = wf?.branch_discipline ?? WORKFLOW_DEFAULTS.branch_discipline;
   if (level === 'silent') return null;
   if (!splitCompoundSegments(command).some(s => GIT_WRITE_PATTERN.test(s.trim()))) return null;
 
@@ -38,13 +37,13 @@ export function checkBranchDisciplineCommand(
   } catch {
     return null; // Not a git repo or git not available
   }
-  const protectedBranches = wf?.protected_branches ?? ['master', 'main'];
+  const protectedBranches = wf?.protected_branches ?? WORKFLOW_DEFAULTS.protected_branches;
   if (!protectedBranches.includes(branch)) return null;
 
   if (level === 'advise') {
     if (cache.hasAdvised('branch_discipline')) return null;
     cache.markAdvised('branch_discipline');
-    const strategy = resolveStrategy(wf?.isolation_strategy ?? 'auto', exec);
+    const strategy = resolveIsolationStrategy(wf?.isolation_strategy ?? WORKFLOW_DEFAULTS.isolation_strategy, exec);
     const isolation = strategy === 'worktree'
       ? 'a worktree (/using-git-worktrees)'
       : 'a feature branch';
@@ -64,13 +63,4 @@ export function checkBranchDisciplineCommand(
       `Create a feature branch (or worktree via /using-git-worktrees) and open a PR. ` +
       `(rules.workflow.branch_discipline: block — set to advise/silent to relax)`,
   };
-}
-
-function resolveStrategy(strategy: 'auto' | 'branch' | 'worktree', exec: ExecFn): 'branch' | 'worktree' {
-  if (strategy !== 'auto') return strategy;
-  try {
-    return exec('git status --porcelain').trim() ? 'worktree' : 'branch';
-  } catch {
-    return 'branch';
-  }
 }

--- a/src/router/hook.ts
+++ b/src/router/hook.ts
@@ -198,36 +198,47 @@ export function handlePreToolUse(
     }
   }
 
-  // Step 1.5: Test-scope check — during tdd+/sdd+, advise a scoped run before
-  // a full-suite command executes. Phase and edit history come from the
-  // session cache (persisted by the PostToolUse hook). Runs pre-execution
-  // because a scoped-run redirect is only actionable before the suite runs.
-  // No first-occurrence suppression: every unscoped run is flagged.
-  // The early return before the rewrite steps (2 and 3) is safe today because
-  // no UNSCOPED_TEST_PATTERNS command is rtk- or python-rewritable; revisit
-  // this ordering if RTK_PREFIXES ever gains test runners.
+  // Steps 1.5 + 1.6: pre-rewrite Bash checks, evaluated collect-then-pick:
+  // every check runs before anything is returned, any block-level result
+  // wins over any advisory, and only when nothing blocks does the first
+  // advisory surface. This guarantees an advisory from one check can never
+  // preempt a block from another. Both run before the rewrite steps (2 and
+  // 3) because a block must win over a rewrite; that early return is safe
+  // today because no UNSCOPED_TEST_PATTERNS command is rtk- or
+  // python-rewritable — revisit if RTK_PREFIXES ever gains test runners.
   if (tool === 'Bash' && typeof args.command === 'string') {
-    // Hooks are separate processes, so the source-edit history comes from the
-    // session cache (persisted by the PostToolUse hook), not a FileTracker.
+    const preflight: { level: 'advise' | 'block'; message: string }[] = [];
+
+    // Step 1.5: Test-scope check — during tdd+/sdd+, advise a scoped run
+    // before a full-suite command executes. Hooks are separate processes, so
+    // phase and source-edit history come from the session cache (persisted
+    // by the PostToolUse hook), not a FileTracker. No first-occurrence
+    // suppression: every unscoped run is flagged.
     const scopeViolation = checkTestScope(
       args.command,
       cache.getCurrentPhase(),
       cache.getEditedFiles('source'),
       config,
     );
-    if (scopeViolation) return scopeViolation;
-  }
+    if (scopeViolation) {
+      preflight.push({
+        level: scopeViolation.startsWith('[BLOCK]') ? 'block' : 'advise',
+        message: scopeViolation,
+      });
+    }
 
-  // Step 1.6: Branch discipline — git commit/push on a protected branch
-  // advises once per session (or blocks, per rules.workflow). Scans every
-  // quote-aware compound segment, so `cd /tmp && git commit` is still caught.
-  // Runs before the rewrite steps because a block must win over a rewrite,
-  // and the once-per-session advisory costs at most one rtk rewrite.
-  if (tool === 'Bash' && typeof args.command === 'string') {
+    // Step 1.6: Branch discipline — git commit/push on a protected branch
+    // advises once per session (or blocks, per rules.workflow). Scans every
+    // quote-aware compound segment, so `cd /tmp && git commit` is still
+    // caught. The once-per-session advisory costs at most one rtk rewrite.
     const branchExec: ExecFn = resolvedOptions.branchExec
       ?? ((cmd) => execSync(cmd, { encoding: 'utf-8', cwd: effectiveCwd, timeout: 5000 }) as string);
     const discipline = checkBranchDisciplineCommand(args.command, config, cache, branchExec);
-    if (discipline) return discipline.message;
+    if (discipline) preflight.push(discipline);
+
+    const blocked = preflight.find(r => r.level === 'block');
+    if (blocked) return blocked.message;
+    if (preflight.length > 0) return preflight[0].message;
   }
 
   // Step 2: Python environment rewrite for Bash commands (skip compound commands)

--- a/src/router/hook.ts
+++ b/src/router/hook.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 import { appendFileSync } from 'node:fs';
 import type { HarnessConfig, RewriteResult } from '../types.js';
 import { SessionCache } from '../session/cache.js';
@@ -7,6 +7,7 @@ import { resolve } from './resolver.js';
 import { tryPythonRewrite } from './python-rewrite.js';
 import { isCompoundCommand } from './intent.js';
 import { checkTestScope } from '../enforcement/test-scope.js';
+import { checkBranchDisciplineCommand, type ExecFn } from './branch-discipline.js';
 
 export type ExecRewriteFn = (rtkPath: string, args: string[]) => string | null;
 export type ExistsCheckFn = (path: string) => boolean;
@@ -14,6 +15,8 @@ export type ExistsCheckFn = (path: string) => boolean;
 export interface HookOptions {
   execRewrite?: ExecRewriteFn;
   existsCheck?: ExistsCheckFn;
+  /** Injectable exec for branch-discipline git probes (testability). */
+  branchExec?: ExecFn;
 }
 
 export type RawExecFileFn = (file: string, args: string[], opts: object) => string;
@@ -213,6 +216,18 @@ export function handlePreToolUse(
       config,
     );
     if (scopeViolation) return scopeViolation;
+  }
+
+  // Step 1.6: Branch discipline — git commit/push on a protected branch
+  // advises once per session (or blocks, per rules.workflow). Scans every
+  // quote-aware compound segment, so `cd /tmp && git commit` is still caught.
+  // Runs before the rewrite steps because a block must win over a rewrite,
+  // and the once-per-session advisory costs at most one rtk rewrite.
+  if (tool === 'Bash' && typeof args.command === 'string') {
+    const branchExec: ExecFn = resolvedOptions.branchExec
+      ?? ((cmd) => execSync(cmd, { encoding: 'utf-8', cwd: effectiveCwd, timeout: 5000 }) as string);
+    const discipline = checkBranchDisciplineCommand(args.command, config, cache, branchExec);
+    if (discipline) return discipline.message;
   }
 
   // Step 2: Python environment rewrite for Bash commands (skip compound commands)

--- a/src/router/hook.ts
+++ b/src/router/hook.ts
@@ -7,7 +7,8 @@ import { resolve } from './resolver.js';
 import { tryPythonRewrite } from './python-rewrite.js';
 import { isCompoundCommand } from './intent.js';
 import { checkTestScope } from '../enforcement/test-scope.js';
-import { checkBranchDisciplineCommand, type ExecFn } from './branch-discipline.js';
+import { checkBranchDisciplineCommand } from './branch-discipline.js';
+import type { ExecFn } from '../session/worktree.js';
 
 export type ExecRewriteFn = (rtkPath: string, args: string[]) => string | null;
 export type ExistsCheckFn = (path: string) => boolean;

--- a/src/session/start.ts
+++ b/src/session/start.ts
@@ -6,7 +6,7 @@ import type { Environment, GraphBuildInfo, HarnessConfig } from '../types.js';
 import { detectEnvironment, callJcodemunchMcpTool } from './environment.js';
 import type { ExecFn, McpQueryFn, RegistrationLookupFn } from './environment.js';
 import { detectPythonEnv } from './python-env.js';
-import { checkBranchDiscipline } from './worktree.js';
+import { checkBranchDiscipline, WORKFLOW_DEFAULTS } from './worktree.js';
 import { captureMetricsBaseline, captureGraphifyStatsViaReport } from './metrics.js';
 import { triggerBuild, waitForBuild } from '../scout/graph-state.js';
 import type { WaitForBuildOpts } from '../scout/graph-state.js';
@@ -334,6 +334,15 @@ function formatActiveRules(config: HarnessConfig): string | null {
         active.push(`${rule} (${level})`);
       }
     }
+  }
+
+  // Branch discipline belongs in the active-rules line too — skill templates
+  // anchor on "see session-start output", which must not be empty for
+  // sessions started on feature branches (where the protected-branch hint
+  // does not fire).
+  const branchLevel = config.rules.workflow?.branch_discipline ?? WORKFLOW_DEFAULTS.branch_discipline;
+  if (branchLevel !== 'silent') {
+    active.push(`branch_discipline (${branchLevel})`);
   }
 
   if (active.length === 0) return null;

--- a/src/session/start.ts
+++ b/src/session/start.ts
@@ -203,7 +203,7 @@ export async function handleSessionStart(
     lines.push(activeRules);
   }
 
-  const suggestion = checkBranchDiscipline(cwd, (cmd) => execSync(cmd, { encoding: 'utf-8' }), config);
+  const suggestion = checkBranchDiscipline((cmd) => execSync(cmd, { encoding: 'utf-8' }), config);
   if (suggestion) {
     lines.push(suggestion);
   }

--- a/src/session/start.ts
+++ b/src/session/start.ts
@@ -6,7 +6,7 @@ import type { Environment, GraphBuildInfo, HarnessConfig } from '../types.js';
 import { detectEnvironment, callJcodemunchMcpTool } from './environment.js';
 import type { ExecFn, McpQueryFn, RegistrationLookupFn } from './environment.js';
 import { detectPythonEnv } from './python-env.js';
-import { checkWorktreeSuggestion } from './worktree.js';
+import { checkBranchDiscipline } from './worktree.js';
 import { captureMetricsBaseline, captureGraphifyStatsViaReport } from './metrics.js';
 import { triggerBuild, waitForBuild } from '../scout/graph-state.js';
 import type { WaitForBuildOpts } from '../scout/graph-state.js';
@@ -203,7 +203,7 @@ export async function handleSessionStart(
     lines.push(activeRules);
   }
 
-  const suggestion = checkWorktreeSuggestion(cwd, (cmd) => execSync(cmd, { encoding: 'utf-8' }));
+  const suggestion = checkBranchDiscipline(cwd, (cmd) => execSync(cmd, { encoding: 'utf-8' }), config);
   if (suggestion) {
     lines.push(suggestion);
   }

--- a/src/session/worktree.ts
+++ b/src/session/worktree.ts
@@ -1,17 +1,40 @@
-import type { HarnessConfig } from '../types.js';
+import type { HarnessConfig, WorkflowRules } from '../types.js';
 import { DEFAULT_CONFIG } from '../config.js';
 
+/** Injectable exec for branch-discipline git probes (shared by the session-start hint and the tool router's commit-time check). */
 export type ExecFn = (cmd: string) => string;
 
-export function checkBranchDiscipline(cwd: string, exec: ExecFn, config: HarnessConfig): string {
-  const wf = config.rules.workflow ?? DEFAULT_CONFIG.rules.workflow!;
-  const level = wf.branch_discipline ?? 'advise';
+/**
+ * Canonical workflow defaults. DEFAULT_CONFIG remains the single source for
+ * the protected-branch list, enforcement level, and isolation strategy —
+ * consumers read from here instead of re-declaring the literals.
+ */
+export const WORKFLOW_DEFAULTS = DEFAULT_CONFIG.rules.workflow as Required<WorkflowRules>;
+
+/**
+ * Resolve the recommended isolation strategy. `worktree` and `branch` force
+ * the answer; `auto` recommends a worktree when the working tree is dirty
+ * (keeps in-flight work untangled), a plain feature branch otherwise. Any
+ * git failure falls back to `branch`.
+ */
+export function resolveIsolationStrategy(strategy: 'auto' | 'branch' | 'worktree', exec: ExecFn): 'branch' | 'worktree' {
+  if (strategy !== 'auto') return strategy;
+  try {
+    return exec('git status --porcelain').trim() ? 'worktree' : 'branch';
+  } catch {
+    return 'branch';
+  }
+}
+
+export function checkBranchDiscipline(exec: ExecFn, config: HarnessConfig): string {
+  const wf = config.rules.workflow ?? WORKFLOW_DEFAULTS;
+  const level = wf.branch_discipline ?? WORKFLOW_DEFAULTS.branch_discipline;
   if (level === 'silent') return '';
-  const protectedBranches = wf.protected_branches ?? ['master', 'main'];
+  const protectedBranches = wf.protected_branches ?? WORKFLOW_DEFAULTS.protected_branches;
   try {
     const branch = exec('git branch --show-current').trim();
     if (!protectedBranches.includes(branch)) return '';
-    const strategy = resolveIsolationStrategy(wf.isolation_strategy ?? 'auto', exec);
+    const strategy = resolveIsolationStrategy(wf.isolation_strategy ?? WORKFLOW_DEFAULTS.isolation_strategy, exec);
     const isolation = strategy === 'worktree'
       ? 'a worktree (/using-git-worktrees) — keeps in-flight work untangled'
       : 'a feature branch';
@@ -21,16 +44,7 @@ export function checkBranchDiscipline(cwd: string, exec: ExecFn, config: Harness
   }
 }
 
-function resolveIsolationStrategy(strategy: 'auto' | 'branch' | 'worktree', exec: ExecFn): 'branch' | 'worktree' {
-  if (strategy !== 'auto') return strategy;
-  try {
-    return exec('git status --porcelain').trim() ? 'worktree' : 'branch';
-  } catch {
-    return 'branch';
-  }
-}
-
 /** @deprecated use checkBranchDiscipline — kept for compatibility */
-export function checkWorktreeSuggestion(cwd: string, exec: ExecFn): string {
-  return checkBranchDiscipline(cwd, exec, DEFAULT_CONFIG);
+export function checkWorktreeSuggestion(_cwd: string, exec: ExecFn): string {
+  return checkBranchDiscipline(exec, DEFAULT_CONFIG);
 }

--- a/src/session/worktree.ts
+++ b/src/session/worktree.ts
@@ -1,15 +1,36 @@
+import type { HarnessConfig } from '../types.js';
+import { DEFAULT_CONFIG } from '../config.js';
+
 export type ExecFn = (cmd: string) => string;
 
-const MAIN_BRANCHES = new Set(['master', 'main']);
-
-export function checkWorktreeSuggestion(cwd: string, exec: ExecFn): string {
+export function checkBranchDiscipline(cwd: string, exec: ExecFn, config: HarnessConfig): string {
+  const wf = config.rules.workflow ?? DEFAULT_CONFIG.rules.workflow!;
+  const level = wf.branch_discipline ?? 'advise';
+  if (level === 'silent') return '';
+  const protectedBranches = wf.protected_branches ?? ['master', 'main'];
   try {
     const branch = exec('git branch --show-current').trim();
-    if (MAIN_BRANCHES.has(branch)) {
-      return `[rig] On ${branch} — consider /using-git-worktrees for isolated feature work.`;
-    }
+    if (!protectedBranches.includes(branch)) return '';
+    const strategy = resolveIsolationStrategy(wf.isolation_strategy ?? 'auto', exec);
+    const isolation = strategy === 'worktree'
+      ? 'a worktree (/using-git-worktrees) — keeps in-flight work untangled'
+      : 'a feature branch';
+    return `[rig] On ${branch} — branch discipline active (${level}): start feature work on ${isolation}, finish with a PR.`;
   } catch {
-    // Not a git repo or git not available
+    return ''; // Not a git repo or git not available
   }
-  return '';
+}
+
+function resolveIsolationStrategy(strategy: 'auto' | 'branch' | 'worktree', exec: ExecFn): 'branch' | 'worktree' {
+  if (strategy !== 'auto') return strategy;
+  try {
+    return exec('git status --porcelain').trim() ? 'worktree' : 'branch';
+  } catch {
+    return 'branch';
+  }
+}
+
+/** @deprecated use checkBranchDiscipline — kept for compatibility */
+export function checkWorktreeSuggestion(cwd: string, exec: ExecFn): string {
+  return checkBranchDiscipline(cwd, exec, DEFAULT_CONFIG);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -216,6 +216,12 @@ export interface ZeroDefectRules {
   unrelated_errors?: EnforcementLevel;
 }
 
+export interface WorkflowRules {
+  branch_discipline?: EnforcementLevel;
+  protected_branches?: string[];
+  isolation_strategy?: 'auto' | 'branch' | 'worktree';
+}
+
 export interface HarnessConfig {
   rules: {
     tool_routing?: ToolRoutingRules;
@@ -224,6 +230,7 @@ export interface HarnessConfig {
     stale_tests?: StaleTestRules;
     test_scope?: TestScopeRules;
     zero_defect?: ZeroDefectRules;
+    workflow?: WorkflowRules;
     enforcement?: {
       default_level: EnforcementLevel;
     };

--- a/templates/skills/review-plus/SKILL.md
+++ b/templates/skills/review-plus/SKILL.md
@@ -111,6 +111,8 @@ After review+ passes:
 
 - The implementation is complete
 - Proceed to merge/PR decision (superpowers:finishing-a-development-branch)
+- If branch discipline is active, finish with a PR (`gh pr create` via
+  `superpowers:finishing-a-development-branch`) rather than a local merge.
 
 ## Completion
 

--- a/templates/skills/sdd-plus/SKILL.md
+++ b/templates/skills/sdd-plus/SKILL.md
@@ -39,6 +39,10 @@ subagent using the superpowers prompt template for that role.
 3. If the plan defines a signal stack, note each task's named gating signal:
    that signal is the task's completion gate, and the implementer dispatch
    prompt must say so.
+4. If branch discipline is active (see session-start output) and you are on a
+   protected branch, create an isolated workspace before implementing — a
+   worktree (`superpowers:using-git-worktrees`) when the plan is multi-task or
+   the working tree is dirty, a plain feature branch otherwise.
 
 ### Phase B: Execute (delegate to superpowers:subagent-driven-development)
 

--- a/templates/skills/sdd-plus/SKILL.md
+++ b/templates/skills/sdd-plus/SKILL.md
@@ -53,6 +53,12 @@ subagent using the superpowers prompt template for that role.
    with the reviewer's findings included in the payload.
 4. Do not pause between tasks. Stop only for BLOCKED you cannot resolve,
    genuine ambiguity, or plan completion.
+5. Parallelism: this plan's tasks run **sequentially** — they share a branch
+   and usually files, so one implementer at a time per branch/worktree (the
+   wrapped skill's no-parallel rule applies within the plan). Orthogonal work
+   *outside* this plan (a different branch, disjoint files, no merge-order
+   dependency) may proceed concurrently in its own worktree; reviewers are
+   read-only and always safe to run in parallel.
 
 ### Phase C: Wrap Up
 

--- a/templates/skills/tdd-plus/SKILL.md
+++ b/templates/skills/tdd-plus/SKILL.md
@@ -34,6 +34,11 @@ Wraps `superpowers:test-driven-development`. Requires superpowers to be installe
 
 3. Identify the task(s) to implement.
 
+4. If branch discipline is active (see session-start output) and you are on a
+   protected branch, create an isolated workspace before implementing — a
+   worktree (`superpowers:using-git-worktrees`) when the plan is multi-task or
+   the working tree is dirty, a plain feature branch otherwise.
+
 ### Phase B: Implement Each Task (delegate to superpowers:test-driven-development)
 
 1. For each task in the plan, follow RED-GREEN-REFACTOR:

--- a/tests/cli/template-content.test.ts
+++ b/tests/cli/template-content.test.ts
@@ -109,4 +109,16 @@ describe('skill templates — loop-aware vocabulary', () => {
     expect(content).toContain('Agent(subagent_type="code-reviewer")');
     expect(content).toContain('XX/35');
   });
+
+  it('tdd+ and sdd+ carry the branch-discipline preflight', () => {
+    for (const skill of ['tdd-plus', 'sdd-plus']) {
+      const content = read(`skills/${skill}/SKILL.md`);
+      expect(content).toContain('branch discipline');
+      expect(content).toContain('isolated workspace');
+    }
+  });
+
+  it('review+ prefers a PR when branch discipline is active', () => {
+    expect(read('skills/review-plus/SKILL.md')).toContain('gh pr create');
+  });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -64,6 +64,13 @@ describe('config', () => {
       const config = await loadConfig(resolve(FIXTURES, 'broken-config.yaml'));
       expect(config).toEqual(DEFAULT_CONFIG);
     });
+
+    it('defaults workflow rules: advise, master/main, auto strategy', async () => {
+      const config = await loadConfig('/nonexistent/.harness.yaml');
+      expect(config.rules.workflow?.branch_discipline).toBe('advise');
+      expect(config.rules.workflow?.protected_branches).toEqual(['master', 'main']);
+      expect(config.rules.workflow?.isolation_strategy).toBe('auto');
+    });
   });
 
   describe('mergeConfigs', () => {
@@ -100,6 +107,14 @@ describe('config', () => {
       expect(merged.rules.tool_routing).toBeDefined();
       expect(merged.rules.tool_routing.grep).toBe('advise');
       expect(merged.rules.tool_routing.sed_i).toBe('block');
+    });
+
+    it('merges partial workflow overrides onto defaults', () => {
+      const merged = mergeConfigs(structuredClone(DEFAULT_CONFIG), {
+        rules: { workflow: { branch_discipline: 'block' } },
+      } as HarnessConfig);
+      expect(merged.rules.workflow?.branch_discipline).toBe('block');
+      expect(merged.rules.workflow?.protected_branches).toEqual(['master', 'main']);
     });
   });
 });

--- a/tests/integration/pre-tool-use.test.ts
+++ b/tests/integration/pre-tool-use.test.ts
@@ -229,7 +229,7 @@ describe('PreToolUse hook E2E', () => {
     // the once-per-session advisory suppression cannot leak between them.
     let gitDir: string;
     let gitHookPath: string;
-    const gitSessionIds = ['branch-advise', 'branch-block'];
+    const gitSessionIds = ['branch-advise', 'branch-block', 'branch-scope-block'];
 
     function workflowYaml(level: string): string {
       return [
@@ -293,6 +293,24 @@ describe('PreToolUse hook E2E', () => {
 
       expect(result.exitCode).toBe(2);
       expect(result.stderr).toContain('[BLOCK]');
+      expect(result.stderr).toContain('Branch discipline');
+      expect(result.stdout).not.toContain('hookSpecificOutput');
+    }, HOOK_TIMEOUT);
+
+    it('exits 2 for a compound test+commit command during tdd+ phase (block must beat any advisory)', async () => {
+      writeFileSync(join(gitDir, '.harness.yaml'), workflowYaml('block'), 'utf-8');
+      const writer = new SessionCache(gitDir, 'branch-scope-block');
+      writer.setEnvironment(makeEnv());
+      writer.setPhase('tdd+');
+      writer.addEditedFile('src/router/resolver.ts', 'source');
+
+      const result = await runHook(gitHookPath, {
+        session_id: 'branch-scope-block',
+        tool_name: 'Bash',
+        tool_input: { command: 'npm test && git commit -m "x"' },
+      }, gitDir);
+
+      expect(result.exitCode).toBe(2);
       expect(result.stderr).toContain('Branch discipline');
       expect(result.stdout).not.toContain('hookSpecificOutput');
     }, HOOK_TIMEOUT);

--- a/tests/integration/pre-tool-use.test.ts
+++ b/tests/integration/pre-tool-use.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { mkdtempSync, rmSync, unlinkSync, writeFileSync, existsSync } from 'node:fs';
+import { execSync } from 'node:child_process';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { initCommand } from '../../src/cli/init.js';
@@ -218,6 +219,81 @@ describe('PreToolUse hook E2E', () => {
 
       expect(result.exitCode).toBe(2);
       expect(result.stderr).toContain('[BLOCK]');
+      expect(result.stdout).not.toContain('hookSpecificOutput');
+    }, HOOK_TIMEOUT);
+  });
+
+  describe('branch discipline (git fixture)', () => {
+    // Separate git-initialized fixture so the shared tempDir stays a plain
+    // directory for the other tests. Each test uses its own session_id so
+    // the once-per-session advisory suppression cannot leak between them.
+    let gitDir: string;
+    let gitHookPath: string;
+    const gitSessionIds = ['branch-advise', 'branch-block'];
+
+    function workflowYaml(level: string): string {
+      return [
+        'rules:',
+        '  workflow:',
+        `    branch_discipline: ${level}`,
+        '    protected_branches: [master, main]',
+        '    isolation_strategy: auto',
+        '',
+      ].join('\n');
+    }
+
+    beforeAll(async () => {
+      gitDir = mkdtempSync(join(tmpdir(), 'rig-e2e-branch-'));
+      await initCommand(gitDir, { force: false });
+      gitHookPath = join(gitDir, '.claude', 'hooks', 'scripts', 'pre-tool-use.ts');
+      expect(existsSync(gitHookPath)).toBe(true);
+      execSync('git init -b master', { cwd: gitDir });
+      execSync('git -c user.email=rig@test.dev -c user.name=rig commit --allow-empty -m init', { cwd: gitDir });
+    }, HOOK_TIMEOUT);
+
+    afterAll(() => {
+      for (const id of gitSessionIds) {
+        const path = sessionCachePath(gitDir, id);
+        if (existsSync(path)) unlinkSync(path);
+      }
+      rmSync(gitDir, { recursive: true, force: true });
+    });
+
+    it('emits branch-discipline advisory as additionalContext for git commit on master', async () => {
+      writeFileSync(join(gitDir, '.harness.yaml'), workflowYaml('advise'), 'utf-8');
+      const writer = new SessionCache(gitDir, 'branch-advise');
+      writer.setEnvironment(makeEnv());
+
+      const result = await runHook(gitHookPath, {
+        session_id: 'branch-advise',
+        tool_name: 'Bash',
+        tool_input: { command: 'git commit -m "test"' },
+      }, gitDir);
+
+      expect(result.exitCode).toBe(0);
+      const jsonLine = result.stdout.split('\n').find(l => l.trim().startsWith('{'));
+      expect(jsonLine).toBeDefined();
+      const parsed = JSON.parse(jsonLine as string);
+      expect(parsed.hookSpecificOutput.hookEventName).toBe('PreToolUse');
+      expect(parsed.hookSpecificOutput.additionalContext).toContain('[ADVISE]');
+      expect(parsed.hookSpecificOutput.additionalContext).toContain('Branch discipline');
+      expect(parsed.hookSpecificOutput.additionalContext).toContain('master');
+    }, HOOK_TIMEOUT);
+
+    it('blocks git push on master with exit 2 when level is block', async () => {
+      writeFileSync(join(gitDir, '.harness.yaml'), workflowYaml('block'), 'utf-8');
+      const writer = new SessionCache(gitDir, 'branch-block');
+      writer.setEnvironment(makeEnv());
+
+      const result = await runHook(gitHookPath, {
+        session_id: 'branch-block',
+        tool_name: 'Bash',
+        tool_input: { command: 'git push origin master' },
+      }, gitDir);
+
+      expect(result.exitCode).toBe(2);
+      expect(result.stderr).toContain('[BLOCK]');
+      expect(result.stderr).toContain('Branch discipline');
       expect(result.stdout).not.toContain('hookSpecificOutput');
     }, HOOK_TIMEOUT);
   });

--- a/tests/router/branch-discipline.test.ts
+++ b/tests/router/branch-discipline.test.ts
@@ -233,6 +233,48 @@ describe('handlePreToolUse branch discipline wiring', () => {
     expect(result).toContain('Branch discipline');
   });
 
+  it('branch-discipline block wins for a compound command during tdd+ phase', () => {
+    // Regression guard for check ordering: a pre-rewrite advisory (test
+    // scope) must never preempt a pre-rewrite block (branch discipline).
+    config = cfg('block');
+    cache.setPhase('tdd+');
+    cache.addEditedFile('src/router/resolver.ts', 'source');
+    const exec = makeExec({ 'git branch --show-current': 'master' });
+    const result = handlePreToolUse(
+      'Bash',
+      { command: 'npm test && git commit -m "x"' },
+      cache,
+      config,
+      undefined,
+      { branchExec: exec },
+    );
+    expect(typeof result).toBe('string');
+    expect(result).toContain('[BLOCK]');
+    expect(result).toContain('Branch discipline');
+  });
+
+  it('test-scope block wins over a branch-discipline advisory on the same command', () => {
+    config = cfg('advise');
+    config.rules.test_scope = { enforcement: 'block', allowed_unscoped: [] };
+    cache.setPhase('tdd+');
+    cache.addEditedFile('src/router/resolver.ts', 'source');
+    const exec = makeExec({
+      'git branch --show-current': 'master',
+      'git status --porcelain': '',
+    });
+    const result = handlePreToolUse(
+      'Bash',
+      { command: 'npm test' },
+      cache,
+      config,
+      undefined,
+      { branchExec: exec },
+    );
+    expect(typeof result).toBe('string');
+    expect(result).toContain('[BLOCK]');
+    expect(result).toContain('TEST SCOPE');
+  });
+
   it('passes git commit through on a feature branch', () => {
     config = cfg('advise');
     const exec = makeExec({ 'git branch --show-current': 'feat/x' });

--- a/tests/router/branch-discipline.test.ts
+++ b/tests/router/branch-discipline.test.ts
@@ -105,6 +105,56 @@ describe('checkBranchDisciplineCommand', () => {
     expect(calls).toEqual([]); // never resolves the branch for a quoted mention
   });
 
+  it('catches git commit behind a -c key=value global option', () => {
+    const exec = makeExec({
+      'git branch --show-current': 'master',
+      'git status --porcelain': '',
+    });
+    const result = checkBranchDisciplineCommand('git -c user.email=x commit -m "x"', cfg('advise'), cache, exec);
+    expect(result).not.toBeNull();
+    expect(result?.level).toBe('advise');
+    expect(result?.message).toContain('master');
+  });
+
+  it('catches git push behind a -C <path> global option', () => {
+    const exec = makeExec({ 'git branch --show-current': 'main' });
+    const result = checkBranchDisciplineCommand('git -C /path push', cfg('block'), cache, exec);
+    expect(result).not.toBeNull();
+    expect(result?.level).toBe('block');
+  });
+
+  it('catches git commit behind a --no-pager global option', () => {
+    const exec = makeExec({
+      'git branch --show-current': 'master',
+      'git status --porcelain': '',
+    });
+    const result = checkBranchDisciplineCommand('git --no-pager commit -m "x"', cfg('advise'), cache, exec);
+    expect(result).not.toBeNull();
+    expect(result?.level).toBe('advise');
+  });
+
+  it('catches git commit behind multiple global options', () => {
+    const exec = makeExec({
+      'git branch --show-current': 'master',
+      'git status --porcelain': '',
+    });
+    const result = checkBranchDisciplineCommand(
+      'git -c user.email=x -c user.name=y commit -m "x"',
+      cfg('advise'),
+      cache,
+      exec,
+    );
+    expect(result).not.toBeNull();
+  });
+
+  it('does not match git commitfoo (word boundary)', () => {
+    const calls: string[] = [];
+    const exec = makeExec({ 'git branch --show-current': 'master' }, calls);
+    const result = checkBranchDisciplineCommand('git commitfoo', cfg('advise'), cache, exec);
+    expect(result).toBeNull();
+    expect(calls).toEqual([]); // pattern gate rejects before branch resolution
+  });
+
   it('returns null for read-only git commands (status, diff)', () => {
     const calls: string[] = [];
     const exec = makeExec({ 'git branch --show-current': 'master' }, calls);

--- a/tests/router/branch-discipline.test.ts
+++ b/tests/router/branch-discipline.test.ts
@@ -105,6 +105,36 @@ describe('checkBranchDisciplineCommand', () => {
     expect(calls).toEqual([]); // never resolves the branch for a quoted mention
   });
 
+  it('consumed advisory costs zero subprocesses on subsequent calls', () => {
+    const exec = makeExec({
+      'git branch --show-current': 'master',
+      'git status --porcelain': '',
+    });
+    const first = checkBranchDisciplineCommand('git commit -m "x"', cfg('advise'), cache, exec);
+    expect(first).not.toBeNull();
+
+    const calls: string[] = [];
+    const exec2 = makeExec({}, calls);
+    const second = checkBranchDisciplineCommand('git commit -m "y"', cfg('advise'), cache, exec2);
+    expect(second).toBeNull();
+    expect(calls).toEqual([]);
+  });
+
+  it('advise message names both committing and pushing', () => {
+    const exec = makeExec({
+      'git branch --show-current': 'master',
+      'git status --porcelain': '',
+    });
+    const result = checkBranchDisciplineCommand('git push', cfg('advise'), cache, exec);
+    expect(result?.message).toContain('committing or pushing on master');
+  });
+
+  it('block message names both commits and pushes', () => {
+    const exec = makeExec({ 'git branch --show-current': 'master' });
+    const result = checkBranchDisciplineCommand('git push', cfg('block'), cache, exec);
+    expect(result?.message).toContain('direct master commits/pushes are blocked');
+  });
+
   it('catches git commit behind a -c key=value global option', () => {
     const exec = makeExec({
       'git branch --show-current': 'master',

--- a/tests/router/branch-discipline.test.ts
+++ b/tests/router/branch-discipline.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { checkBranchDisciplineCommand } from '../../src/router/branch-discipline.js';
+import { handlePreToolUse } from '../../src/router/hook.js';
+import { SessionCache } from '../../src/session/cache.js';
+import { DEFAULT_CONFIG } from '../../src/config.js';
+import type { Environment, HarnessConfig } from '../../src/types.js';
+
+function makeExec(responses: Record<string, string | Error>, calls?: string[]) {
+  return (cmd: string): string => {
+    calls?.push(cmd);
+    const response = responses[cmd];
+    if (response === undefined) throw new Error(`unexpected command: ${cmd}`);
+    if (response instanceof Error) throw response;
+    return response;
+  };
+}
+
+function makeEnv(overrides: Partial<Environment> = {}): Environment {
+  return {
+    rtkAvailable: false,
+    rtkPath: null,
+    jcodemunchAvailable: false,
+    jcodemunchCwdIndexed: false,
+    jcodemunchCwdRepo: null,
+    jcodemunchKnownRepos: [],
+    graphifyAvailable: false,
+    graphifyGraphPath: null,
+    detectedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+function cfg(
+  level: string,
+  strategy = 'auto',
+  branches = ['master', 'main'],
+): HarnessConfig {
+  const config = structuredClone(DEFAULT_CONFIG);
+  config.rules.workflow = {
+    branch_discipline: level as never,
+    protected_branches: branches,
+    isolation_strategy: strategy as never,
+  };
+  return config;
+}
+
+describe('checkBranchDisciplineCommand', () => {
+  let cache: SessionCache;
+
+  beforeEach(() => {
+    cache = new SessionCache();
+  });
+
+  it('advises on git commit on master and suppresses the second call', () => {
+    const exec = makeExec({
+      'git branch --show-current': 'master',
+      'git status --porcelain': '',
+    });
+    const result = checkBranchDisciplineCommand('git commit -m "x"', cfg('advise'), cache, exec);
+    expect(result).not.toBeNull();
+    expect(result?.level).toBe('advise');
+    expect(result?.message).toContain('master');
+    expect(result?.message).toContain('Branch discipline');
+    expect(result?.message).toContain('a feature branch');
+    expect(result?.message).toContain('rules.workflow.branch_discipline');
+
+    const second = checkBranchDisciplineCommand('git commit -m "y"', cfg('advise'), cache, exec);
+    expect(second).toBeNull();
+  });
+
+  it('detects git commit in a compound segment', () => {
+    const exec = makeExec({
+      'git branch --show-current': 'master',
+      'git status --porcelain': '',
+    });
+    const result = checkBranchDisciplineCommand('cd /tmp && git commit -m "x"', cfg('advise'), cache, exec);
+    expect(result).not.toBeNull();
+    expect(result?.level).toBe('advise');
+    expect(result?.message).toContain('master');
+  });
+
+  it('blocks git push on main when level is block, with remediation text', () => {
+    const exec = makeExec({ 'git branch --show-current': 'main' });
+    const result = checkBranchDisciplineCommand('git push', cfg('block'), cache, exec);
+    expect(result).not.toBeNull();
+    expect(result?.level).toBe('block');
+    expect(result?.message).toContain('[BLOCK]');
+    expect(result?.message).toContain('main');
+    expect(result?.message).toContain('feature branch');
+    expect(result?.message).toContain('PR');
+    expect(result?.message).toContain('rules.workflow.branch_discipline: block');
+  });
+
+  it('returns null for git commit on a feature branch', () => {
+    const exec = makeExec({ 'git branch --show-current': 'feat/x' });
+    const result = checkBranchDisciplineCommand('git commit -m "x"', cfg('advise'), cache, exec);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when "git commit" appears only inside quotes', () => {
+    const calls: string[] = [];
+    const exec = makeExec({ 'git branch --show-current': 'master' }, calls);
+    const result = checkBranchDisciplineCommand('echo "git commit"', cfg('advise'), cache, exec);
+    expect(result).toBeNull();
+    expect(calls).toEqual([]); // never resolves the branch for a quoted mention
+  });
+
+  it('returns null for read-only git commands (status, diff)', () => {
+    const calls: string[] = [];
+    const exec = makeExec({ 'git branch --show-current': 'master' }, calls);
+    expect(checkBranchDisciplineCommand('git status', cfg('advise'), cache, exec)).toBeNull();
+    expect(checkBranchDisciplineCommand('git diff', cfg('advise'), cache, exec)).toBeNull();
+    expect(calls).toEqual([]); // pattern gate rejects before branch resolution
+  });
+
+  it('returns null when level is silent', () => {
+    const calls: string[] = [];
+    const exec = makeExec({ 'git branch --show-current': 'master' }, calls);
+    const result = checkBranchDisciplineCommand('git commit -m "x"', cfg('silent'), cache, exec);
+    expect(result).toBeNull();
+    expect(calls).toEqual([]); // silent short-circuits before branch resolution
+  });
+
+  it('returns null when not a git repo (exec throws)', () => {
+    const exec = makeExec({ 'git branch --show-current': new Error('not a repo') });
+    const result = checkBranchDisciplineCommand('git commit -m "x"', cfg('advise'), cache, exec);
+    expect(result).toBeNull();
+  });
+
+  it('uses worktree wording when auto strategy sees a dirty tree', () => {
+    const exec = makeExec({
+      'git branch --show-current': 'master',
+      'git status --porcelain': ' M src/a.ts\n',
+    });
+    const result = checkBranchDisciplineCommand('git commit -m "x"', cfg('advise'), cache, exec);
+    expect(result).not.toBeNull();
+    expect(result?.message).toContain('using-git-worktrees');
+  });
+});
+
+describe('handlePreToolUse branch discipline wiring', () => {
+  let cache: SessionCache;
+  let config: HarnessConfig;
+
+  beforeEach(() => {
+    cache = new SessionCache();
+    cache.setEnvironment(makeEnv());
+  });
+
+  it('returns the [ADVISE] message for git commit on master at advise level', () => {
+    config = cfg('advise');
+    const exec = makeExec({
+      'git branch --show-current': 'master',
+      'git status --porcelain': '',
+    });
+    const result = handlePreToolUse(
+      'Bash',
+      { command: 'git commit -m "x"' },
+      cache,
+      config,
+      undefined,
+      { branchExec: exec },
+    );
+    expect(typeof result).toBe('string');
+    expect(result).toContain('[ADVISE]');
+    expect(result).toContain('Branch discipline');
+    expect(result).toContain('master');
+  });
+
+  it('returns the [BLOCK] message for git push on master at block level', () => {
+    config = cfg('block');
+    const exec = makeExec({ 'git branch --show-current': 'master' });
+    const result = handlePreToolUse(
+      'Bash',
+      { command: 'git push origin master' },
+      cache,
+      config,
+      undefined,
+      { branchExec: exec },
+    );
+    expect(typeof result).toBe('string');
+    expect(result).toContain('[BLOCK]');
+    expect(result).toContain('Branch discipline');
+  });
+
+  it('passes git commit through on a feature branch', () => {
+    config = cfg('advise');
+    const exec = makeExec({ 'git branch --show-current': 'feat/x' });
+    const result = handlePreToolUse(
+      'Bash',
+      { command: 'git commit -m "x"' },
+      cache,
+      config,
+      undefined,
+      { branchExec: exec },
+    );
+    expect(result).toBeNull();
+  });
+});

--- a/tests/session/start.test.ts
+++ b/tests/session/start.test.ts
@@ -140,7 +140,21 @@ describe('handleSessionStart', () => {
     expect(output).toContain('indexed');
   });
 
-  it('includes worktree suggestion when on master', async () => {
+  it('includes branch discipline hint with worktree wording on master with dirty tree', async () => {
+    vi.mocked(execSync).mockImplementation((cmd: string) => {
+      if (cmd === 'which rtk') throw new Error('not found');
+      if (cmd === 'which jcodemunch') throw new Error('not found');
+      if (cmd === 'git branch --show-current') return 'master';
+      if (cmd === 'git status --porcelain') return ' M src/a.ts\n';
+      return '';
+    });
+
+    const output = await startSession('/home/user/test-project', cache);
+    expect(output).toContain('branch discipline');
+    expect(output).toContain('using-git-worktrees');
+  });
+
+  it('includes branch discipline hint with feature-branch wording on master with clean tree', async () => {
     vi.mocked(execSync).mockImplementation((cmd: string) => {
       if (cmd === 'which rtk') throw new Error('not found');
       if (cmd === 'which jcodemunch') throw new Error('not found');
@@ -149,10 +163,11 @@ describe('handleSessionStart', () => {
     });
 
     const output = await startSession('/home/user/test-project', cache);
-    expect(output).toContain('using-git-worktrees');
+    expect(output).toContain('branch discipline');
+    expect(output).toContain('feature branch');
   });
 
-  it('omits worktree suggestion when on feature branch', async () => {
+  it('omits branch discipline hint when on feature branch', async () => {
     vi.mocked(execSync).mockImplementation((cmd: string) => {
       if (cmd === 'which rtk') throw new Error('not found');
       if (cmd === 'which jcodemunch') throw new Error('not found');
@@ -162,6 +177,7 @@ describe('handleSessionStart', () => {
 
     const output = await startSession('/home/user/test-project', cache);
     expect(output).not.toContain('using-git-worktrees');
+    expect(output).not.toContain('branch discipline');
   });
 
   it('warns when rtk is not installed', async () => {

--- a/tests/session/start.test.ts
+++ b/tests/session/start.test.ts
@@ -323,6 +323,47 @@ describe('handleSessionStart', () => {
     expect(output).toContain('no_mocks');
   });
 
+  it('includes branch_discipline in active enforcement when not silent', async () => {
+    vi.mocked(execSync).mockImplementation((cmd: string) => {
+      if (cmd === 'which rtk') return '/usr/bin/rtk';
+      if (cmd === 'which jcodemunch') return '/usr/bin/jcodemunch';
+      if (cmd.includes('list_repos')) return '{"repos":["local/test-project"]}';
+      return '';
+    });
+
+    // Default config: branch_discipline is advise — it must appear in the
+    // active-rules line so skill templates' "see session-start output"
+    // anchor is never empty for branch discipline.
+    const output = await startSession('/home/user/test-project', cache);
+    expect(output).toContain('Active enforcement');
+    expect(output).toContain('branch_discipline (advise)');
+  });
+
+  it('omits branch_discipline from active enforcement when silent', async () => {
+    vi.mocked(execSync).mockImplementation((cmd: string) => {
+      if (cmd === 'which rtk') return '/usr/bin/rtk';
+      if (cmd === 'which jcodemunch') return '/usr/bin/jcodemunch';
+      if (cmd.includes('list_repos')) return '{"repos":["local/test-project"]}';
+      return '';
+    });
+
+    const { writeFileSync, mkdirSync, rmSync } = await import('node:fs');
+    const { join } = await import('node:path');
+    const configDir = '/tmp/rig-test-config-' + process.pid + '-bd-silent';
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, '.harness.yaml'), [
+      'rules:',
+      '  workflow:',
+      '    branch_discipline: silent',
+    ].join('\n'));
+
+    const output = await startSession(configDir, cache);
+    expect(output).toContain('Active enforcement'); // constitutional defaults still active
+    expect(output).not.toContain('branch_discipline');
+
+    rmSync(configDir, { recursive: true });
+  });
+
   it('omits active enforcement line when all constitutional rules are silent', async () => {
     vi.mocked(execSync).mockImplementation((cmd: string) => {
       if (cmd === 'which rtk') return '/usr/bin/rtk';
@@ -342,6 +383,8 @@ describe('handleSessionStart', () => {
       '    no_mocks: silent',
       '    evidence_only: silent',
       '    full_accounting: silent',
+      '  workflow:',
+      '    branch_discipline: silent',
     ].join('\n'));
 
     const output = await startSession(configDir, cache);

--- a/tests/session/worktree.test.ts
+++ b/tests/session/worktree.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { checkWorktreeSuggestion, checkBranchDiscipline } from '../../src/session/worktree.js';
+import { checkWorktreeSuggestion, checkBranchDiscipline, resolveIsolationStrategy } from '../../src/session/worktree.js';
 import { DEFAULT_CONFIG } from '../../src/config.js';
 
 function makeExec(results: Record<string, string | Error>) {
@@ -80,5 +80,12 @@ describe('checkBranchDiscipline', () => {
     expect(checkBranchDiscipline(exec, cfg('advise'))).toBe('');
     const noGit = makeExec({ 'git branch --show-current': new Error('not a repo') });
     expect(checkBranchDiscipline(noGit, cfg('advise'))).toBe('');
+  });
+});
+
+describe('resolveIsolationStrategy', () => {
+  it('falls back to branch when git status throws after branch resolution succeeds', () => {
+    const exec = makeExec({ 'git status --porcelain': new Error('git status failed') });
+    expect(resolveIsolationStrategy('auto', exec)).toBe('branch');
   });
 });

--- a/tests/session/worktree.test.ts
+++ b/tests/session/worktree.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { checkWorktreeSuggestion } from '../../src/session/worktree.js';
+import { checkWorktreeSuggestion, checkBranchDiscipline } from '../../src/session/worktree.js';
+import { DEFAULT_CONFIG } from '../../src/config.js';
 
 function makeExec(results: Record<string, string | Error>) {
   return (cmd: string): string => {
@@ -9,16 +10,22 @@ function makeExec(results: Record<string, string | Error>) {
   };
 }
 
+function cfg(level: string, strategy = 'auto', branches = ['master', 'main']) {
+  const c = structuredClone(DEFAULT_CONFIG);
+  c.rules.workflow = { branch_discipline: level as never, protected_branches: branches, isolation_strategy: strategy as never };
+  return c;
+}
+
 describe('checkWorktreeSuggestion', () => {
-  it('returns suggestion when on master', () => {
-    const exec = makeExec({ 'git branch --show-current': 'master' });
+  it('returns branch-discipline hint when on master with a dirty tree (worktree wording)', () => {
+    const exec = makeExec({ 'git branch --show-current': 'master', 'git status --porcelain': ' M src/a.ts\n' });
     const result = checkWorktreeSuggestion('/some/project', exec);
     expect(result).toContain('master');
     expect(result).toContain('using-git-worktrees');
   });
 
-  it('returns suggestion when on main', () => {
-    const exec = makeExec({ 'git branch --show-current': 'main' });
+  it('returns branch-discipline hint when on main with a dirty tree (worktree wording)', () => {
+    const exec = makeExec({ 'git branch --show-current': 'main', 'git status --porcelain': ' M src/a.ts\n' });
     const result = checkWorktreeSuggestion('/some/project', exec);
     expect(result).toContain('main');
     expect(result).toContain('using-git-worktrees');
@@ -34,5 +41,44 @@ describe('checkWorktreeSuggestion', () => {
     const exec = makeExec({ 'git branch --show-current': new Error('not a git repo') });
     const result = checkWorktreeSuggestion('/some/project', exec);
     expect(result).toBe('');
+  });
+});
+
+describe('checkBranchDiscipline', () => {
+  it('silent level suppresses the hint entirely', () => {
+    const exec = makeExec({ 'git branch --show-current': 'master', 'git status --porcelain': '' });
+    expect(checkBranchDiscipline('/p', exec, cfg('silent'))).toBe('');
+  });
+
+  it('advise on protected branch with clean tree recommends a feature branch', () => {
+    const exec = makeExec({ 'git branch --show-current': 'master', 'git status --porcelain': '' });
+    const out = checkBranchDiscipline('/p', exec, cfg('advise'));
+    expect(out).toContain('master');
+    expect(out).toContain('branch discipline');
+    expect(out).toContain('feature branch');
+    expect(out).toContain('PR');
+  });
+
+  it('auto strategy recommends worktree when tree is dirty', () => {
+    const exec = makeExec({ 'git branch --show-current': 'main', 'git status --porcelain': ' M src/a.ts\n' });
+    const out = checkBranchDiscipline('/p', exec, cfg('advise'));
+    expect(out).toContain('using-git-worktrees');
+  });
+
+  it('worktree strategy always recommends worktree', () => {
+    const exec = makeExec({ 'git branch --show-current': 'master', 'git status --porcelain': '' });
+    expect(checkBranchDiscipline('/p', exec, cfg('advise', 'worktree'))).toContain('using-git-worktrees');
+  });
+
+  it('respects custom protected_branches', () => {
+    const exec = makeExec({ 'git branch --show-current': 'develop', 'git status --porcelain': '' });
+    expect(checkBranchDiscipline('/p', exec, cfg('advise', 'auto', ['develop']))).toContain('develop');
+  });
+
+  it('returns empty on feature branch and outside git repos', () => {
+    const exec = makeExec({ 'git branch --show-current': 'feat/x', 'git status --porcelain': '' });
+    expect(checkBranchDiscipline('/p', exec, cfg('advise'))).toBe('');
+    const noGit = makeExec({ 'git branch --show-current': new Error('not a repo') });
+    expect(checkBranchDiscipline('/p', noGit, cfg('advise'))).toBe('');
   });
 });

--- a/tests/session/worktree.test.ts
+++ b/tests/session/worktree.test.ts
@@ -47,12 +47,12 @@ describe('checkWorktreeSuggestion', () => {
 describe('checkBranchDiscipline', () => {
   it('silent level suppresses the hint entirely', () => {
     const exec = makeExec({ 'git branch --show-current': 'master', 'git status --porcelain': '' });
-    expect(checkBranchDiscipline('/p', exec, cfg('silent'))).toBe('');
+    expect(checkBranchDiscipline(exec, cfg('silent'))).toBe('');
   });
 
   it('advise on protected branch with clean tree recommends a feature branch', () => {
     const exec = makeExec({ 'git branch --show-current': 'master', 'git status --porcelain': '' });
-    const out = checkBranchDiscipline('/p', exec, cfg('advise'));
+    const out = checkBranchDiscipline(exec, cfg('advise'));
     expect(out).toContain('master');
     expect(out).toContain('branch discipline');
     expect(out).toContain('feature branch');
@@ -61,24 +61,24 @@ describe('checkBranchDiscipline', () => {
 
   it('auto strategy recommends worktree when tree is dirty', () => {
     const exec = makeExec({ 'git branch --show-current': 'main', 'git status --porcelain': ' M src/a.ts\n' });
-    const out = checkBranchDiscipline('/p', exec, cfg('advise'));
+    const out = checkBranchDiscipline(exec, cfg('advise'));
     expect(out).toContain('using-git-worktrees');
   });
 
   it('worktree strategy always recommends worktree', () => {
     const exec = makeExec({ 'git branch --show-current': 'master', 'git status --porcelain': '' });
-    expect(checkBranchDiscipline('/p', exec, cfg('advise', 'worktree'))).toContain('using-git-worktrees');
+    expect(checkBranchDiscipline(exec, cfg('advise', 'worktree'))).toContain('using-git-worktrees');
   });
 
   it('respects custom protected_branches', () => {
     const exec = makeExec({ 'git branch --show-current': 'develop', 'git status --porcelain': '' });
-    expect(checkBranchDiscipline('/p', exec, cfg('advise', 'auto', ['develop']))).toContain('develop');
+    expect(checkBranchDiscipline(exec, cfg('advise', 'auto', ['develop']))).toContain('develop');
   });
 
   it('returns empty on feature branch and outside git repos', () => {
     const exec = makeExec({ 'git branch --show-current': 'feat/x', 'git status --porcelain': '' });
-    expect(checkBranchDiscipline('/p', exec, cfg('advise'))).toBe('');
+    expect(checkBranchDiscipline(exec, cfg('advise'))).toBe('');
     const noGit = makeExec({ 'git branch --show-current': new Error('not a repo') });
-    expect(checkBranchDiscipline('/p', noGit, cfg('advise'))).toBe('');
+    expect(checkBranchDiscipline(noGit, cfg('advise'))).toBe('');
   });
 });


### PR DESCRIPTION
Implements docs/superpowers/specs/2026-06-12-branch-discipline-design.md (plan: docs/superpowers/plans/2026-06-12-branch-discipline.md).

**Config** — `rules.workflow`: `branch_discipline: silent|advise|block` (default advise), `protected_branches` (default master/main), `isolation_strategy: auto|branch|worktree` (auto: dirty tree or plan execution → worktree, else plain branch).

**Three seams:**
- **Session start** — the old unconditional worktree hint becomes config-aware `checkBranchDiscipline`: level-gated, strategy-aware wording, PR expectation; `silent` is the new off switch. Branch discipline now appears in the active-rules emission so every plus-skill inherits awareness.
- **Commit time (PreToolUse Step 1.6)** — `git commit|push` detected across quote-aware compound segments **and behind git global options** (`git -c … commit`); advise = once-per-session agent-visible advisory (zero subprocess cost once consumed); block = exit 2 with remediation. Pre-rewrite checks now pick by severity, so a test-scope advisory can never preempt a discipline block.
- **Skill chain** — tdd+/sdd+ preflight (isolated workspace before implementing: worktree when multi-task/dirty, branch otherwise); review+ prefers `gh pr create` when the rule is active.

Never auto-creates branches/worktrees, never opens PRs, blocks only by explicit config.

**Review trail:** per-task spec reviews (typed spec-reviewer, all compliant), whole-branch quality review (typed code-reviewer: 'with fixes' — all 8 findings addressed, including two block-bypass holes), executed via sdd+ with worktree-isolated implementers. 1238 tests (+39), coverage 96.9%/91.0%, docs across README/getting-started/architecture/skill-wrapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)