### PR TITLE
fix: enforcement reads real hook payloads; stale-test turn model; PreToolUse structured severity

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -214,6 +214,18 @@ grace period, source edits without corresponding test edits trigger a warning.
 The source's creation turn is exempt -- you don't get flagged for the edit you
 just made.
 
+**Turn model (cross-process):** hooks run as separate processes, so each
+invocation builds a fresh `FileTracker` — an in-memory turn counter alone
+would never advance and the creation-turn exemption would apply forever. A
+"turn" is therefore defined as **one PostToolUse Edit/Write invocation**: the
+counter and a turn-stamped edit history persist in the session cache, and the
+handler hydrates the fresh tracker from that history before running the
+check. With `grace_period: 0`, a source file edited in one invocation and
+still uncovered by a matching test edit fires on the next Edit/Write
+invocation — and keeps firing on subsequent ones until a covering test edit
+is recorded. Entering `tdd+`/`sdd+` from another phase clears the history
+along with the edited-file sets (the counter stays monotonic).
+
 ### Test scope control
 
 During `tdd+` or `sdd+` phase, running the full test suite (e.g., `npm test`,

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -83,7 +83,7 @@ JSON. The seam for a custom check is the generated hook script, around that
 ```typescript
 // In .claude/hooks/scripts/post-tool-use.ts (the generated file), after:
 //   const result = handlePostToolUse(input.tool_name, input.tool_input,
-//     tracker, cache, config, execFn);
+//     tracker, cache, config, execFn, input.tool_response);
 import { checkSecrets } from './check-secrets.js';
 
 let custom: EnforcementViolation | null = null;

--- a/src/enforcement/file-tracker.ts
+++ b/src/enforcement/file-tracker.ts
@@ -45,6 +45,20 @@ export class FileTracker {
     this.turn++;
   }
 
+  /**
+   * Set the current turn explicitly. Used by the cross-process turn model:
+   * hooks rebuild a fresh FileTracker per invocation and replay turn-stamped
+   * edits from the session cache, so the turn cannot be derived by counting
+   * nextTurn() calls within one process.
+   */
+  setTurn(turn: number): void {
+    this.turn = turn;
+  }
+
+  getTurn(): number {
+    return this.turn;
+  }
+
   getSourceEdits(): FileEdit[] {
     return [...this.sourceEdits];
   }

--- a/src/enforcement/post-tool-use.ts
+++ b/src/enforcement/post-tool-use.ts
@@ -13,10 +13,40 @@ import {
 import type { ExecFn } from '../session/metrics.js';
 
 /**
+ * Extract a Bash command's output from the PostToolUse payload.
+ *
+ * Claude Code delivers command output in `tool_response` — either a plain
+ * string or an object carrying `stdout`/`stderr` (joined here because test
+ * runners routinely report failures on stderr). `tool_input.output` is kept
+ * as a fallback for older harnesses and hand-built fixtures; it is never
+ * populated by current Claude Code payloads.
+ */
+export function extractBashOutput(
+  toolResponse: unknown,
+  args: Record<string, unknown>,
+): string | undefined {
+  if (typeof toolResponse === 'string' && toolResponse.length > 0) {
+    return toolResponse;
+  }
+  if (toolResponse && typeof toolResponse === 'object') {
+    const response = toolResponse as Record<string, unknown>;
+    const parts = [response.stdout, response.stderr].filter(
+      (v): v is string => typeof v === 'string' && v.length > 0,
+    );
+    if (parts.length > 0) return parts.join('\n');
+  }
+  const legacy = args.output;
+  return typeof legacy === 'string' && legacy.length > 0 ? legacy : undefined;
+}
+
+/**
  * PostToolUse hook handler. Composes all enforcement checks.
  * Returns null if all clean, or a combined violation whose level is derived
  * from the checks themselves (any block-level violation → 'block') — never
  * from message text, which can embed arbitrary tool output.
+ *
+ * `toolResponse` is the hook payload's `tool_response` field — the real
+ * channel for command output (see extractBashOutput).
  */
 export function handlePostToolUse(
   tool: string,
@@ -25,6 +55,7 @@ export function handlePostToolUse(
   cache: SessionCache,
   config: HarnessConfig,
   execFn?: ExecFn,
+  toolResponse?: unknown,
 ): EnforcementViolation | null {
   const metric = incrementMetric(tool, args);
   if (metric) {
@@ -77,7 +108,7 @@ export function handlePostToolUse(
   // Zero-defect check on test command output
   if (tool === 'Bash') {
     const command = args.command as string;
-    const output = args.output as string;
+    const output = extractBashOutput(toolResponse, args);
 
     if (command && output) {
       // Check if this was a test run

--- a/src/enforcement/post-tool-use.ts
+++ b/src/enforcement/post-tool-use.ts
@@ -83,15 +83,37 @@ export function handlePostToolUse(
   // Track file edits
   if (tool === 'Edit' || tool === 'Write') {
     const filePath = args.file_path as string;
+
+    // Cross-process turn model: hooks run as separate processes, so the
+    // FileTracker arrives empty and its in-memory turn counter never
+    // advances — which made the creation-turn exemption apply forever and
+    // left the stale-test check dormant. A "turn" is one PostToolUse
+    // Edit/Write invocation: the counter and the turn-stamped edit history
+    // persist in the session cache. An empty tracker (the real hook case)
+    // is hydrated from history; a tracker that already carries edits
+    // (same-process reuse in unit tests) is left intact to avoid duplicates.
+    const turn = cache.advanceEditTurn();
+    if (tracker.getSourceEdits().length === 0 && tracker.getTestEdits().length === 0) {
+      for (const edit of cache.getEditHistory()) {
+        tracker.setTurn(edit.turn);
+        tracker.recordEdit(edit.file);
+      }
+    }
+    // Never rewind: a same-process tracker may have advanced its own turn
+    // (nextTurn) past the cache counter; the effective turn is the max.
+    tracker.setTurn(Math.max(turn, tracker.getTurn()));
+
     if (filePath) {
       tracker.recordEdit(filePath);
 
       // Persist to the session cache: hooks run as separate processes, so the
       // in-memory FileTracker resets between invocations. The cache is what
-      // lets the PreToolUse test-scope check see prior source edits.
+      // lets the PreToolUse test-scope check and the stale-test turn model
+      // see prior edits.
       const category = tracker.classifyFile(filePath);
       if (category === 'source' || category === 'test') {
         cache.addEditedFile(filePath, category);
+        cache.recordEditTurn(filePath, category, turn);
       }
 
       // Constitutional check on edited test files

--- a/src/enforcement/stale-test.ts
+++ b/src/enforcement/stale-test.ts
@@ -8,6 +8,7 @@ import type { EnforcementViolation, HarnessConfig } from '../types.js';
 export function checkStaleTests(tracker: FileTracker, config: HarnessConfig): EnforcementViolation | null {
   const gracePeriod = config.rules.stale_tests?.grace_period ?? 0;
   const enforcement = config.rules.stale_tests?.enforcement ?? 'advise';
+  if (enforcement === 'silent') return null;
   const stale = tracker.getStaleSources(gracePeriod);
 
   if (stale.length === 0) return null;

--- a/src/enforcement/test-scope.ts
+++ b/src/enforcement/test-scope.ts
@@ -1,4 +1,4 @@
-import type { HarnessConfig } from '../types.js';
+import type { EnforcementViolation, HarnessConfig } from '../types.js';
 
 const UNSCOPED_TEST_PATTERNS = [
   { pattern: /^(npx\s+)?vitest\s+run\s*$/, runner: 'npx vitest run' },
@@ -37,14 +37,16 @@ function deriveTestPath(sourcePath: string): string {
 /**
  * Check if a test command should be scoped based on the current phase and
  * recent source edits (file paths, e.g. from the session cache).
- * Returns null if no redirect needed.
+ * Returns null if no redirect needed, or a violation carrying its level —
+ * severity is structural ({ level, message }), never sniffed from the
+ * message text.
  */
 export function checkTestScope(
   command: string,
   currentPhase: string | null,
   sourceEdits: string[],
   config: HarnessConfig,
-): string | null {
+): EnforcementViolation | null {
   // Only enforce during scoped-execution phases (tdd+ and sdd+ tasks both run scoped)
   if (!currentPhase || !SCOPED_PHASES.includes(currentPhase)) return null;
 
@@ -59,7 +61,8 @@ export function checkTestScope(
 
   if (sourceEdits.length === 0) return null;
 
-  const prefix = enforcement === 'block' ? '[BLOCK]' : '[ADVISE]';
+  const level = enforcement === 'block' ? 'block' : 'advise';
+  const prefix = level === 'block' ? '[BLOCK]' : '[ADVISE]';
 
   const testPaths = sourceEdits.map(deriveTestPath);
   const scopedCommand = `${runner} ${testPaths.join(' ')}`;
@@ -76,5 +79,5 @@ export function checkTestScope(
     `Full suite runs are reserved for the verify+ phase (final verification).`,
   ];
 
-  return lines.join('\n');
+  return { level, message: lines.join('\n') };
 }

--- a/src/router/hook.ts
+++ b/src/router/hook.ts
@@ -1,6 +1,6 @@
 import { execFileSync, execSync } from 'node:child_process';
 import { appendFileSync } from 'node:fs';
-import type { HarnessConfig, RewriteResult } from '../types.js';
+import type { EnforcementViolation, HarnessConfig, RewriteResult } from '../types.js';
 import { SessionCache } from '../session/cache.js';
 import { findMatchingRule, getDefaultRules } from './rules.js';
 import { resolve } from './resolver.js';
@@ -141,8 +141,11 @@ function defaultEnv() {
 }
 
 /**
- * PreToolUse hook handler. Returns null to allow, a string to advise/block,
- * or a RewriteResult to transparently rewrite the tool call.
+ * PreToolUse hook handler. Returns null to allow, a structured
+ * EnforcementViolation ({ level, message }) to advise/block, or a
+ * RewriteResult to transparently rewrite the tool call. Severity is
+ * structural — the hook template switches on `level`, never on message-text
+ * prefixes like '[BLOCK]', which can legitimately appear inside messages.
  *
  * Flow:
  * 1. Resolution-level blocks (file_modify, rtk_cat_code) — always block
@@ -157,7 +160,7 @@ export function handlePreToolUse(
   config: HarnessConfig,
   cwd?: string,
   options?: ExecRewriteFn | HookOptions,
-): string | RewriteResult | null {
+): EnforcementViolation | RewriteResult | null {
   const effectiveCwd = cwd ?? process.cwd();
   const resolvedOptions: HookOptions = typeof options === 'function'
     ? { execRewrite: options }
@@ -175,14 +178,18 @@ export function handlePreToolUse(
       // advises, then every ADVISORY_READVISE_PERIOD-th suppressed
       // occurrence re-advises.
       if (enforcement === 'advise' && !cache.shouldAdvise('scout_explore')) return null;
-      const prefix = enforcement === 'block' ? '[BLOCK]' : '[ADVISE]';
-      return [
-        `${prefix} Tool Router: scout_explore detected`,
-        `advise: use scout — You MUST use Agent with subagent_type: "scout" instead of Explore when examining codebases. Scout uses jcodemunch and graphify MCP tools for token-efficient exploration (80%+ fewer tokens).`,
-        enforcement === 'block'
-          ? 'This operation is blocked by .harness.yaml. Use the recommended tool instead.'
-          : 'Do not dismiss this advisory. Switch to subagent_type: "scout" now.',
-      ].join('\n');
+      const level = enforcement === 'block' ? 'block' : 'advise';
+      const prefix = level === 'block' ? '[BLOCK]' : '[ADVISE]';
+      return {
+        level,
+        message: [
+          `${prefix} Tool Router: scout_explore detected`,
+          `advise: use scout — You MUST use Agent with subagent_type: "scout" instead of Explore when examining codebases. Scout uses jcodemunch and graphify MCP tools for token-efficient exploration (80%+ fewer tokens).`,
+          level === 'block'
+            ? 'This operation is blocked by .harness.yaml. Use the recommended tool instead.'
+            : 'Do not dismiss this advisory. Switch to subagent_type: "scout" now.',
+        ].join('\n'),
+      };
     }
     // jcodemunch not available — fall through to file_discovery
     match = findMatchingRule(tool, args, rules, new Set(['scout_explore']));
@@ -192,11 +199,14 @@ export function handlePreToolUse(
   if (match) {
     const resolution = resolve(match, env);
     if (resolution.action === 'block') {
-      return [
-        `[BLOCK] Tool Router: ${match.intent} operation blocked`,
-        `Reason: ${resolution.reason}`,
-        'This operation is always blocked. Use the recommended alternative.',
-      ].join('\n');
+      return {
+        level: 'block',
+        message: [
+          `[BLOCK] Tool Router: ${match.intent} operation blocked`,
+          `Reason: ${resolution.reason}`,
+          'This operation is always blocked. Use the recommended alternative.',
+        ].join('\n'),
+      };
     }
   }
 
@@ -209,7 +219,7 @@ export function handlePreToolUse(
   // today because no UNSCOPED_TEST_PATTERNS command is rtk- or
   // python-rewritable — revisit if RTK_PREFIXES ever gains test runners.
   if (tool === 'Bash' && typeof args.command === 'string') {
-    const preflight: { level: 'advise' | 'block'; message: string }[] = [];
+    const preflight: EnforcementViolation[] = [];
 
     // Step 1.5: Test-scope check — during tdd+/sdd+, advise a scoped run
     // before a full-suite command executes. Hooks are separate processes, so
@@ -222,12 +232,7 @@ export function handlePreToolUse(
       cache.getEditedFiles('source'),
       config,
     );
-    if (scopeViolation) {
-      preflight.push({
-        level: scopeViolation.startsWith('[BLOCK]') ? 'block' : 'advise',
-        message: scopeViolation,
-      });
-    }
+    if (scopeViolation) preflight.push(scopeViolation);
 
     // Step 1.6: Branch discipline — git commit/push on a protected branch
     // advises on the first occurrence and every ADVISORY_READVISE_PERIOD-th
@@ -241,8 +246,8 @@ export function handlePreToolUse(
     if (discipline) preflight.push(discipline);
 
     const blocked = preflight.find(r => r.level === 'block');
-    if (blocked) return blocked.message;
-    if (preflight.length > 0) return preflight[0].message;
+    if (blocked) return blocked;
+    if (preflight.length > 0) return preflight[0];
   }
 
   // Step 2: Python environment rewrite for Bash commands (skip compound commands)
@@ -294,16 +299,19 @@ export function handlePreToolUse(
     if (!cache.shouldAdvise(match.intent)) return null;
   }
 
-  const prefix = enforcementLevel === 'block' ? '[BLOCK]' : '[ADVISE]';
-
   if (resolution.action === 'advise') {
-    return [
-      `${prefix} Tool Router: ${match.intent} detected`,
-      `advise: use ${resolution.tool} — ${resolution.reason}`,
-      enforcementLevel === 'block'
-        ? 'This operation is blocked by .harness.yaml. Use the recommended tool instead.'
-        : 'Consider using the recommended tool for better efficiency.',
-    ].join('\n');
+    const level = enforcementLevel === 'block' ? 'block' : 'advise';
+    const prefix = level === 'block' ? '[BLOCK]' : '[ADVISE]';
+    return {
+      level,
+      message: [
+        `${prefix} Tool Router: ${match.intent} detected`,
+        `advise: use ${resolution.tool} — ${resolution.reason}`,
+        level === 'block'
+          ? 'This operation is blocked by .harness.yaml. Use the recommended tool instead.'
+          : 'Consider using the recommended tool for better efficiency.',
+      ].join('\n'),
+    };
   }
 
   return null;

--- a/src/session/cache.ts
+++ b/src/session/cache.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 import { readFileSync, writeFileSync, existsSync, unlinkSync, realpathSync } from 'node:fs';
 import { join } from 'node:path';
-import type { Environment, GraphBuildInfo, GraphifyProjectStats, MetricsBaseline, PythonEnv, SessionCacheFile } from '../types.js';
+import type { EditHistoryEntry, Environment, GraphBuildInfo, GraphifyProjectStats, MetricsBaseline, PythonEnv, SessionCacheFile } from '../types.js';
 
 const ENV_TTL_MS = 4 * 60 * 60 * 1000; // 4 hours
 
@@ -43,6 +43,8 @@ export class SessionCache {
   private pythonEnv: PythonEnv | undefined;
   private advisedIntents: Set<string> = new Set();
   private advisorySuppressCounts: Map<string, number> = new Map();
+  private editTurnCounter = 0;
+  private editHistory: EditHistoryEntry[] = [];
 
   constructor(cwd?: string, sessionId?: string) {
     this.cwd = cwd;
@@ -85,13 +87,42 @@ export class SessionCache {
   }
 
   /**
-   * Clear all recorded source and test edits. Called when a scoped-execution
-   * phase (tdd+/sdd+) is entered from a different phase, so test-scope
-   * suggestions reflect the current feature's edits, not the whole session's.
+   * Clear all recorded source and test edits (including the turn-stamped
+   * history). Called when a scoped-execution phase (tdd+/sdd+) is entered
+   * from a different phase, so test-scope suggestions and stale-test checks
+   * reflect the current feature's edits, not the whole session's. The turn
+   * counter itself stays monotonic — only the history is scoped.
    */
   clearEditedFiles(): void {
     this.editedFiles.clear();
+    this.editHistory = [];
     this.save();
+  }
+
+  /**
+   * Cross-process turn model for the stale-test check: one PostToolUse
+   * Edit/Write invocation = one turn. Hooks run as separate processes, so
+   * the counter must live here, not in the in-memory FileTracker.
+   */
+  getEditTurn(): number {
+    return this.editTurnCounter;
+  }
+
+  /** Advance the edit-turn counter and return the new turn number. */
+  advanceEditTurn(): number {
+    this.editTurnCounter++;
+    this.save();
+    return this.editTurnCounter;
+  }
+
+  /** Record a turn-stamped edit for cross-process stale-test detection. */
+  recordEditTurn(file: string, category: 'source' | 'test', turn: number): void {
+    this.editHistory.push({ file, category, turn });
+    this.save();
+  }
+
+  getEditHistory(): EditHistoryEntry[] {
+    return [...this.editHistory];
   }
 
   setPhase(phase: string): void {
@@ -233,6 +264,8 @@ export class SessionCache {
     this.pythonEnv = undefined;
     this.advisedIntents = new Set();
     this.advisorySuppressCounts = new Map();
+    this.editTurnCounter = 0;
+    this.editHistory = [];
     this.save();
   }
 
@@ -255,6 +288,8 @@ export class SessionCache {
       pythonEnv: this.pythonEnv ?? null,
       advisedIntents: Array.from(this.advisedIntents),
       advisorySuppressCounts: Object.fromEntries(this.advisorySuppressCounts),
+      editTurnCounter: this.editTurnCounter,
+      editHistory: [...this.editHistory],
     };
   }
 
@@ -293,6 +328,8 @@ export class SessionCache {
       this.pythonEnv = data.pythonEnv ?? undefined;
       this.advisedIntents = new Set(data.advisedIntents ?? []);
       this.advisorySuppressCounts = new Map(Object.entries(data.advisorySuppressCounts ?? {}));
+      this.editTurnCounter = data.editTurnCounter ?? 0;
+      this.editHistory = data.editHistory ?? [];
     } catch {
       // Corrupt or unreadable file — start fresh
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -171,6 +171,16 @@ export interface SessionCacheFile {
   advisedIntents?: string[];
   advisorySuppressCounts?: Record<string, number>;
   scoutedDirs?: string[];
+  editTurnCounter?: number;
+  editHistory?: EditHistoryEntry[];
+}
+
+/** A turn-stamped file edit, persisted for the cross-process stale-test
+ * turn model: one PostToolUse Edit/Write invocation = one turn. */
+export interface EditHistoryEntry {
+  file: string;
+  category: 'source' | 'test';
+  turn: number;
 }
 
 // ── Config Types ──

--- a/templates/hooks/post-tool-use.ts
+++ b/templates/hooks/post-tool-use.ts
@@ -52,7 +52,9 @@ import { execSync } from 'node:child_process';
     execSync(cmd, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], ...opts }) as string;
 
   loadConfig(resolve(cwd, '.harness.yaml')).then((config: any) => {
-    const result = handlePostToolUse(input.tool_name, input.tool_input, tracker, cache, config, execFn);
+    // tool_response carries the tool's real output (Bash stdout/stderr) —
+    // tool_input never does in current Claude Code payloads.
+    const result = handlePostToolUse(input.tool_name, input.tool_input, tracker, cache, config, execFn, input.tool_response);
 
     if (result) {
       // The severity comes from the structured result's level, derived by the

--- a/templates/hooks/pre-tool-use.ts
+++ b/templates/hooks/pre-tool-use.ts
@@ -46,7 +46,7 @@ import { readFileSync } from 'node:fs';
     const result = handlePreToolUse(input.tool_name, input.tool_input, cache, config);
 
     // Transparent rewrite: output JSON with updatedInput
-    if (result && typeof result === 'object' && result.type === 'rewrite') {
+    if (result && result.type === 'rewrite') {
       const output = JSON.stringify({
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',
@@ -57,10 +57,13 @@ import { readFileSync } from 'node:fs';
       process.exit(0);
     }
 
-    // Block: exit 2 + stderr (rejects the tool call, agent-visible)
-    if (result && typeof result === 'string') {
-      if (result.startsWith('[BLOCK]')) {
-        console.error(result);
+    if (result) {
+      // The severity comes from the structured result's level, derived by
+      // the router itself — never from sniffing the message text, which can
+      // embed arbitrary content (e.g. the literal string '[BLOCK]').
+      if (result.level === 'block') {
+        // Block: exit 2 + stderr (rejects the tool call, agent-visible)
+        console.error(result.message);
         process.exit(2); // block
       }
       // Advise: agent-visible additionalContext JSON. Plain text on exit 0
@@ -68,7 +71,7 @@ import { readFileSync } from 'node:fs';
       console.log(JSON.stringify({
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',
-          additionalContext: result,
+          additionalContext: result.message,
         },
       }));
     }

--- a/tests/cli/init.test.ts
+++ b/tests/cli/init.test.ts
@@ -301,12 +301,15 @@ describe('initCommand', () => {
     }
   });
 
-  it('generates pre-tool-use hook that only exits 2 for BLOCK, not ADVISE', async () => {
+  it('generates pre-tool-use hook that only exits 2 for block-level results, not advisories', async () => {
     await initCommand(tempDir, { force: false });
 
     const content = readFileSync(join(tempDir, '.claude', 'hooks', 'scripts', 'pre-tool-use.ts'), 'utf-8');
-    // Must check for [BLOCK] prefix before exiting 2
-    expect(content).toContain("startsWith('[BLOCK]')");
+    // Severity must come from the structured result's level — never from
+    // sniffing the message text for a '[BLOCK]' prefix, which can appear
+    // legitimately inside advisory messages.
+    expect(content).toContain("result.level === 'block'");
+    expect(content).not.toContain("startsWith('[BLOCK]')");
     // Exit 2 must be conditional, not unconditional
     expect(content).not.toMatch(/process\.exit\(2\)\s*;\s*\n\s*\}/);
     // Final fallback must be exit 0

--- a/tests/enforcement/post-tool-use.test.ts
+++ b/tests/enforcement/post-tool-use.test.ts
@@ -49,11 +49,101 @@ describe('handlePostToolUse', () => {
     );
   });
 
-  it('checks zero-defect on Bash test commands', () => {
+  it('checks zero-defect on Bash test commands (legacy tool_input.output fallback)', () => {
     const testOutput = 'FAIL tests/a.test.ts\nTests: 1 failed';
     const result = handlePostToolUse('Bash', { command: 'npx vitest run', output: testOutput }, tracker, cache, config);
     expect(result).not.toBeNull();
     expect(result?.message).toContain('ZERO-DEFECT');
+  });
+
+  describe('zero-defect output extraction from the real hook payload (tool_response)', () => {
+    // Claude Code's PostToolUse payload delivers command output in
+    // `tool_response` (a string, or an object with stdout/stderr) — NOT in
+    // `tool_input.output`. The handler must read the real field or the check
+    // is dormant in every live session.
+    const failingOutput = 'FAIL tests/a.test.ts\nTests: 1 failed';
+
+    it('fires when output arrives as a tool_response string', () => {
+      const result = handlePostToolUse(
+        'Bash',
+        { command: 'npx vitest run' },
+        tracker,
+        cache,
+        config,
+        undefined,
+        failingOutput,
+      );
+      expect(result).not.toBeNull();
+      expect(result?.message).toContain('ZERO-DEFECT');
+    });
+
+    it('fires when output arrives as tool_response { stdout }', () => {
+      const result = handlePostToolUse(
+        'Bash',
+        { command: 'npx vitest run' },
+        tracker,
+        cache,
+        config,
+        undefined,
+        { stdout: failingOutput },
+      );
+      expect(result).not.toBeNull();
+      expect(result?.message).toContain('ZERO-DEFECT');
+    });
+
+    it('joins stdout and stderr when both present (failures often land on stderr)', () => {
+      const result = handlePostToolUse(
+        'Bash',
+        { command: 'npx vitest run' },
+        tracker,
+        cache,
+        config,
+        undefined,
+        { stdout: 'RUN v3.0.0', stderr: 'FAIL tests/a.test.ts\nTests: 1 failed' },
+      );
+      expect(result).not.toBeNull();
+      expect(result?.message).toContain('ZERO-DEFECT');
+    });
+
+    it('prefers tool_response over the legacy tool_input.output when both present', () => {
+      const result = handlePostToolUse(
+        'Bash',
+        { command: 'npx vitest run', output: 'Tests: 5 passed' },
+        tracker,
+        cache,
+        config,
+        undefined,
+        failingOutput,
+      );
+      expect(result).not.toBeNull();
+      expect(result?.message).toContain('ZERO-DEFECT');
+    });
+
+    it('passes cleanly when tool_response shows a passing run', () => {
+      const result = handlePostToolUse(
+        'Bash',
+        { command: 'npx vitest run' },
+        tracker,
+        cache,
+        config,
+        undefined,
+        'Test Files  1 passed (1)\nTests  5 passed (5)',
+      );
+      expect(result).toBeNull();
+    });
+
+    it('returns null when tool_response carries no string output', () => {
+      const result = handlePostToolUse(
+        'Bash',
+        { command: 'npx vitest run' },
+        tracker,
+        cache,
+        config,
+        undefined,
+        { interrupted: false },
+      );
+      expect(result).toBeNull();
+    });
   });
 
   it('checks constitutional on stack test file edits', () => {

--- a/tests/enforcement/post-tool-use.test.ts
+++ b/tests/enforcement/post-tool-use.test.ts
@@ -378,6 +378,63 @@ describe('handlePostToolUse', () => {
     expect(cache.getGraphifyStats('/external/unreachable')).toBeUndefined();
   });
 
+  describe('stale-test detection across hook processes (turn model)', () => {
+    // Hooks run as separate processes: every invocation builds a FRESH
+    // FileTracker. A "turn" is one PostToolUse Edit/Write invocation, counted
+    // in the session cache; the turn-stamped edit history is hydrated into
+    // the fresh tracker so a source file edited in an earlier invocation
+    // (and not covered by a test edit) fires on a later one.
+    function freshInvocation(
+      sharedCache: SessionCache,
+      filePath: string,
+    ): ReturnType<typeof handlePostToolUse> {
+      // Fresh tracker per call simulates the separate hook process.
+      return handlePostToolUse(
+        'Edit',
+        { file_path: filePath, old_string: 'a', new_string: 'b' },
+        new FileTracker(),
+        sharedCache,
+        config,
+      );
+    }
+
+    it('fires on the second consecutive edit of the same source file', () => {
+      const first = freshInvocation(cache, 'src/feature/widget.ts');
+      expect(first).toBeNull();
+
+      const second = freshInvocation(cache, 'src/feature/widget.ts');
+      expect(second).not.toBeNull();
+      expect(second?.level).toBe('advise');
+      expect(second?.message).toContain('STALE TEST');
+      expect(second?.message).toContain('src/feature/widget.ts');
+    });
+
+    it('fires for an earlier uncovered source edit when a different file is edited', () => {
+      freshInvocation(cache, 'src/feature/widget.ts');
+      const result = freshInvocation(cache, 'src/feature/gadget.ts');
+      expect(result).not.toBeNull();
+      expect(result?.message).toContain('src/feature/widget.ts');
+      // The current invocation's edit is exempt (creation turn).
+      expect(result?.message).not.toContain('src/feature/gadget.ts');
+    });
+
+    it('does not fire once a covering test edit is recorded', () => {
+      freshInvocation(cache, 'src/feature/widget.ts');
+      freshInvocation(cache, 'tests/feature/widget.test.ts');
+      const result = freshInvocation(cache, 'src/feature/widget.ts');
+      expect(result).toBeNull();
+    });
+
+    it('respects grace_period across invocations', () => {
+      config.rules.stale_tests = { enforcement: 'advise', grace_period: 1 };
+      freshInvocation(cache, 'src/feature/widget.ts'); // turn 1
+      expect(freshInvocation(cache, 'src/feature/widget.ts')).toBeNull(); // turn 2, within grace
+      const third = freshInvocation(cache, 'src/feature/widget.ts'); // turn 3, past grace
+      expect(third).not.toBeNull();
+      expect(third?.message).toContain('STALE TEST');
+    });
+  });
+
   describe('session cache persistence of edits', () => {
     it('persists source file edits to the session cache', () => {
       handlePostToolUse('Edit', { file_path: 'src/router/resolver.ts' }, tracker, cache, config);

--- a/tests/enforcement/stale-test.test.ts
+++ b/tests/enforcement/stale-test.test.ts
@@ -32,6 +32,13 @@ describe('checkStaleTests', () => {
     expect(result?.message).not.toContain('src/router/resolver.ts');
   });
 
+  it('returns null at silent enforcement even when sources are stale', () => {
+    config.rules.stale_tests = { enforcement: 'silent', grace_period: 0 };
+    tracker.recordEdit('src/router/rules.ts');
+    tracker.nextTurn();
+    expect(checkStaleTests(tracker, config)).toBeNull();
+  });
+
   it('includes enforcement level from config', () => {
     config.rules.stale_tests = { enforcement: 'block', grace_period: 0 };
     tracker.recordEdit('src/router/rules.ts');

--- a/tests/enforcement/test-scope.test.ts
+++ b/tests/enforcement/test-scope.test.ts
@@ -35,9 +35,9 @@ describe('checkTestScope', () => {
 
     const result = checkTestScope('npx vitest run', 'tdd+', sourceEdits, config);
     expect(result).not.toBeNull();
-    expect(result).toContain('TEST SCOPE');
-    expect(result).toContain('resolver.test.ts');
-    expect(result).toContain('zero-defect.test.ts');
+    expect(result?.message).toContain('TEST SCOPE');
+    expect(result?.message).toContain('resolver.test.ts');
+    expect(result?.message).toContain('zero-defect.test.ts');
   });
 
   it('returns null for unscoped test during verify+ phase', () => {
@@ -56,7 +56,7 @@ describe('checkTestScope', () => {
 
     const result = checkTestScope('pytest', 'tdd+', sourceEdits, config);
     expect(result).not.toBeNull();
-    expect(result).toContain('TEST SCOPE');
+    expect(result?.message).toContain('TEST SCOPE');
   });
 
   it('returns null for scoped pytest run', () => {
@@ -69,13 +69,15 @@ describe('checkTestScope', () => {
     config.rules.test_scope = { enforcement: 'block', allowed_unscoped: [] };
 
     const result = checkTestScope('npx vitest run', 'tdd+', sourceEdits, config);
-    expect(result).toContain('[BLOCK]');
+    expect(result?.level).toBe('block');
+    expect(result?.message).toContain('[BLOCK]');
   });
 
   it('shows advise by default', () => {
     sourceEdits.push('src/router/resolver.ts');
     const result = checkTestScope('npx vitest run', 'tdd+', sourceEdits, config);
-    expect(result).toContain('[ADVISE]');
+    expect(result?.level).toBe('advise');
+    expect(result?.message).toContain('[ADVISE]');
   });
 
   it('generates correct scoped command suggestion', () => {
@@ -83,7 +85,7 @@ describe('checkTestScope', () => {
     sourceEdits.push('src/router/rules.ts');
 
     const result = checkTestScope('npx vitest run', 'tdd+', sourceEdits, config);
-    expect(result).toContain('npx vitest run tests/router/resolver.test.ts tests/router/rules.test.ts');
+    expect(result?.message).toContain('npx vitest run tests/router/resolver.test.ts tests/router/rules.test.ts');
   });
 
   it('redirects unscoped test during sdd+ phase', () => {
@@ -91,8 +93,8 @@ describe('checkTestScope', () => {
 
     const result = checkTestScope('npx vitest run', 'sdd+', sourceEdits, config);
     expect(result).not.toBeNull();
-    expect(result).toContain('TEST SCOPE');
-    expect(result).toContain('tests/router/resolver.test.ts');
+    expect(result?.message).toContain('TEST SCOPE');
+    expect(result?.message).toContain('tests/router/resolver.test.ts');
   });
 
   it('returns null when enforcement is silent', () => {
@@ -108,8 +110,8 @@ describe('checkTestScope', () => {
 
     const result = checkTestScope('npm test', 'tdd+', sourceEdits, config);
     expect(result).not.toBeNull();
-    expect(result).toContain('TEST SCOPE');
-    expect(result).toContain('npm test -- tests/router/resolver.test.ts');
+    expect(result?.message).toContain('TEST SCOPE');
+    expect(result?.message).toContain('npm test -- tests/router/resolver.test.ts');
   });
 
   it('detects npm run test as an unscoped full-suite run', () => {
@@ -117,6 +119,6 @@ describe('checkTestScope', () => {
 
     const result = checkTestScope('npm run test', 'sdd+', sourceEdits, config);
     expect(result).not.toBeNull();
-    expect(result).toContain('npm test -- tests/router/resolver.test.ts');
+    expect(result?.message).toContain('npm test -- tests/router/resolver.test.ts');
   });
 });

--- a/tests/eval/first-occurrence-eval.test.ts
+++ b/tests/eval/first-occurrence-eval.test.ts
@@ -88,9 +88,9 @@ describe('Context Eval: first-occurrence advisory suppression', () => {
 
       if (scenario.expectedFirst === 'advise') {
         expect(first).not.toBeNull();
-        expect(first).toContain('ADVISE');
+        expect(first).toMatchObject({ level: 'advise' });
       } else {
-        expect(first).toContain('BLOCK');
+        expect(first).toMatchObject({ level: 'block' });
       }
 
       // Second call
@@ -105,9 +105,9 @@ describe('Context Eval: first-occurrence advisory suppression', () => {
         expect(second).toBeNull();
       } else if (scenario.expectedSecond === 'advise') {
         expect(second).not.toBeNull();
-        expect(second).toContain('ADVISE');
+        expect(second).toMatchObject({ level: 'advise' });
       } else {
-        expect(second).toContain('BLOCK');
+        expect(second).toMatchObject({ level: 'block' });
       }
     });
   }

--- a/tests/eval/score.test.ts
+++ b/tests/eval/score.test.ts
@@ -4,15 +4,23 @@ import type { EvalResult } from './score.js';
 import type { ExpectedOutcome } from './scenarios.js';
 
 describe('scoreResult', () => {
+  // handlePreToolUse returns structured { level, message } results — the
+  // action comes from the level field, never from message-text sniffing.
   it('scores 1.0 for exact match on advise', () => {
     const expected: ExpectedOutcome = { action: 'advise', tool: 'rtk grep' };
-    const actual = '[ADVISE] Tool Router: text_search detected\nadvise: use rtk grep — ...';
+    const actual = {
+      level: 'advise' as const,
+      message: '[ADVISE] Tool Router: text_search detected\nadvise: use rtk grep — ...',
+    };
     expect(scoreResult(expected, actual)).toBe(1.0);
   });
 
   it('scores 0.5 for action match but wrong tool', () => {
     const expected: ExpectedOutcome = { action: 'advise', tool: 'rtk grep' };
-    const actual = '[ADVISE] Tool Router: text_search detected\nadvise: use Grep — ...';
+    const actual = {
+      level: 'advise' as const,
+      message: '[ADVISE] Tool Router: text_search detected\nadvise: use Grep — ...',
+    };
     expect(scoreResult(expected, actual)).toBe(0.5);
   });
 
@@ -28,26 +36,47 @@ describe('scoreResult', () => {
 
   it('scores 0.0 for expected allow but got advise', () => {
     const expected: ExpectedOutcome = { action: 'allow' };
-    const actual = '[ADVISE] Tool Router: file_read detected\nadvise: use Read — ...';
+    const actual = {
+      level: 'advise' as const,
+      message: '[ADVISE] Tool Router: file_read detected\nadvise: use Read — ...',
+    };
     expect(scoreResult(expected, actual)).toBe(0.0);
   });
 
   it('scores 1.0 for exact match on block', () => {
     const expected: ExpectedOutcome = { action: 'block' };
-    const actual = '[BLOCK] Tool Router: file_modify operation blocked\nReason: ...';
+    const actual = {
+      level: 'block' as const,
+      message: '[BLOCK] Tool Router: file_modify operation blocked\nReason: ...',
+    };
     expect(scoreResult(expected, actual)).toBe(1.0);
   });
 
   it('scores 1.0 for advise with no specific tool expected', () => {
     const expected: ExpectedOutcome = { action: 'block' };
-    const actual = '[BLOCK] Tool Router: file_modify operation blocked';
+    const actual = {
+      level: 'block' as const,
+      message: '[BLOCK] Tool Router: file_modify operation blocked',
+    };
     expect(scoreResult(expected, actual)).toBe(1.0);
   });
 
   it('scores 0.0 for wrong action', () => {
     const expected: ExpectedOutcome = { action: 'block' };
-    const actual = '[ADVISE] Tool Router: text_search detected';
+    const actual = {
+      level: 'advise' as const,
+      message: '[ADVISE] Tool Router: text_search detected',
+    };
     expect(scoreResult(expected, actual)).toBe(0.0);
+  });
+
+  it('does not escalate an advisory whose message embeds the literal [BLOCK]', () => {
+    const expected: ExpectedOutcome = { action: 'advise' };
+    const actual = {
+      level: 'advise' as const,
+      message: "[ADVISE] advise: use Grep — output mentions '[BLOCK]' literally",
+    };
+    expect(scoreResult(expected, actual)).toBe(1.0);
   });
 });
 

--- a/tests/eval/score.ts
+++ b/tests/eval/score.ts
@@ -31,22 +31,24 @@ export interface ParsedResult {
 
 /**
  * Parse a hook result into a structured { action, tool? } form.
- * Handles string output (advise/block), RewriteResult (rewrite), and null (allow).
+ * Handles structured EnforcementViolation output (advise/block),
+ * RewriteResult (rewrite), and null (allow). Severity comes from the
+ * structured level — never from sniffing the message text.
  */
-export function parseResult(result: string | import('../../src/types.js').RewriteResult | null): ParsedResult {
+export function parseResult(
+  result: import('../../src/types.js').EnforcementViolation | import('../../src/types.js').RewriteResult | null,
+): ParsedResult {
   if (result === null) return { action: 'allow' };
-  if (typeof result === 'object' && result.type === 'rewrite') {
+  if ('type' in result && result.type === 'rewrite') {
     const firstWord = result.command.split(/\s+/)[0];
     // "rtk grep ..." -> tool is "rtk grep"
     const secondWord = result.command.split(/\s+/)[1];
     const tool = secondWord ? `${firstWord} ${secondWord}` : firstWord;
     return { action: 'rewrite', tool };
   }
-  // String output
-  const str = result as string;
-  if (str.includes('[BLOCK]')) return { action: 'block' };
-  if (str.includes('[ADVISE]')) {
-    const match = str.match(/advise: use (.+?) —/i) ?? str.match(/advise: use (\S+)/i);
+  if ('level' in result) {
+    if (result.level === 'block') return { action: 'block' };
+    const match = result.message.match(/advise: use (.+?) —/i) ?? result.message.match(/advise: use (\S+)/i);
     return { action: 'advise', tool: match?.[1]?.trim() };
   }
   return { action: 'unknown' };
@@ -61,7 +63,7 @@ export function parseResult(result: string | import('../../src/types.js').Rewrit
  */
 export function scoreResult(
   expected: ExpectedOutcome,
-  result: string | import('../../src/types.js').RewriteResult | null,
+  result: import('../../src/types.js').EnforcementViolation | import('../../src/types.js').RewriteResult | null,
 ): number {
   const parsed = parseResult(result);
 

--- a/tests/integration/post-tool-use.test.ts
+++ b/tests/integration/post-tool-use.test.ts
@@ -3,12 +3,23 @@ import { mkdtempSync, rmSync, existsSync, writeFileSync, unlinkSync } from 'node
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { initCommand } from '../../src/cli/init.js';
-import { runHook, readSessionCache } from '../helpers/hook-runner.js';
+import { runHook } from '../helpers/hook-runner.js';
 import { sessionCachePath } from '../../src/session/cache.js';
+
+// FIXTURE REALISM PRINCIPLE: e2e fixtures must mimic the harness, not the
+// implementation's assumptions. Claude Code's PostToolUse payload carries
+// session_id, hook_event_name, tool_name, tool_input, and tool_response —
+// command output lives in tool_response (a string, or an object with
+// stdout/stderr), never in tool_input.output. Fixtures that speak the hook's
+// internal dialect can pass while the check is dormant in every live session
+// (exactly what happened to zero-defect before this audit). The single
+// tool_input.output fixture below is an explicit back-compat test for the
+// legacy fallback and is labeled as such.
 
 describe('PostToolUse hook E2E', () => {
   // npx tsx may need to install on first run in CI
   const HOOK_TIMEOUT = 30_000;
+  const SESSION_ID = 'e2e-post-real';
   let tempDir: string;
   let hookPath: string;
 
@@ -28,22 +39,26 @@ describe('PostToolUse hook E2E', () => {
 
   afterAll(() => {
     // The hook subprocess persists edit tracking to a session cache keyed by
-    // tempDir (no session_id) — remove the exact path so /tmp doesn't
+    // (tempDir, SESSION_ID) — remove the exact paths so /tmp doesn't
     // accumulate fixtures. Never glob-delete: real sessions own sibling
     // cache files.
-    const cachePath = sessionCachePath(tempDir);
-    if (existsSync(cachePath)) unlinkSync(cachePath);
+    for (const path of [sessionCachePath(tempDir, SESSION_ID), sessionCachePath(tempDir)]) {
+      if (existsSync(path)) unlinkSync(path);
+    }
     rmSync(tempDir, { recursive: true, force: true });
   });
 
   it('exits 0 for non-test source file edit', async () => {
     const result = await runHook(hookPath, {
+      session_id: SESSION_ID,
+      hook_event_name: 'PostToolUse',
       tool_name: 'Edit',
       tool_input: {
         file_path: 'src/router/resolver.ts',
         old_string: 'foo',
         new_string: 'bar',
       },
+      tool_response: { filePath: 'src/router/resolver.ts' },
     }, tempDir);
 
     expectNonBlock(result);
@@ -51,12 +66,15 @@ describe('PostToolUse hook E2E', () => {
 
   it('exits 0 for mock in unit test file (no_mocks only applies to stack/E2E tests)', async () => {
     const result = await runHook(hookPath, {
+      session_id: SESSION_ID,
+      hook_event_name: 'PostToolUse',
       tool_name: 'Edit',
       tool_input: {
         file_path: 'tests/router/resolver.test.ts',
         old_string: 'old',
         new_string: 'vi.mock("some-module")',
       },
+      tool_response: { filePath: 'tests/router/resolver.test.ts' },
     }, tempDir);
 
     expectNonBlock(result);
@@ -64,29 +82,75 @@ describe('PostToolUse hook E2E', () => {
 
   it('exits 0 for test file edit without mocks', async () => {
     const result = await runHook(hookPath, {
+      session_id: SESSION_ID,
+      hook_event_name: 'PostToolUse',
       tool_name: 'Edit',
       tool_input: {
         file_path: 'tests/router/resolver.test.ts',
         old_string: 'old',
         new_string: 'expect(true).toBe(true)',
       },
+      tool_response: { filePath: 'tests/router/resolver.test.ts' },
     }, tempDir);
 
     expectNonBlock(result);
   });
 
-  it('exits 2 and surfaces zero-defect violation on stderr for failing test output', async () => {
-    // zero_defect.tolerance defaults to strict → [BLOCK]-level violation.
+  it('exits 2 and surfaces zero-defect violation on stderr for failing test output in tool_response', async () => {
+    // zero_defect.tolerance defaults to strict → block-level violation.
     // PostToolUse exit 2 cannot undo the tool call, but Claude Code feeds
     // stderr back to the agent as an error — the agent-visible channel.
+    // Output arrives in tool_response.{stdout,stderr}, the real channel.
+    const result = await runHook(hookPath, {
+      session_id: SESSION_ID,
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Bash',
+      tool_input: {
+        command: 'npx vitest run tests/foo.test.ts',
+        description: 'Run foo tests',
+      },
+      tool_response: {
+        stdout: ' FAIL  tests/foo.test.ts\n' +
+          ' ✗ should work\n' +
+          '   AssertionError: expected true to be false\n\n' +
+          ' Test Files  1 failed (1)',
+        stderr: '',
+        interrupted: false,
+        isImage: false,
+      },
+    }, tempDir);
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain('ZERO-DEFECT');
+  }, HOOK_TIMEOUT);
+
+  it('fires zero-defect when the failure output lands on tool_response stderr', async () => {
+    const result = await runHook(hookPath, {
+      session_id: SESSION_ID,
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Bash',
+      tool_input: { command: 'npx vitest run tests/foo.test.ts' },
+      tool_response: {
+        stdout: 'RUN v3.0.0',
+        stderr: ' FAIL  tests/foo.test.ts\n Test Files  1 failed (1)',
+        interrupted: false,
+        isImage: false,
+      },
+    }, tempDir);
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain('ZERO-DEFECT');
+  }, HOOK_TIMEOUT);
+
+  it('still fires zero-defect via the legacy tool_input.output fallback (BACK-COMPAT, not the real payload shape)', async () => {
+    // Explicit back-compat coverage: older harnesses and hand-built probes
+    // put output on tool_input.output. The fallback must keep working, but
+    // no other fixture in this file may use this dialect.
     const result = await runHook(hookPath, {
       tool_name: 'Bash',
       tool_input: {
         command: 'npx vitest run tests/foo.test.ts',
-        output: ' FAIL  tests/foo.test.ts\n' +
-          ' ✗ should work\n' +
-          '   AssertionError: expected true to be false\n\n' +
-          ' Test Files  1 failed (1)',
+        output: ' FAIL  tests/foo.test.ts\n Test Files  1 failed (1)',
       },
     }, tempDir);
 
@@ -96,11 +160,16 @@ describe('PostToolUse hook E2E', () => {
 
   it('exits 0 for test command with passing output', async () => {
     const result = await runHook(hookPath, {
+      session_id: SESSION_ID,
+      hook_event_name: 'PostToolUse',
       tool_name: 'Bash',
-      tool_input: {
-        command: 'npx vitest run tests/foo.test.ts',
-        output: ' Test Files  1 passed (1)\n' +
+      tool_input: { command: 'npx vitest run tests/foo.test.ts' },
+      tool_response: {
+        stdout: ' Test Files  1 passed (1)\n' +
           '      Tests  5 passed (5)',
+        stderr: '',
+        interrupted: false,
+        isImage: false,
       },
     }, tempDir);
 
@@ -109,11 +178,11 @@ describe('PostToolUse hook E2E', () => {
 
   it('exits 0 for non-test bash commands', async () => {
     const result = await runHook(hookPath, {
+      session_id: SESSION_ID,
+      hook_event_name: 'PostToolUse',
       tool_name: 'Bash',
-      tool_input: {
-        command: 'ls -la',
-        output: 'total 0\ndrwxr-xr-x',
-      },
+      tool_input: { command: 'ls -la' },
+      tool_response: { stdout: 'total 0\ndrwxr-xr-x', stderr: '', interrupted: false, isImage: false },
     }, tempDir);
 
     expectNonBlock(result);
@@ -122,12 +191,15 @@ describe('PostToolUse hook E2E', () => {
   it('emits advise-level violations as agent-visible additionalContext JSON', async () => {
     // no_mocks defaults to advise; a mock in a stack test file fires it.
     const result = await runHook(hookPath, {
+      session_id: SESSION_ID,
+      hook_event_name: 'PostToolUse',
       tool_name: 'Edit',
       tool_input: {
         file_path: 'tests/router/resolver.stack.test.ts',
         old_string: 'old',
         new_string: 'vi.mock("some-module")',
       },
+      tool_response: { filePath: 'tests/router/resolver.stack.test.ts' },
     }, tempDir);
 
     expect(result.exitCode).toBe(0);
@@ -141,12 +213,15 @@ describe('PostToolUse hook E2E', () => {
   it('exits 2 with stderr for block-level violations (evidence_only)', async () => {
     // evidence_only defaults to block; an evidence-less pass claim fires it.
     const result = await runHook(hookPath, {
+      session_id: SESSION_ID,
+      hook_event_name: 'PostToolUse',
       tool_name: 'Edit',
       tool_input: {
         file_path: 'src/notes.ts',
         old_string: 'old',
         new_string: '// all tests pass',
       },
+      tool_response: { filePath: 'src/notes.ts' },
     }, tempDir);
 
     expect(result.exitCode).toBe(2);
@@ -156,8 +231,11 @@ describe('PostToolUse hook E2E', () => {
 
   it('emits no JSON on stdout for clean operations', async () => {
     const result = await runHook(hookPath, {
+      session_id: SESSION_ID,
+      hook_event_name: 'PostToolUse',
       tool_name: 'Bash',
-      tool_input: { command: 'echo hello', output: 'hello' },
+      tool_input: { command: 'echo hello' },
+      tool_response: { stdout: 'hello', stderr: '', interrupted: false, isImage: false },
     }, tempDir);
 
     expect(result.exitCode).toBe(0);
@@ -184,11 +262,16 @@ describe('PostToolUse hook E2E', () => {
       const result = await runHook(
         join(adviseDir, '.claude', 'hooks', 'scripts', 'post-tool-use.ts'),
         {
+          session_id: SESSION_ID,
+          hook_event_name: 'PostToolUse',
           tool_name: 'Bash',
-          tool_input: {
-            command: 'npx vitest run',
-            output: "FAIL tests/hooks.test.ts > emits the '[BLOCK]' prefix\n" +
+          tool_input: { command: 'npx vitest run' },
+          tool_response: {
+            stdout: "FAIL tests/hooks.test.ts > emits the '[BLOCK]' prefix\n" +
               'Tests: 1 failed',
+            stderr: '',
+            interrupted: false,
+            isImage: false,
           },
         },
         adviseDir,
@@ -202,8 +285,9 @@ describe('PostToolUse hook E2E', () => {
       expect(parsed.hookSpecificOutput.additionalContext).toContain('ZERO-DEFECT');
       expect(parsed.hookSpecificOutput.additionalContext).toContain('[BLOCK]');
     } finally {
-      const adviseCachePath = sessionCachePath(adviseDir);
-      if (existsSync(adviseCachePath)) unlinkSync(adviseCachePath);
+      for (const path of [sessionCachePath(adviseDir, SESSION_ID), sessionCachePath(adviseDir)]) {
+        if (existsSync(path)) unlinkSync(path);
+      }
       rmSync(adviseDir, { recursive: true, force: true });
     }
   }, HOOK_TIMEOUT);
@@ -211,9 +295,27 @@ describe('PostToolUse hook E2E', () => {
   it('runs successfully for various tool types', async () => {
     // Verify multiple tool types all exit cleanly
     const tools = [
-      { tool_name: 'Read', tool_input: { file_path: '/some/file.ts' } },
-      { tool_name: 'Bash', tool_input: { command: 'ls', output: '' } },
-      { tool_name: 'Glob', tool_input: { pattern: '**/*.ts' } },
+      {
+        session_id: SESSION_ID,
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Read',
+        tool_input: { file_path: '/some/file.ts' },
+        tool_response: { type: 'text', file: { filePath: '/some/file.ts' } },
+      },
+      {
+        session_id: SESSION_ID,
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Bash',
+        tool_input: { command: 'ls' },
+        tool_response: { stdout: '', stderr: '', interrupted: false, isImage: false },
+      },
+      {
+        session_id: SESSION_ID,
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Glob',
+        tool_input: { pattern: '**/*.ts' },
+        tool_response: { filenames: [], numFiles: 0 },
+      },
     ];
 
     for (const input of tools) {

--- a/tests/integration/post-tool-use.test.ts
+++ b/tests/integration/post-tool-use.test.ts
@@ -292,6 +292,51 @@ describe('PostToolUse hook E2E', () => {
     }
   }, HOOK_TIMEOUT);
 
+  describe('stale-test detection across hook processes', () => {
+    // Each hook invocation is a separate process with a fresh FileTracker —
+    // the turn counter and edit history must come from the session cache or
+    // the creation-turn exemption applies forever and the check is dormant.
+    const STALE_SESSION = 'e2e-post-stale';
+
+    function editPayload(file: string) {
+      return {
+        session_id: STALE_SESSION,
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Edit',
+        tool_input: { file_path: file, old_string: 'a', new_string: 'b' },
+        tool_response: { filePath: file },
+      };
+    }
+
+    afterAll(() => {
+      const path = sessionCachePath(tempDir, STALE_SESSION);
+      if (existsSync(path)) unlinkSync(path);
+    });
+
+    it('fires the stale-test advisory on the second consecutive source edit', async () => {
+      const first = await runHook(hookPath, editPayload('src/feature/widget.ts'), tempDir);
+      expect(first.exitCode).toBe(0);
+      expect(first.stdout).not.toContain('STALE TEST');
+
+      const second = await runHook(hookPath, editPayload('src/feature/widget.ts'), tempDir);
+      expect(second.exitCode).toBe(0);
+      const jsonLine = second.stdout.split('\n').find(l => l.trim().startsWith('{'));
+      expect(jsonLine).toBeDefined();
+      const parsed = JSON.parse(jsonLine as string);
+      expect(parsed.hookSpecificOutput.additionalContext).toContain('STALE TEST');
+      expect(parsed.hookSpecificOutput.additionalContext).toContain('src/feature/widget.ts');
+    }, HOOK_TIMEOUT);
+
+    it('stops firing once a covering test edit lands in a later invocation', async () => {
+      const testEdit = await runHook(hookPath, editPayload('tests/feature/widget.test.ts'), tempDir);
+      expect(testEdit.exitCode).toBe(0);
+
+      const third = await runHook(hookPath, editPayload('src/feature/widget.ts'), tempDir);
+      expect(third.exitCode).toBe(0);
+      expect(third.stdout).not.toContain('STALE TEST');
+    }, HOOK_TIMEOUT);
+  });
+
   it('runs successfully for various tool types', async () => {
     // Verify multiple tool types all exit cleanly
     const tools = [

--- a/tests/router/branch-discipline.test.ts
+++ b/tests/router/branch-discipline.test.ts
@@ -307,10 +307,11 @@ describe('handlePreToolUse branch discipline wiring', () => {
       undefined,
       { branchExec: exec },
     );
-    expect(typeof result).toBe('string');
-    expect(result).toContain('[ADVISE]');
-    expect(result).toContain('Branch discipline');
-    expect(result).toContain('master');
+    expect(result).toMatchObject({ level: 'advise' });
+    const advisory = result as { level: string; message: string };
+    expect(advisory.message).toContain('[ADVISE]');
+    expect(advisory.message).toContain('Branch discipline');
+    expect(advisory.message).toContain('master');
   });
 
   it('returns the [BLOCK] message for git push on master at block level', () => {
@@ -324,9 +325,10 @@ describe('handlePreToolUse branch discipline wiring', () => {
       undefined,
       { branchExec: exec },
     );
-    expect(typeof result).toBe('string');
-    expect(result).toContain('[BLOCK]');
-    expect(result).toContain('Branch discipline');
+    expect(result).toMatchObject({ level: 'block' });
+    const blockResult = result as { level: string; message: string };
+    expect(blockResult.message).toContain('[BLOCK]');
+    expect(blockResult.message).toContain('Branch discipline');
   });
 
   it('branch-discipline block wins for a compound command during tdd+ phase', () => {
@@ -344,9 +346,10 @@ describe('handlePreToolUse branch discipline wiring', () => {
       undefined,
       { branchExec: exec },
     );
-    expect(typeof result).toBe('string');
-    expect(result).toContain('[BLOCK]');
-    expect(result).toContain('Branch discipline');
+    expect(result).toMatchObject({ level: 'block' });
+    const compound = result as { level: string; message: string };
+    expect(compound.message).toContain('[BLOCK]');
+    expect(compound.message).toContain('Branch discipline');
   });
 
   it('test-scope block wins over a branch-discipline advisory on the same command', () => {
@@ -366,9 +369,10 @@ describe('handlePreToolUse branch discipline wiring', () => {
       undefined,
       { branchExec: exec },
     );
-    expect(typeof result).toBe('string');
-    expect(result).toContain('[BLOCK]');
-    expect(result).toContain('TEST SCOPE');
+    expect(result).toMatchObject({ level: 'block' });
+    const scopeBlock = result as { level: string; message: string };
+    expect(scopeBlock.message).toContain('[BLOCK]');
+    expect(scopeBlock.message).toContain('TEST SCOPE');
   });
 
   it('passes git commit through on a feature branch', () => {

--- a/tests/router/hook.test.ts
+++ b/tests/router/hook.test.ts
@@ -7,6 +7,11 @@ import { mkdtempSync, rmSync, unlinkSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+/** Narrow a router result to its advisory message ('' for null/rewrites). */
+function msg(result: unknown): string {
+  return (result as { message?: string } | null)?.message ?? '';
+}
+
 function makeEnv(overrides: Partial<Environment> = {}): Environment {
   return {
     rtkAvailable: false,
@@ -41,16 +46,17 @@ describe('handlePreToolUse', () => {
     cache.setEnvironment(makeEnv({ jcodemunchAvailable: true, jcodemunchCwdIndexed: true }));
     const result = handlePreToolUse('Grep', { pattern: 'function' }, cache, config);
     expect(result).not.toBeNull();
-    expect(result).toContain('jcodemunch');
-    expect(result).toContain('ADVISE');
+    expect(msg(result)).toContain('jcodemunch');
+    expect(msg(result)).toContain('ADVISE');
   });
 
   it('blocks sed -i regardless of environment', () => {
     cache.setEnvironment(makeEnv({ rtkAvailable: true, jcodemunchAvailable: true, jcodemunchCwdIndexed: true }));
     const result = handlePreToolUse('Bash', { command: "sed -i 's/old/new/g' file.ts" }, cache, config);
     expect(result).not.toBeNull();
-    expect(result).toContain('block');
-    expect(result).toContain('Edit');
+    expect(result).toMatchObject({ level: 'block' });
+    expect(msg(result)).toContain('block');
+    expect(msg(result)).toContain('Edit');
   });
 
   it('advises rtk for grep when rtk available but rewrite declines', () => {
@@ -59,7 +65,7 @@ describe('handlePreToolUse', () => {
     // passed because the spawn failed (ENOENT), polluting the field diag log.
     const result = handlePreToolUse('Bash', { command: 'grep -r pattern .' }, cache, config, undefined, () => null);
     expect(result).not.toBeNull();
-    expect(result).toContain('rtk');
+    expect(msg(result)).toContain('rtk');
   });
 
   it('returns null for pass-through tools', () => {
@@ -78,8 +84,8 @@ describe('handlePreToolUse', () => {
     cache.setEnvironment(makeEnv({ jcodemunchAvailable: true, jcodemunchCwdIndexed: true }));
     const result = handlePreToolUse('Grep', { pattern: 'test' }, cache, config);
     expect(result).not.toBeNull();
-    expect(result).toContain('jcodemunch');
-    expect(result).toContain('ADVISE');
+    expect(msg(result)).toContain('jcodemunch');
+    expect(msg(result)).toContain('ADVISE');
   });
 
   it('suppresses jcodemunch advisory for native Grep on second call (first-occurrence)', () => {
@@ -102,7 +108,7 @@ describe('handlePreToolUse', () => {
     // Call 11 — re-advisory fires
     const readvisory = handlePreToolUse('Grep', { pattern: 'p11' }, cache, config);
     expect(readvisory).not.toBeNull();
-    expect(readvisory).toContain('jcodemunch');
+    expect(msg(readvisory)).toContain('jcodemunch');
     // Call 12 — suppressed again
     expect(handlePreToolUse('Grep', { pattern: 'p12' }, cache, config)).toBeNull();
   });
@@ -111,8 +117,8 @@ describe('handlePreToolUse', () => {
     cache.setEnvironment(makeEnv({ jcodemunchAvailable: true, jcodemunchCwdIndexed: true }));
     const result = handlePreToolUse('Read', { file_path: '/some/file.ts' }, cache, config);
     expect(result).not.toBeNull();
-    expect(result).toContain('jcodemunch');
-    expect(result).toContain('ADVISE');
+    expect(msg(result)).toContain('jcodemunch');
+    expect(msg(result)).toContain('ADVISE');
   });
 
   it('suppresses native Read advisory on second call (first-occurrence)', () => {
@@ -144,8 +150,8 @@ describe('handlePreToolUse', () => {
     cache.setEnvironment(makeEnv({ jcodemunchAvailable: true, jcodemunchCwdIndexed: true }));
     const result = handlePreToolUse('Grep', { pattern: 'function' }, cache, config);
     expect(result).not.toBeNull();
-    expect(result).toContain('jcodemunch');
-    expect(result).toContain('ADVISE');
+    expect(msg(result)).toContain('jcodemunch');
+    expect(msg(result)).toContain('ADVISE');
   });
 
   it('suppresses Grep advisory on second call (first-occurrence)', () => {
@@ -165,8 +171,8 @@ describe('handlePreToolUse', () => {
     cache.setEnvironment(makeEnv({ jcodemunchAvailable: true, jcodemunchCwdIndexed: true }));
     const result = handlePreToolUse('Glob', { pattern: '**/*.ts' }, cache, config);
     expect(result).not.toBeNull();
-    expect(result).toContain('jcodemunch');
-    expect(result).toContain('ADVISE');
+    expect(msg(result)).toContain('jcodemunch');
+    expect(msg(result)).toContain('ADVISE');
   });
 
   it('suppresses Glob advisory on second call (first-occurrence)', () => {
@@ -186,8 +192,9 @@ describe('handlePreToolUse', () => {
     cache.setEnvironment(makeEnv());
     const result = handlePreToolUse('Bash', { command: 'rtk cat /some/file.ts' }, cache, config);
     expect(result).not.toBeNull();
-    expect(result).toContain('BLOCK');
-    expect(result).toContain('jcodemunch');
+    expect(result).toMatchObject({ level: 'block' });
+    expect(msg(result)).toContain('BLOCK');
+    expect(msg(result)).toContain('jcodemunch');
   });
 
   it('allows rtk cat on non-code files', () => {
@@ -209,7 +216,8 @@ describe('handlePreToolUse', () => {
     cache.setEnvironment(makeEnv({ jcodemunchAvailable: true, jcodemunchCwdIndexed: true }));
     const result = handlePreToolUse('Read', { file_path: '/some/file.ts' }, cache, config);
     expect(result).not.toBeNull();
-    expect(result).toContain('BLOCK');
+    expect(result).toMatchObject({ level: 'block' });
+    expect(msg(result)).toContain('BLOCK');
   });
 
   // Python environment rewrite tests
@@ -297,8 +305,8 @@ describe('scout_explore advisory', () => {
     cache.setEnvironment(makeEnv({ jcodemunchAvailable: true, jcodemunchCwdIndexed: true }));
     const result = handlePreToolUse('Agent', { subagent_type: 'Explore', prompt: 'find auth files' }, cache, config);
     expect(result).not.toBeNull();
-    expect(result).toContain('scout');
-    expect(result).toContain('ADVISE');
+    expect(msg(result)).toContain('scout');
+    expect(msg(result)).toContain('ADVISE');
   });
 
   it('suppresses scout advisory for Agent Explore on second call (first-occurrence)', () => {
@@ -312,15 +320,15 @@ describe('scout_explore advisory', () => {
     cache.setEnvironment(makeEnv({ jcodemunchAvailable: true, jcodemunchCwdIndexed: false }));
     const result = handlePreToolUse('Agent', { subagent_type: 'Explore', prompt: 'map the codebase' }, cache, config);
     expect(result).not.toBeNull();
-    expect(result).toContain('scout');
-    expect(result).toContain('ADVISE');
+    expect(msg(result)).toContain('scout');
+    expect(msg(result)).toContain('ADVISE');
   });
 
   it('falls through to file_discovery advisory when jcodemunch not available but rtk available', () => {
     cache.setEnvironment(makeEnv({ jcodemunchAvailable: false, rtkAvailable: true, rtkPath: '/usr/bin/rtk' }));
     const result = handlePreToolUse('Agent', { subagent_type: 'Explore', prompt: 'find tests' }, cache, config);
     expect(result).not.toBeNull();
-    expect(result).toContain('rtk find');
+    expect(msg(result)).toContain('rtk find');
     expect(result).not.toContain('scout');
   });
 
@@ -328,7 +336,7 @@ describe('scout_explore advisory', () => {
     cache.setEnvironment(makeEnv({ jcodemunchAvailable: false, rtkAvailable: false }));
     const result = handlePreToolUse('Agent', { subagent_type: 'Explore', prompt: 'find config' }, cache, config);
     expect(result).not.toBeNull();
-    expect(result).toContain('Glob');
+    expect(msg(result)).toContain('Glob');
     expect(result).not.toContain('scout');
   });
 
@@ -343,8 +351,9 @@ describe('scout_explore advisory', () => {
     cache.setEnvironment(makeEnv({ jcodemunchAvailable: true, jcodemunchCwdIndexed: true }));
     const result = handlePreToolUse('Agent', { subagent_type: 'Explore', prompt: 'find auth' }, cache, config);
     expect(result).not.toBeNull();
-    expect(result).toContain('BLOCK');
-    expect(result).toContain('scout');
+    expect(result).toMatchObject({ level: 'block' });
+    expect(msg(result)).toContain('BLOCK');
+    expect(msg(result)).toContain('scout');
   });
 });
 
@@ -414,9 +423,9 @@ describe('handlePreToolUse test-scope check', () => {
 
     const result = handlePreToolUse('Bash', { command: 'npx vitest run' }, cache, config);
     expect(result).not.toBeNull();
-    expect(result).toContain('[ADVISE]');
-    expect(result).toContain('TEST SCOPE');
-    expect(result).toContain('tests/router/resolver.test.ts');
+    expect(msg(result)).toContain('[ADVISE]');
+    expect(msg(result)).toContain('TEST SCOPE');
+    expect(msg(result)).toContain('tests/router/resolver.test.ts');
   });
 
   it('advises scoped run for npm test during sdd+ phase', () => {
@@ -425,8 +434,8 @@ describe('handlePreToolUse test-scope check', () => {
 
     const result = handlePreToolUse('Bash', { command: 'npm test' }, cache, config);
     expect(result).not.toBeNull();
-    expect(result).toContain('TEST SCOPE');
-    expect(result).toContain('npm test -- tests/enforcement/test-scope.test.ts');
+    expect(msg(result)).toContain('TEST SCOPE');
+    expect(msg(result)).toContain('npm test -- tests/enforcement/test-scope.test.ts');
   });
 
   it('blocks full-suite run when config says block', () => {
@@ -436,7 +445,7 @@ describe('handlePreToolUse test-scope check', () => {
 
     const result = handlePreToolUse('Bash', { command: 'npx vitest run' }, cache, config);
     expect(result).not.toBeNull();
-    expect(result).toContain('[BLOCK]');
+    expect(msg(result)).toContain('[BLOCK]');
   });
 
   it('passes through full-suite run when no phase is set', () => {
@@ -480,7 +489,7 @@ describe('handlePreToolUse test-scope check', () => {
 
     const first = handlePreToolUse('Bash', { command: 'npx vitest run' }, cache, config);
     const second = handlePreToolUse('Bash', { command: 'npx vitest run' }, cache, config);
-    expect(first).toContain('TEST SCOPE');
-    expect(second).toContain('TEST SCOPE');
+    expect(msg(first)).toContain('TEST SCOPE');
+    expect(msg(second)).toContain('TEST SCOPE');
   });
 });

--- a/tests/router/rewrite.test.ts
+++ b/tests/router/rewrite.test.ts
@@ -313,8 +313,8 @@ describe('handlePreToolUse: block rules take priority', () => {
     const result = handlePreToolUse(
       'Bash', { command: "sed -i 's/foo/bar/' file.ts" }, cache, DEFAULT_CONFIG, undefined, mockRewriteSuccess,
     );
-    expect(typeof result).toBe('string');
-    expect(result).toContain('[BLOCK]');
+    expect(result).toMatchObject({ level: 'block' });
+    expect((result as { message: string }).message).toContain('[BLOCK]');
   });
 
   it('blocks rtk cat on code files even when rtk available', () => {
@@ -323,8 +323,8 @@ describe('handlePreToolUse: block rules take priority', () => {
     const result = handlePreToolUse(
       'Bash', { command: 'rtk cat src/types.ts' }, cache, DEFAULT_CONFIG, undefined, mockRewriteSuccess,
     );
-    expect(typeof result).toBe('string');
-    expect(result).toContain('[BLOCK]');
+    expect(result).toMatchObject({ level: 'block' });
+    expect((result as { message: string }).message).toContain('[BLOCK]');
   });
 });
 
@@ -343,7 +343,7 @@ describe('handlePreToolUse: non-Bash tools', () => {
     detectedAt: Date.now(),
   };
 
-  it('Read tool returns string (advise), never RewriteResult', () => {
+  it('Read tool returns a structured advisory, never RewriteResult', () => {
     const cache = new SessionCache();
     cache.setEnvironment(ENV_WITH_RTK);
     const result = handlePreToolUse(
@@ -351,29 +351,32 @@ describe('handlePreToolUse: non-Bash tools', () => {
     );
     // Should be string (advise about jcodemunch) or null (allow), never a RewriteResult
     if (result !== null) {
-      expect(typeof result).toBe('string');
+      expect((result as { type?: string }).type).not.toBe('rewrite');
+      expect(result).toMatchObject({ level: 'advise' });
     }
   });
 
-  it('Grep tool returns string (advise), never RewriteResult', () => {
+  it('Grep tool returns a structured advisory, never RewriteResult', () => {
     const cache = new SessionCache();
     cache.setEnvironment(ENV_WITH_RTK);
     const result = handlePreToolUse(
       'Grep', { pattern: 'function resolve' }, cache, DEFAULT_CONFIG, undefined, mockRewriteSuccess,
     );
     if (result !== null) {
-      expect(typeof result).toBe('string');
+      expect((result as { type?: string }).type).not.toBe('rewrite');
+      expect(result).toMatchObject({ level: 'advise' });
     }
   });
 
-  it('Glob tool returns string (advise), never RewriteResult', () => {
+  it('Glob tool returns a structured advisory, never RewriteResult', () => {
     const cache = new SessionCache();
     cache.setEnvironment(ENV_WITH_RTK);
     const result = handlePreToolUse(
       'Glob', { pattern: '**/*.ts' }, cache, DEFAULT_CONFIG, undefined, mockRewriteSuccess,
     );
     if (result !== null) {
-      expect(typeof result).toBe('string');
+      expect((result as { type?: string }).type).not.toBe('rewrite');
+      expect(result).toMatchObject({ level: 'advise' });
     }
   });
 
@@ -411,8 +414,8 @@ describe('handlePreToolUse: rtk unavailable', () => {
     );
     // rtk not available, so mockRewriteSuccess is never called
     // Falls through to advise about jcodemunch (default config has grep: 'advise')
-    expect(typeof result).toBe('string');
-    expect(result).toContain('jcodemunch');
+    expect(result).toMatchObject({ level: 'advise' });
+    expect((result as { message: string }).message).toContain('jcodemunch');
   });
 
   it('cat falls through to advise jcodemunch when rtk unavailable', () => {
@@ -421,8 +424,8 @@ describe('handlePreToolUse: rtk unavailable', () => {
     const result = handlePreToolUse(
       'Bash', { command: 'cat src/file.ts' }, cache, DEFAULT_CONFIG, undefined, mockRewriteSuccess,
     );
-    expect(typeof result).toBe('string');
-    expect(result).toContain('[ADVISE]');
+    expect(result).toMatchObject({ level: 'advise' });
+    expect((result as { message: string }).message).toContain('[ADVISE]');
   });
 
   it('find falls through to advise jcodemunch when rtk unavailable', () => {
@@ -431,8 +434,8 @@ describe('handlePreToolUse: rtk unavailable', () => {
     const result = handlePreToolUse(
       'Bash', { command: 'find . -name "*.ts"' }, cache, DEFAULT_CONFIG, undefined, mockRewriteSuccess,
     );
-    expect(typeof result).toBe('string');
-    expect(result).toContain('[ADVISE]');
+    expect(result).toMatchObject({ level: 'advise' });
+    expect((result as { message: string }).message).toContain('[ADVISE]');
   });
 });
 
@@ -457,8 +460,8 @@ describe('handlePreToolUse: neither rtk nor jcodemunch', () => {
     const result = handlePreToolUse(
       'Bash', { command: 'cat src/file.ts' }, cache, DEFAULT_CONFIG, undefined, mockRewriteSuccess,
     );
-    expect(typeof result).toBe('string');
-    expect(result).toContain('Read');
+    expect(result).toMatchObject({ level: 'advise' });
+    expect((result as { message: string }).message).toContain('Read');
   });
 
   it('grep falls through to advise Grep', () => {
@@ -467,8 +470,8 @@ describe('handlePreToolUse: neither rtk nor jcodemunch', () => {
     const result = handlePreToolUse(
       'Bash', { command: 'grep -r "TODO" src/' }, cache, DEFAULT_CONFIG, undefined, mockRewriteSuccess,
     );
-    expect(typeof result).toBe('string');
-    expect(result).toContain('Grep');
+    expect(result).toMatchObject({ level: 'advise' });
+    expect((result as { message: string }).message).toContain('Grep');
   });
 
   it('find falls through to advise Glob', () => {
@@ -477,8 +480,8 @@ describe('handlePreToolUse: neither rtk nor jcodemunch', () => {
     const result = handlePreToolUse(
       'Bash', { command: 'find . -name "*.ts"' }, cache, DEFAULT_CONFIG, undefined, mockRewriteSuccess,
     );
-    expect(typeof result).toBe('string');
-    expect(result).toContain('Glob');
+    expect(result).toMatchObject({ level: 'advise' });
+    expect((result as { message: string }).message).toContain('Glob');
   });
 
   it('git status is allowed (no routing needed)', () => {
@@ -546,8 +549,8 @@ describe('handlePreToolUse: pipe handling', () => {
     const result = handlePreToolUse(
       'Bash', { command: "rg pattern . ; sed -i 's/a/b/g' f" }, cache, DEFAULT_CONFIG, undefined, mockRewriteSuccess,
     );
-    expect(typeof result).toBe('string');
-    expect(result).toContain('[BLOCK]');
+    expect(result).toMatchObject({ level: 'block' });
+    expect((result as { message: string }).message).toContain('[BLOCK]');
   });
 
   it('chained ls; diff passes through without rtk rewrite', () => {
@@ -611,7 +614,7 @@ describe('handlePreToolUse: rtk returns identical command', () => {
     );
     // tryRtkRewrite returns null for identical, so falls through to advise
     expect(result).not.toBeNull();
-    // Should be an advise string, not a RewriteResult
-    expect(typeof result).toBe('string');
+    // Should be a structured advisory, not a RewriteResult
+    expect(result).toMatchObject({ level: 'advise' });
   });
 });

--- a/tests/session/cache.test.ts
+++ b/tests/session/cache.test.ts
@@ -120,6 +120,41 @@ describe('SessionCache', () => {
     expect(cache.getMetricCounters()).toEqual({ rtkCalls: 2, jmCalls: 1, efficientCalls: 0, graphifyCalls: 0 });
   });
 
+  describe('edit-turn counter and turn-stamped history (cross-process stale-test model)', () => {
+    it('starts the edit turn counter at 0', () => {
+      expect(cache.getEditTurn()).toBe(0);
+    });
+
+    it('advances the edit turn counter and returns the new value', () => {
+      expect(cache.advanceEditTurn()).toBe(1);
+      expect(cache.advanceEditTurn()).toBe(2);
+      expect(cache.getEditTurn()).toBe(2);
+    });
+
+    it('records turn-stamped edits in history', () => {
+      cache.recordEditTurn('src/router/resolver.ts', 'source', 1);
+      cache.recordEditTurn('tests/router/resolver.test.ts', 'test', 2);
+      expect(cache.getEditHistory()).toEqual([
+        { file: 'src/router/resolver.ts', category: 'source', turn: 1 },
+        { file: 'tests/router/resolver.test.ts', category: 'test', turn: 2 },
+      ]);
+    });
+
+    it('clearEditedFiles clears the turn-stamped history too', () => {
+      cache.recordEditTurn('src/a.ts', 'source', 1);
+      cache.clearEditedFiles();
+      expect(cache.getEditHistory()).toEqual([]);
+    });
+
+    it('reset clears the counter and history', () => {
+      cache.advanceEditTurn();
+      cache.recordEditTurn('src/a.ts', 'source', 1);
+      cache.reset();
+      expect(cache.getEditTurn()).toBe(0);
+      expect(cache.getEditHistory()).toEqual([]);
+    });
+  });
+
   describe('shouldAdvise (advisory re-suppression)', () => {
     it('returns true on the first call for an intent', () => {
       expect(cache.shouldAdvise('native_grep')).toBe(true);
@@ -179,6 +214,21 @@ describe('SessionCache (file-backed)', () => {
     cleanupPaths.push(path);
     return path;
   }
+
+  it('persists the edit-turn counter and history across instances (hook processes)', () => {
+    trackPath(sessionCachePath(testCwd));
+    const first = new SessionCache(testCwd);
+    const turn = first.advanceEditTurn();
+    first.recordEditTurn('src/feature/widget.ts', 'source', turn);
+
+    // A later hook invocation (separate process) loads from disk.
+    const second = new SessionCache(testCwd);
+    expect(second.getEditTurn()).toBe(1);
+    expect(second.getEditHistory()).toEqual([
+      { file: 'src/feature/widget.ts', category: 'source', turn: 1 },
+    ]);
+    expect(second.advanceEditTurn()).toBe(2);
+  });
 
   it('generates deterministic path from cwd', () => {
     const path = sessionCachePath(testCwd);


### PR DESCRIPTION
## Summary

Fixes two production-dormancy bugs found live by /verify-harness (task #25), plus two riders.

### 1. Zero-defect reads tool_response (dormant live)

`handlePostToolUse` read test output from `tool_input.output`, but Claude Code's PostToolUse payload delivers it in `tool_response` (string, or object with stdout/stderr). The check therefore never fired in real sessions. Output is now extracted from `tool_response` first — stdout and stderr joined, since test runners report failures on stderr — falling back to `tool_input.output` for older harnesses and hand-built fixtures.

### 2. E2E fixture realism audit

The e2e fixtures hand-crafted the hook's internal dialect (`tool_input.output`), so the suite passed while the check was dormant live. All PostToolUse fixtures now speak the real payload schema (`session_id`, `hook_event_name`, `tool_name`, `tool_input`, `tool_response`), with one explicitly labeled back-compat fixture for the legacy fallback. Principle recorded in the test file header: **e2e fixtures must mimic the harness, not the implementation's assumptions.** PreToolUse and session-start fixtures audited; already conformant.

### 3. Stale-test turn model (dormant live) + silent gap

Each hook invocation builds a fresh `FileTracker` whose turn counter starts at 0, so the creation-turn exemption applied forever and consecutive uncovered source edits never fired. Chosen semantics: **one PostToolUse Edit/Write invocation = one turn**, with the counter and a turn-stamped edit history persisted in the session cache; the handler hydrates the fresh tracker from history (same-process trackers are left intact, and the effective turn never rewinds). `grace_period` semantics preserved. Entering tdd+/sdd+ clears the history with the edited-file sets. Documented in `docs/architecture.md` (stale-test section). Also adds the missing `silent`-level early return in `checkStaleTests`.

### 4. PreToolUse structured severity (rider)

`handlePreToolUse` now returns `EnforcementViolation` (`{ level, message }`) instead of strings, and `checkTestScope` does too — eliminating the last `startsWith('[BLOCK]')` sniffing (the pattern #37 removed from PostToolUse). The generated hook switches on `result.level`. Observable behavior (exit codes, stderr, additionalContext) unchanged.

## Verification

- `npm test`: 1271 passed (51 files)
- `npm run lint`, `npm run lint:md`: clean
- Coverage gate: 97% stmts / 91.05% branches / 96.22% funcs / 97% lines (thresholds 80/75/80/80)
- Ground-truth probes against a dist-backed `rig init` install, real payload shapes piped into the hooks:
  - zero-defect: failing vitest output in `tool_response.stdout` → `[BLOCK] ZERO-DEFECT VIOLATION` on stderr, exit 2
  - stale-test: two consecutive Edit invocations (separate processes, same session) → first silent, second emits `STALE TEST WARNING` as agent-visible `additionalContext`
  - PreToolUse block path (`sed -i`) → exit 2 via structured level

🤖 Generated with [Claude Code](https://claude.com/claude-code)