### PR TITLE
chore: bump version to 0.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rig",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rig",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rig",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Agent harness that enforces tool routing, skill chains, and multi-agent discipline in Claude Code",
   "type": "module",
   "main": "dist/cli/index.js",


### PR DESCRIPTION
Releases the post-0.6.0 fixes already merged to master:

- **#43** — enforcement reads the real PostToolUse payload (`tool_response`); stale-test cross-process turn model; PreToolUse structured severity. **This is the load-bearing fix — without it, PostToolUse zero-defect/stale-test enforcement is dormant in installed projects.**
- **#41** — advisory re-suppression (re-advise every 10th), `/savings` aggregation across session-cache fragments, e2e cache hygiene.
- **#42** — completed specs/plans archived to `docs/archive/`.

Version-only bump; no code change. Tag + release cut after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)