### PR TITLE
feat: teams-aware sdd+ — detect, offer, degrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ rules:
     branch_discipline: advise  # block | advise | silent — git commit/push on a protected branch
     protected_branches: [master, main]
     isolation_strategy: auto   # auto | branch | worktree — auto picks worktree when the tree is dirty
+    team_execution: offer      # offer | auto | never — parallel teammates for independent tasks (needs experimental agent-teams)
 ```
 
 Each enforcement rule can be `block` (hook exits nonzero), `advise` (advisory

--- a/README.md
+++ b/README.md
@@ -23,11 +23,12 @@ and you carry the integration burden — remembering which is installed, which
 to reach for, and what each is saving you. Rig carries it instead:
 
 - **Plug-and-play detection** — session start probes the whole panel (PATH,
-  MCP registrations, proxy markers), auto-indexes the project, auto-builds the
-  knowledge graph, and reports what's online. Install a tool and it joins the
-  panel; remove one and rig degrades gracefully (jcodemunch-only analysis when
-  graphify fails, pass-through when rtk is absent, general-purpose subagents
-  when typed agents are deleted).
+  MCP registrations, proxy markers, the experimental agent-teams flag),
+  auto-indexes the project, auto-builds the knowledge graph, and reports what's
+  online. Install a tool and it joins the panel; remove one and rig degrades
+  gracefully (jcodemunch-only analysis when graphify fails, pass-through when
+  rtk is absent, general-purpose subagents when typed agents are deleted,
+  sequential dispatch when agent-teams is off).
 - **Routing, not memory** — PreToolUse hooks steer every operation to the best
   instrument available right now. You never have to remember the stack exists.
 - **One pane of glass** — `/savings` reports every layer side by side (tool
@@ -64,7 +65,7 @@ upgrades the three places where process text alone can't reach:
 | | plain superpowers | superpowers through rig |
 | --- | --- | --- |
 | **Enforcement** | Persuasive skill text the agent can rationalize around | PreToolUse/PostToolUse hooks that programmatically block or advise (`.harness.yaml`) |
-| **Subagents** | Every implementer and reviewer dispatched as a general-purpose agent; role and discipline ride inside the prompt | Typed agents in `.claude/agents/`: tool-scoped (reviewers carry no Edit/Write tools), enforcement rules in their system prompt, named in the UI, backstop-calibrated turn budgets with partial-status resumption, worktree-isolated implementers (see architecture.md "Subagent operations") |
+| **Subagents** | Every implementer and reviewer dispatched as a general-purpose agent; role and discipline ride inside the prompt | Typed agents in `.claude/agents/`: tool-scoped (reviewers carry no Edit/Write tools), enforcement rules in their system prompt, named in the UI, backstop-calibrated turn budgets with partial-status resumption, worktree-isolated implementers, and team-mode execution of independent plan tasks as parallel teammates when Claude Code's experimental agent-teams feature is detected (see architecture.md "Subagent operations") |
 | **Trajectory** | The skill chain ends at merge | Opt-in agent-loop trajectory: `brain+`/`plan+` can design a layered signal stack so the system self-assembles gate-by-gate and hands off to an always-on maintainer agent |
 
 The result: the same superpowers workflows, but the review chain is

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -331,6 +331,23 @@ below are what make that hierarchy reliable in practice:
   advisories via `additionalContext`, blocks via exit 2, and the typed
   agents' system prompts instruct reading `.harness.yaml` at runtime.
 
+**Hook coverage in worktrees (empirically probed).** Hooks fire for
+subagent/teammate tool calls regardless of the command's working directory:
+they run in the session process via `${CLAUDE_PROJECT_DIR}`, so a
+`cd <worktree> && sed -i ...` issued from a worktree-isolated agent is
+blocked by the router exactly as in the main checkout (observed: `[BLOCK]
+Tool Router: file_modify operation blocked`, command never executed).
+Config resolution inside a worktree cwd falls back to built-in defaults:
+`.harness.yaml` is gitignored, so worktrees lack it, and `loadConfig`
+resolves (rather than rejecting) with a config equal to `DEFAULT_CONFIG` —
+enforcement still runs, at default levels, unless a `.harness.yaml` is
+copied into the worktree. Session-cache writes from a worktree cwd land in a
+per-worktree fragment (observed: a fresh `/tmp/rig-session-*.json` with
+`"cwd"` set to the worktree path), invisible to `/savings` same-cwd matching
+— the same fragmentation already documented for subdirectory contexts.
+Teammates additionally carry enforcement in their typed system prompts, so
+the hook layer and the prompt layer overlap rather than depend on each other.
+
 **Agent teams (forward-looking).** Claude Code's experimental agent-teams
 feature maps naturally onto `sdd+`: genuinely independent plan tasks could
 execute as a team of worktree-isolated implementer teammates sharing a task

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -301,6 +301,24 @@ prompts, falling back to general-purpose if the definition is missing.
 `brain+` and `plan+` load `references/agent-loops.md` for the opt-in
 signal-stack / maintainer-loop trajectory.
 
+When Claude Code's experimental agent-teams feature is detected
+(`Environment.agentTeamsAvailable`, from the `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`
+flag) and `rules.workflow.team_execution` is not `never`, `sdd+`'s Phase A
+preflight computes task independence from the plan's contract — disjoint
+`**Files:**` lists and no `Depends on:` marker either way. If two or more tasks
+are pairwise independent it offers team mode (at `offer`, asks once; at `auto`,
+proceeds without asking), entering a parallel `Phase B-team`: at most three
+worktree-isolated `implementer` teammates implement unblocked tasks on
+`<plan-branch>-task-N` branches while the session acts as lead — running the
+two-stage spec/code review on each completed branch and merging approved
+branches into the plan branch in dependency order, re-running the suite after
+each merge. The independence contract that gates this is authored in `plan+`
+(every task's `**Files:**` list exhaustive; `Depends on:` markers for
+order-only coupling). Absent the flag, at `never`, when declined, or with no
+independent pair, `sdd+` uses the sequential dispatch unchanged — the team path
+is strictly additive (the full parallelism model and worktree hook-coverage
+behavior are in "Subagent operations" below).
+
 ### Subagent operations
 
 Rig tunes the superpowers workflows for Claude Code's subagent hierarchy —
@@ -348,12 +366,44 @@ per-worktree fragment (observed: a fresh `/tmp/rig-session-*.json` with
 Teammates additionally carry enforcement in their typed system prompts, so
 the hook layer and the prompt layer overlap rather than depend on each other.
 
-**Agent teams (forward-looking).** Claude Code's experimental agent-teams
-feature maps naturally onto `sdd+`: genuinely independent plan tasks could
-execute as a team of worktree-isolated implementer teammates sharing a task
-list, with reviewers as teammates and the session as lead. Per the cockpit
-pattern, rig would detect the capability, offer it, and degrade to today's
-sequential dispatch when absent. Tracked as future work; not yet designed.
+**Agent teams.** Claude Code's experimental agent-teams feature maps onto
+`sdd+`, and rig wires it per the cockpit pattern — detect, offer, degrade:
+
+- **Detect.** Session start reads `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` (via
+  the injectable env record in `detectEnvironment`) into
+  `Environment.agentTeamsAvailable`, and the panel emits `agent-teams:
+  available (experimental)` when set. `rules.workflow.team_execution`
+  (`offer` | `auto` | `never`, default `offer`) gates use independently of
+  detection.
+- **Offer.** `sdd+`'s Phase A preflight derives task independence from the
+  plan's contract — a task pair is independent when their `**Files:**` lists
+  are disjoint and neither carries a `Depends on:` marker (the contract is
+  authored in `plan+`, which requires exhaustive `**Files:**` lists). With two
+  or more pairwise-independent tasks and `team_execution` not `never`: at
+  `offer` rig asks once, at `auto` it proceeds silently.
+- **Execute (Phase B-team).** A team named for the plan carries a shared task
+  list mirroring the plan, `Depends on:` encoded as blocked-by edges so only
+  unblocked tasks are claimable. At most three `implementer` teammates — never
+  more than the count of currently-unblocked independent tasks — run
+  worktree-isolated, each claiming one task and pushing a
+  `<plan-branch>-task-N` branch. The session is **lead**: it runs the
+  two-stage spec/code review on each completed branch, routes findings back as
+  blocked tasks for a fresh implementer dispatch, and merges approved branches
+  into the plan branch in dependency order, re-running the suite after each
+  merge. On completion it shuts down teammates, deletes the team, and
+  continues to Phase C as in sequential mode.
+- **Degrade.** Absent the flag, at `never`, when the offer is declined, or
+  with no independent pair, `sdd+` falls back to sequential
+  implementer → spec-reviewer → code-reviewer dispatch, byte-for-byte
+  unchanged. Team mode is strictly additive.
+
+Turn budgets, worktree isolation, and enforcement apply to teammates exactly
+as to any typed implementer dispatch — including the hook-coverage behavior in
+worktrees recorded above (hooks fire session-level regardless of command cwd;
+config falls back to defaults inside a worktree lacking `.harness.yaml`;
+session-cache writes fragment per worktree cwd), so the parallelization
+heuristic is unchanged: read-only agents always parallelizable, implementers
+parallelizable across branches, serialized within a branch or a merge chain.
 
 `debug+` wraps `superpowers:systematic-debugging` with mandatory scout agent
 context harvesting. It maps the affected code area before debugging, ensuring

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -156,6 +156,37 @@ either path. During `/brain+`, projects that fit the agent-loop pattern are offe
 opt-in signal-stack trajectory (see the agent-loops reference installed into
 `brain-plus/references/`).
 
+## Team mode (experimental)
+
+When Claude Code's experimental agent-teams feature is enabled
+(`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`), session start reports
+`agent-teams: available (experimental)` and `/sdd+` can execute a plan's
+**independent** tasks as parallel teammates instead of dispatching them one at
+a time.
+
+During `/sdd+` preflight, rig computes task independence from the plan's
+contract — tasks are independent when their `**Files:**` lists are disjoint and
+neither carries a `Depends on:` marker. When two or more tasks are pairwise
+independent and `rules.workflow.team_execution` is not `never`:
+
+- at `offer` (the default), rig asks once whether to run them as parallel
+  teammates;
+- at `auto`, rig uses team mode without asking.
+
+The topology is **teammates implement, the lead reviews and merges**: rig spawns
+at most three worktree-isolated `implementer` teammates, each claiming one
+unblocked task and pushing its own `<plan-branch>-task-N` branch. The session
+(lead) runs the two-stage spec/code review on each completed branch and merges
+approved branches into the plan branch in dependency order, re-running the suite
+after each merge.
+
+Team mode is strictly additive. When the flag is absent, `team_execution` is
+`never`, the offer is declined, or no two tasks are independent, `/sdd+` falls
+back to the same sequential implementer → spec-reviewer → code-reviewer dispatch
+it has always used — byte-for-byte unchanged. See
+[architecture.md](architecture.md) "Subagent operations" for the full
+parallelism model and the worktree hook-coverage note.
+
 ## Configure enforcement
 
 Edit `.harness.yaml` to adjust enforcement levels:
@@ -179,6 +210,7 @@ rules:
     branch_discipline: advise    # block | advise | silent — git commit/push on a protected branch
     protected_branches: [master, main]
     isolation_strategy: auto     # auto | branch | worktree
+    team_execution: offer        # offer | auto | never — parallel teammates for independent tasks (needs the experimental agent-teams flag)
 ```
 
 **Branch discipline (`rules.workflow`):** when you commit or push on a branch

--- a/docs/skill-wrapping.md
+++ b/docs/skill-wrapping.md
@@ -45,7 +45,7 @@ brain+                           superpowers:brainstorming
 | `verification-before-completion` | Completeness check | Full suite unlocked, spec drift detection, evidence standards |
 | `requesting-code-review` | Code quality review | Two-stage review (spec + quality), constitutional checklist, typed code-reviewer/spec-reviewer agent dispatch (tool-scoped, no file edits) |
 | `systematic-debugging` | Structured debugging | Scout-harvested context, no phase prerequisite |
-| `subagent-driven-development` | Per-task subagent execution | Typed implementer/spec-reviewer/code-reviewer dispatch via `sdd+`, enforcement rules in each agent's system prompt, signal-stack gating |
+| `subagent-driven-development` | Per-task subagent execution | Typed implementer/spec-reviewer/code-reviewer dispatch via `sdd+`, enforcement rules in each agent's system prompt, signal-stack gating, team-mode parallel execution of independent tasks (experimental agent-teams) |
 | `using-git-worktrees` | Workspace isolation | Config-gated, strategy-aware advisory (`rules.workflow`): rig recommends worktree vs branch from tree state and plan context |
 
 Without wrapping, superpowers gives you generic process discipline. With

--- a/docs/superpowers/plans/2026-06-12-teams-aware-sdd.md
+++ b/docs/superpowers/plans/2026-06-12-teams-aware-sdd.md
@@ -1,0 +1,259 @@
+# Teams-Aware sdd+ Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When Claude Code's experimental agent-teams feature is enabled, `sdd+` offers to execute independent plan tasks as parallel worktree-isolated implementer teammates with the lead reviewing and merging; everything degrades byte-for-byte to sequential dispatch when absent. Spec: `docs/superpowers/specs/2026-06-12-teams-aware-sdd-design.md`.
+
+**Architecture:** One detection field (`Environment.agentTeamsAvailable` from the `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` env flag, injectable), one config key (`workflow.team_execution`), template prose in `plan-plus` (independence contract) and `sdd-plus` (preflight offer + team procedure), a mandatory empirical probe of hook coverage in worktrees, and the mandated docs pass + consistency sweep as the final tasks.
+
+**Tech Stack:** TypeScript, vitest, injectable env record (extends the `ExecFn` testability convention).
+
+**Sequencing:** Execute AFTER the hook-payload-drift fix (task #25) and the docs-archive PR merge. Task 0 rebases.
+
+## Constitutional Rules for This Plan
+
+Active enforcement: `evidence_only: block`, `zero_defect.unrelated_errors: block`, `no_mocks: advise`, `conditional_assert: block`, `empty_test: block`, `stale_tests: advise`, `branch_discipline (advise)`.
+
+- Show command output before claiming any step done
+- Every source change ships with test changes in the same task
+- Work happens on `feat/teams-aware-sdd` (never a protected branch)
+
+## Mock Policy
+
+Stack/E2E (real deps): none involved — detection reads an injected env record; no Docker services. Unit tests: no mocking frameworks; env records and `ExecFn` fakes per repo convention.
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/types.ts` | Modify | `Environment.agentTeamsAvailable`; `WorkflowRules.team_execution` |
+| `src/session/environment.ts` | Modify | Read the flag via injectable env record |
+| `src/session/start.ts` | Modify | Panel line when available |
+| `src/config.ts` | Modify | `team_execution: 'offer'` default (merge spread already generic over workflow) |
+| `templates/skills/plan-plus/SKILL.md` | Modify | Exhaustive-Files + `Depends on:` instructions |
+| `templates/skills/sdd-plus/SKILL.md` | Modify | Preflight offer, Phase B-team procedure, degrade path |
+| `docs/architecture.md` | Modify | Worktree hook-coverage probe answer (Task 1); teams graduation (Task 7) |
+| `tests/session/environment.test.ts`, `tests/session/start.test.ts`, `tests/config.test.ts`, `tests/cli/template-content.test.ts` | Tests | Per-task below |
+| README.md, docs/getting-started.md, docs/skill-wrapping.md | Modify | Task 7 docs pass |
+
+---
+
+### Task 0: Rebase onto post-#25 master
+
+**Files:** none
+
+- [ ] Step 1: Confirm task #25's PR and the docs-archive PR (#42) are merged: `gh pr list --state merged --limit 5`
+- [ ] Step 2: `git checkout feat/teams-aware-sdd && git rebase origin/master` (resolve `.gitignore`/`.markdownlint-cli2.jsonc` overlaps by keeping both sides' additions)
+- [ ] Step 3: `npm install && npm test` — all pass (baseline count noted for later tasks; expect ≥1249 plus #25's additions)
+
+### Task 1: Worktree hook-coverage probe (spec §7 — mandatory first)
+
+**Files:**
+- Modify: `docs/architecture.md` (Subagent operations section — record the answer)
+**Test strategy:** empirical probe, evidence in commit message + doc text; no unit tests (documentation task)
+**Mock check:** none
+
+- [ ] **Step 1: Probe A — hook firing for subagent tool calls in a worktree.** Create a worktree (`git worktree add /tmp/teams-probe -b probe/teams-hooks`), then from the MAIN session run a Bash command with cwd inside the worktree that the router must block: `cd /tmp/teams-probe && sed -i '' 's/a/b/' README.md` — record whether the `[BLOCK]` fires (expected: yes — hooks run in the session process regardless of command cwd; compound-segment scanning catches the cd-prefixed form).
+- [ ] **Step 2: Probe B — config and session-cache resolution from a worktree cwd.** Pipe a real-shape payload into the installed PostToolUse hook with cwd set to the worktree (`cd /tmp/teams-probe && echo '<payload with session_id teams-probe, Edit on a .ts file>' | npx tsx /Users/jerome/tools/skills/claude-rig/.claude/hooks/scripts/post-tool-use.ts`); record (a) whether `.harness.yaml` resolves (worktrees lack the gitignored file — expected: falls back to DEFAULT_CONFIG), (b) which `/tmp/rig-session-*` cache file is written (expected: keyed by worktree cwd — a fragment invisible to `/savings` matching, as architecture.md already documents for subdirectory contexts).
+- [ ] **Step 3: Record the findings** in `docs/architecture.md`'s "Subagent operations" section as a short "Hook coverage in worktrees" note: hooks fire for teammate tool calls (session-level), config inside worktrees falls back to defaults unless `.harness.yaml` is present, session-cache writes fragment per worktree cwd; teammates additionally carry enforcement in their typed system prompts. Adjust wording to match what the probes actually showed — if either expectation is contradicted, STOP and report NEEDS_CONTEXT with the evidence before proceeding to Task 6.
+- [ ] **Step 4: Clean up** (`git worktree remove --force /tmp/teams-probe; git branch -D probe/teams-hooks`) and commit: `docs: record worktree hook-coverage probe results`
+
+### Task 2: Detection — `agentTeamsAvailable`
+
+**Files:**
+- Modify: `src/types.ts` (Environment, after `headroomInitialized`), `src/session/environment.ts` (detectEnvironment)
+- Test: `tests/session/environment.test.ts`
+
+- [ ] **Step 1: Write failing tests** (follow the file's existing fixture style for detectEnvironment's injectable params):
+
+```typescript
+  it('detects agent teams from the experimental env flag', async () => {
+    const env = await detectEnvironment('/p', failExec, () => false, () => undefined,
+      failMcp, failRegistration, { CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1' });
+    expect(env.agentTeamsAvailable).toBe(true);
+  });
+
+  it('reports agent teams unavailable when the flag is absent or not "1"', async () => {
+    const base = [failExec, () => false, () => undefined, failMcp, failRegistration] as const;
+    const none = await detectEnvironment('/p', ...base, {});
+    expect(none.agentTeamsAvailable).toBe(false);
+    const zero = await detectEnvironment('/p', ...base, { CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '0' });
+    expect(zero.agentTeamsAvailable).toBe(false);
+  });
+```
+
+(Adapt helper names — `failExec`/`failMcp`/`failRegistration` stand for the file's existing no-op fixtures; read the test file first and reuse its actual helpers. If positional defaults make a trailing param awkward, accept an options object — pick whichever matches the file's conventions and keep ALL existing call sites compiling.)
+
+- [ ] **Step 2:** RED run (`npx vitest run tests/session/environment.test.ts`)
+- [ ] **Step 3: Implement.** `src/types.ts`: add `agentTeamsAvailable?: boolean;` to `Environment`. `src/session/environment.ts`: add trailing param `envVars: Record<string, string | undefined> = process.env` to `detectEnvironment`, and include `agentTeamsAvailable: envVars.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS === '1'` in the returned object.
+- [ ] **Step 4:** GREEN + full `tests/session/` pass + `npm run lint`
+- [ ] **Step 5:** Commit `feat: detect experimental agent-teams availability`
+
+### Task 3: Panel emission
+
+**Files:**
+- Modify: `src/session/start.ts` (panel lines, adjacent to the headroom line ~156)
+- Test: `tests/session/start.test.ts`
+
+- [ ] **Step 1: Failing test** (follow start.test.ts's existing emission-assertion style): when the detected environment has `agentTeamsAvailable: true`, session-start output contains `agent-teams: available (experimental)`; when false/absent, it does not.
+- [ ] **Step 2:** RED
+- [ ] **Step 3:** In the panel-emission block of `handleSessionStart`, after the headroom line:
+
+```typescript
+  if (env.agentTeamsAvailable) {
+    lines.push('  agent-teams: available (experimental)');
+  }
+```
+
+- [ ] **Step 4:** GREEN + `npm run lint`
+- [ ] **Step 5:** Commit `feat: session-start panel reports agent-teams availability`
+
+### Task 4: Config — `workflow.team_execution`
+
+**Files:**
+- Modify: `src/types.ts` (WorkflowRules), `src/config.ts` (DEFAULT_CONFIG)
+- Test: `tests/config.test.ts`
+
+- [ ] **Step 1: Failing tests:**
+
+```typescript
+  it('defaults team_execution to offer', async () => {
+    const config = await loadConfig('/nonexistent/.harness.yaml');
+    expect(config.rules.workflow?.team_execution).toBe('offer');
+  });
+
+  it('merges team_execution override while keeping other workflow defaults', () => {
+    const merged = mergeConfigs(structuredClone(DEFAULT_CONFIG), {
+      rules: { workflow: { team_execution: 'never' } },
+    } as HarnessConfig);
+    expect(merged.rules.workflow?.team_execution).toBe('never');
+    expect(merged.rules.workflow?.branch_discipline).toBe('advise');
+  });
+```
+
+- [ ] **Step 2:** RED
+- [ ] **Step 3:** `WorkflowRules` gains `team_execution?: 'offer' | 'auto' | 'never';`; `DEFAULT_CONFIG.rules.workflow` gains `team_execution: 'offer',`. (The workflow merge spread is already generic — no mergeConfigs change.)
+- [ ] **Step 4:** GREEN + lint
+- [ ] **Step 5:** Commit `feat: workflow.team_execution config (offer|auto|never)`
+
+### Task 5: plan+ — independence contract
+
+**Files:**
+- Modify: `templates/skills/plan-plus/SKILL.md` (Phase B, after the existing task-pattern step)
+- Test: `tests/cli/template-content.test.ts`
+
+- [ ] **Step 1: Failing test** (in the loop-aware/typed-dispatch describe area):
+
+```typescript
+  it('plan-plus carries the parallelism/independence contract', () => {
+    const content = read('skills/plan-plus/SKILL.md');
+    expect(content).toContain('Depends on: Task');
+    expect(content).toContain('exhaustive');
+  });
+```
+
+- [ ] **Step 2:** RED
+- [ ] **Step 3:** Add to Phase B (numbered to fit the existing list, after the task-pattern step):
+
+```markdown
+N. **Independence contract** (consumed by sdd+ team mode): every task's
+   `**Files:**` list must be exhaustive — include shared test files a task
+   extends (a tests file touched by several tasks makes them dependent).
+   Where ordering matters even without file overlap, add an explicit
+   `Depends on: Task N` line under the task header. A pair of tasks is
+   parallelizable only when their Files lists are disjoint AND neither
+   depends on the other.
+```
+
+- [ ] **Step 4:** GREEN
+- [ ] **Step 5:** Commit `feat: plan+ independence contract for team execution`
+
+### Task 6: sdd+ — preflight offer and team procedure
+
+**Files:**
+- Modify: `templates/skills/sdd-plus/SKILL.md`
+- Test: `tests/cli/template-content.test.ts`
+
+- [ ] **Step 1: Failing tests:**
+
+```typescript
+  it('sdd-plus offers team mode behind detection and config', () => {
+    const content = read('skills/sdd-plus/SKILL.md');
+    expect(content).toContain('agent-teams');
+    expect(content).toContain('team_execution');
+    expect(content).toContain('Team mode available');
+    expect(content).toContain('at most 3');
+    expect(content).toContain('sequential dispatch');
+  });
+```
+
+- [ ] **Step 2:** RED
+- [ ] **Step 3:** Two template additions. (a) New Phase A step after the signal-stack step:
+
+```markdown
+N. **Team-mode preflight.** If session-start reported `agent-teams: available
+   (experimental)` AND `rules.workflow.team_execution` is not `never`:
+   compute task independence from the plan's contract (disjoint `**Files:**`
+   lists AND no `Depends on:` marker either way). If ≥2 tasks are pairwise
+   independent: at `offer`, ask once — "Team mode available: tasks [N, M, …]
+   are independent — run them as parallel teammates? Sequential otherwise." —
+   and proceed per the answer; at `auto`, use team mode without asking. In
+   every other case (flag absent, `never`, declined, no independent pairs),
+   use the standard sequential dispatch below, unchanged.
+```
+
+(b) New section after Phase B, titled `### Phase B-team: Team execution (when team mode is on)`:
+
+```markdown
+1. Create a team named after the plan (e.g. `sdd-<plan-slug>`); the team's
+   shared task list mirrors the plan: one entry per plan task, with
+   `Depends on:` markers encoded as blocked-by edges so only unblocked tasks
+   are claimable.
+2. Spawn implementer teammates — at most 3, and never more than the number of
+   currently-unblocked independent tasks. Each is the typed `implementer`
+   agent, worktree-isolated, joined to the team with a distinct name. Each
+   teammate's standing instructions: claim one unblocked task, execute it on
+   its own branch (`<plan-branch>-task-N`) off the plan branch following the
+   task's TDD steps exactly, push the branch, mark the task complete, then
+   claim the next unblocked task or go idle.
+3. **Lead loop (you):** on each task-completion notification, run the
+   standard two-stage review from Phase B (spec-reviewer, then code-reviewer)
+   against that task's branch. Route review findings back as new blocked
+   tasks assigned to a fresh implementer dispatch. Merge each approved task
+   branch into the plan branch in dependency order — one merge at a time,
+   re-running the suite after each merge.
+4. When all plan tasks are complete and merged: send each teammate a shutdown
+   request, delete the team, and continue to Phase C as in sequential mode.
+5. Turn budgets, worktree isolation, and enforcement apply to teammates
+   exactly as to any typed implementer dispatch (see architecture.md
+   "Subagent operations", including the worktree hook-coverage note).
+```
+
+- [ ] **Step 4:** GREEN + `npm run lint:md`
+- [ ] **Step 5:** Commit `feat: sdd+ team-mode preflight and lead-reviews-merges procedure`
+
+### Task 7: Documentation pass (mandated final docs task)
+
+**Files:** README.md, docs/getting-started.md, docs/architecture.md, docs/skill-wrapping.md
+
+- [ ] Step 1: README — cockpit "Plug-and-play detection" bullet gains agent-teams in the probe list; "Rig vs plain superpowers" Subagents cell appends ", team-mode execution of independent plan tasks when Claude Code's experimental agent-teams feature is detected".
+- [ ] Step 2: getting-started — Configure-enforcement sample gains `team_execution: offer  # offer | auto | never (requires the experimental agent-teams flag)`; new short section "Team mode (experimental)" after the skill-chain section: what the offer looks like, the 3-teammate cap, lead-reviews-and-merges, and the degrade guarantee.
+- [ ] Step 3: architecture.md — Layer 3 `sdd+` paragraph gains team mode (preflight, B-team, cap, lead loop); "Subagent operations" agent-teams paragraph rewritten from forward-looking ("Tracked as future work; not yet designed") to shipped, describing detection, the parallelism model end-to-end, and referencing the Task 1 hook-coverage note.
+- [ ] Step 4: skill-wrapping.md — `subagent-driven-development` row's overlay cell appends ", team-mode parallel execution (experimental agent-teams)".
+- [ ] Step 5: `npm run lint:md` → 0 errors. Commit `docs: teams-aware sdd+ and the parallelism model`
+
+### Task 8: Docs-consistency sweep + full verification + PR
+
+**Files:** none new (fixes from findings only)
+
+- [ ] Step 1: Dispatch a typed code-reviewer for a docs-consistency sweep over the branch (the v0.6.0 pre-release pattern): counts, cross-doc claims, config samples vs DEFAULT_CONFIG, template/docs agreement on the team procedure, degrade-path claims vs code. Fix findings on the branch.
+- [ ] Step 2: `npm test` (all pass), `npm run lint`, `npm run lint:md`, coverage gate holds.
+- [ ] Step 3: Push branch; `gh pr create` titled "feat: teams-aware sdd+ — detect, offer, degrade". Do NOT merge — report PR URL for sign-off.
+
+## Verification (overall → spec §11)
+
+1. AC1 (flag unset = identical behavior) — Tasks 2/4 negative tests; degrade prose in Task 6
+2. AC2 (detect, offer, auto/never) — Tasks 2/3/4/6
+3. AC3 (plan+ contract) — Task 5
+4. AC4 (probe answer recorded) — Task 1
+5. AC5 (docs + sweep + gates) — Tasks 7/8

--- a/docs/superpowers/specs/2026-06-12-teams-aware-sdd-design.md
+++ b/docs/superpowers/specs/2026-06-12-teams-aware-sdd-design.md
@@ -1,7 +1,9 @@
 # Teams-Aware sdd+ — Design
 
 **Date:** 2026-06-12
-**Status:** Approved
+**Status:** Approved — plan written
+(`docs/superpowers/plans/2026-06-12-teams-aware-sdd.md`); execution pending
+the #25 merge.
 **Task:** #23. Sequenced behind the hook-payload-drift fix (task #25) for merge
 order only; no code dependency.
 

--- a/docs/superpowers/specs/2026-06-12-teams-aware-sdd-design.md
+++ b/docs/superpowers/specs/2026-06-12-teams-aware-sdd-design.md
@@ -1,0 +1,164 @@
+# Teams-Aware sdd+ — Design
+
+**Date:** 2026-06-12
+**Status:** Approved
+**Task:** #23. Sequenced behind the hook-payload-drift fix (task #25) for merge
+order only; no code dependency.
+
+## 1. Problem statement
+
+`sdd+` executes plan tasks strictly sequentially. That is correct within a
+branch (shared files, merge chain) but leaves Claude Code's experimental
+agent-teams capability unused when a plan contains genuinely independent
+tasks. Per the cockpit pattern, rig should detect the capability, offer it,
+and degrade gracefully — never force it.
+
+The v0.6.0 parallelism rule ("one implementer per branch/worktree; orthogonal
+work concurrent") is the manual version of this; teams make it first-class
+with a shared task list and lead coordination instead of orchestrator
+hand-juggling.
+
+## 2. Decision log (design Q&A, 2026-06-12)
+
+1. **Detect + offer, config-gated** — `workflow.team_execution: offer | auto
+   | never` (default `offer`). sdd+ asks once per plan when the capability
+   and fit are both present; `auto` skips the ask; `never` suppresses.
+2. **plan+ declares, sdd+ verifies** — independence = disjoint `**Files:**`
+   lists AND no explicit `Depends on: Task N` marker, both required. The plan
+   stays the single contract.
+3. **Teammates implement; lead reviews and merges (v1)** — only the implement
+   stage parallelizes. The lead keeps today's two-stage typed review per
+   completed task and merges per-task branches in dependency order.
+   Reviewers-as-teammates deferred to v2.
+4. **Docs mandate** — the implementation plan MUST end with a docs pass
+   covering teams mode and the broader parallelism model, plus a pre-merge
+   docs-consistency sweep (user requirement, recorded in task #23).
+
+## 3. Detection
+
+- `Environment.agentTeamsAvailable: boolean` — true when
+  `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS === '1'` in the process environment.
+  Verified live: the flag is present in hook/session processes and persisted
+  in `~/.claude/settings.json`'s `env` block when the feature is enabled.
+- Detection reads an injectable env record (same testability convention as
+  `ExecFn`), runs in `detectEnvironment()`, caches in `SessionCache`, and is
+  emitted in the session-start panel: `agent-teams: available (experimental)`.
+- Flag absent → `false` → the feature is invisible end-to-end.
+
+## 4. Configuration
+
+```yaml
+rules:
+  workflow:
+    team_execution: offer      # offer | auto | never
+```
+
+Default `offer`. `WorkflowRules` type, `DEFAULT_CONFIG`, and `mergeConfigs`
+extended; absent key → default applies (consistent with 0.6.0 workflow
+semantics). README/getting-started config samples updated.
+
+## 5. plan+ changes — independence in the contract
+
+Two additions to the plan+ template (Phase B):
+
+1. **Files lists are the disjointness input** — instruct that every task's
+   `**Files:**` list must be exhaustive, including shared test files a task
+   extends (the historical leak: multiple tasks appending to one
+   template-content test file).
+2. **Explicit dependency markers** — add `Depends on: Task N` to any task
+   that must follow another even without file overlap.
+
+A task pair is independent iff their Files lists are disjoint AND neither
+carries a dependency marker on the other.
+
+## 6. sdd+ changes — team mode
+
+**Preflight (Phase A):** when `agentTeamsAvailable` AND `team_execution !=
+never` AND the plan contains ≥2 pairwise-independent tasks: at `offer`, ask
+once — "Team mode available: tasks N, M are independent — run as parallel
+teammates? Sequential otherwise." At `auto`, proceed without asking. Any
+other condition → sequential, unchanged.
+
+**Phase B-team (new section in the template):**
+
+1. Create a team named from the plan slug (team = shared task list, 1:1).
+2. Mirror plan tasks into the task list; encode dependency markers as
+   blocked-by edges so teammates can only claim unblocked tasks.
+3. Spawn up to **3** implementer teammates (v1 cap) — typed `implementer`
+   agent, worktree isolation, team name + teammate name. Each teammate's
+   instructions: claim an unblocked task, work it on its own branch
+   (`<plan-branch>-task-N`) off the plan branch, follow the task's TDD steps,
+   push, mark the task complete, claim the next or idle.
+4. **Lead loop (the sdd+ session):** on each completion notification, run the
+   existing two-stage typed review (spec-reviewer → code-reviewer) on that
+   task's branch; route fixes back as new tasks on the shared list; merge
+   reviewed branches into the plan branch in dependency order.
+5. On plan completion: send shutdown requests to teammates, delete the team,
+   run Phase C wrap-up as today.
+
+**Degrade path:** flag absent / `never` / declined / no independent pairs →
+today's sequential dispatch, byte-for-byte identical behavior.
+
+**Operational rules carried over:** per-teammate turn backstops; one
+implementer per branch/worktree (holds by construction); enforcement reaches
+teammates via hooks where they fire, and via the typed agents' system prompts
+(`.harness.yaml` read at runtime) regardless.
+
+## 7. Known risk — resolve as the plan's first task
+
+**Hook coverage inside teammate worktrees.** Teammate worktrees live under
+`.claude/worktrees/`; whether the project's PreToolUse/PostToolUse hooks fire
+there depends on `CLAUDE_PROJECT_DIR` resolution in worktree sessions. The
+implementation plan's first task is an empirical probe (spawn a worktree
+agent, run a hook-triggering command, observe). If hooks do not fire in
+worktrees, v1 documents the enforcement gap explicitly (architecture.md
+subagent operations) and relies on the agents' system-prompt enforcement;
+the gap becomes a tracked follow-up.
+
+## 8. What v1 deliberately does not do
+
+- No reviewers-as-teammates (v2 candidate after the lead-loop pattern proves
+  out).
+- No cross-plan / portfolio teams (orthogonal work items remain
+  orchestrator-managed per the parallelism rule).
+- No auto-merge: every merge goes through the lead after two-stage review.
+- No teams without the env flag, ever — detection is the only entry.
+
+## 9. Documentation (mandated, final plan task)
+
+- README: cockpit detection list gains agent-teams; "Rig vs plain
+  superpowers" Subagents cell gains team-mode mention.
+- docs/getting-started.md: team_execution config + a short "team mode" usage
+  section.
+- docs/architecture.md: Layer 3 sdd+ section gains the team procedure; the
+  "Subagent operations" agent-teams paragraph graduates from forward-looking
+  to shipped, with the full parallelism model described.
+- docs/skill-wrapping.md: subagent-driven-development row notes team mode.
+- Followed by a pre-merge docs-consistency sweep (v0.6.0 pattern).
+
+## 10. Testing
+
+- Unit (injectable env record): detection true/false/missing; config
+  defaults, merge, `never`/`auto`/`offer` resolution.
+- Template-content: plan+ dependency-marker + exhaustive-Files instructions;
+  sdd+ preflight offer prose, team procedure, v1 cap, degrade path.
+- Independence computation: if implemented as code (vs prose), unit-test the
+  disjointness+marker logic incl. the shared-test-file case; if prose-only in
+  v1, the template-content tests carry it and the eval harness (task #26)
+  owns behavioral verification.
+- Behavioral (offer fires correctly, teammates coordinate, lead merges in
+  order): explicitly deferred to dogfooding + the #26 eval harness — same
+  honest split as the loop docs.
+
+## 11. Acceptance criteria
+
+1. With the env flag unset, every code path and template behaves identically
+   to v0.6.x (deterministic tests prove the degrade path).
+2. With the flag set, session start reports agent-teams availability; sdd+
+   offers team mode only when the plan has ≥2 independent tasks and config
+   is `offer`; `auto`/`never` behave as specified.
+3. plan+ emits dependency markers and exhaustive-Files guidance
+   (template-content tests).
+4. The worktree hook-coverage probe (§7) has a recorded answer in
+   architecture.md, whichever way it lands.
+5. Docs per §9; full suite, coverage gate, lint, docs-consistency sweep green.

--- a/src/config.ts
+++ b/src/config.ts
@@ -51,6 +51,7 @@ export const DEFAULT_CONFIG: HarnessConfig = {
       branch_discipline: 'advise',
       protected_branches: ['master', 'main'],
       isolation_strategy: 'auto',
+      team_execution: 'offer',
     },
     enforcement: {
       default_level: 'advise',

--- a/src/session/environment.ts
+++ b/src/session/environment.ts
@@ -91,6 +91,7 @@ export async function detectEnvironment(
   statCheck: (path: string) => { size: number } | undefined = defaultStatCheck,
   mcpQuery: McpQueryFn = defaultMcpQuery,
   registrationLookup: RegistrationLookupFn = resolveJcodemunchRegistration,
+  envVars: Record<string, string | undefined> = process.env,
 ): Promise<Environment> {
   const rtkResult = detectRtk(exec);
   const jmResult = await detectJcodemunch(cwd, exec, mcpQuery, registrationLookup);
@@ -110,6 +111,7 @@ export async function detectEnvironment(
     graphifyGraphPath: graphifyResult.state === 'ready' ? graphifyResult.graphPath ?? null : null,
     graphifyVersion: graphifyResult.cliVersion ?? null,
     graphBuildInfo: graphifyResult.state === 'absent' && !graphifyResult._cliFound ? undefined : graphifyResult,
+    agentTeamsAvailable: envVars.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS === '1',
     detectedAt: Date.now(),
   };
 }

--- a/src/session/start.ts
+++ b/src/session/start.ts
@@ -51,6 +51,7 @@ export interface SessionStartDeps {
   readFile?: (path: string) => string;
   homeDir?: string;
   graphWait?: WaitForBuildOpts;
+  envVars?: Record<string, string | undefined>;
 }
 
 // graphify update can return before graph.json is fully written; poll across
@@ -68,6 +69,7 @@ export async function handleSessionStart(
 ): Promise<string> {
   const { env, fileCapHit, autoIndex } = await detectAndIndex(
     cwd, deps.exec, deps.existsCheck, deps.statCheck, deps.mcpQuery, deps.registrationLookup,
+    deps.envVars,
   );
 
   // Headroom (context-compression proxy) is complementary to rig — record
@@ -155,6 +157,10 @@ export async function handleSessionStart(
 
   if (env.headroomInitialized) {
     lines.push('  headroom: proxy configured (context-layer compression)');
+  }
+
+  if (env.agentTeamsAvailable) {
+    lines.push('  agent-teams: available (experimental)');
   }
 
   if (env.jcodemunchAvailable) {
@@ -356,8 +362,9 @@ export async function detectAndIndex(
   statCheck?: (path: string) => { size: number } | undefined,
   mcpQuery?: McpQueryFn,
   registrationLookup?: RegistrationLookupFn,
+  envVars?: Record<string, string | undefined>,
 ): Promise<{ env: Environment; fileCapHit?: FileCapWarning; autoIndex: AutoIndexOutcome }> {
-  const env = await detectEnvironment(cwd, exec, existsCheck, statCheck, mcpQuery, registrationLookup);
+  const env = await detectEnvironment(cwd, exec, existsCheck, statCheck, mcpQuery, registrationLookup, envVars);
   let fileCapHit: FileCapWarning | undefined;
   let autoIndex: AutoIndexOutcome = 'not_needed';
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -233,6 +233,8 @@ export interface WorkflowRules {
   branch_discipline?: EnforcementLevel;
   protected_branches?: string[];
   isolation_strategy?: 'auto' | 'branch' | 'worktree';
+  /** How sdd+ uses agent-teams when detected: offer (ask once), auto, or never. */
+  team_execution?: 'offer' | 'auto' | 'never';
 }
 
 export interface HarnessConfig {

--- a/src/types.ts
+++ b/src/types.ts
@@ -140,6 +140,8 @@ export interface Environment {
   graphifyVersion?: string | null;
   headroomAvailable?: boolean;
   headroomInitialized?: boolean;
+  /** Claude Code's experimental agent-teams feature is enabled for this session. */
+  agentTeamsAvailable?: boolean;
   detectedAt: number;
 }
 

--- a/templates/skills/plan-plus/SKILL.md
+++ b/templates/skills/plan-plus/SKILL.md
@@ -80,6 +80,14 @@ This skill runs after `brain+` has produced a validated design. It creates the i
    - Rollout gates (credentials, schedule enablement, live writes) are
      explicitly reserved to the user — never automated in any task
 
+5. **Independence contract** (consumed by sdd+ team mode): every task's
+   `**Files:**` list must be exhaustive — include shared test files a task
+   extends (a tests file touched by several tasks makes them dependent).
+   Where ordering matters even without file overlap, add an explicit
+   `Depends on: Task N` line under the task header. A pair of tasks is
+   parallelizable only when their Files lists are disjoint AND neither
+   depends on the other.
+
 ### Phase C: Validate Plan
 
 1. Confirm the plan:

--- a/templates/skills/sdd-plus/SKILL.md
+++ b/templates/skills/sdd-plus/SKILL.md
@@ -44,6 +44,16 @@ subagent using the superpowers prompt template for that role.
    worktree (`superpowers:using-git-worktrees`) when the plan is multi-task or
    the working tree is dirty, a plain feature branch otherwise.
 
+5. **Team-mode preflight.** If session-start reported `agent-teams: available
+   (experimental)` AND `rules.workflow.team_execution` is not `never`:
+   compute task independence from the plan's contract (disjoint `**Files:**`
+   lists AND no `Depends on:` marker either way). If ≥2 tasks are pairwise
+   independent: at `offer`, ask once — "Team mode available: tasks [N, M, …]
+   are independent — run them as parallel teammates? Sequential otherwise." —
+   and proceed per the answer; at `auto`, use team mode without asking. In
+   every other case (flag absent, `never`, declined, no independent pairs),
+   use the standard sequential dispatch below, unchanged.
+
 ### Phase B: Execute (delegate to superpowers:subagent-driven-development)
 
 1. Invoke `superpowers:subagent-driven-development` with the loaded plan.
@@ -59,6 +69,31 @@ subagent using the superpowers prompt template for that role.
    *outside* this plan (a different branch, disjoint files, no merge-order
    dependency) may proceed concurrently in its own worktree; reviewers are
    read-only and always safe to run in parallel.
+
+### Phase B-team: Team execution (when team mode is on)
+
+1. Create a team named after the plan (e.g. `sdd-<plan-slug>`); the team's
+   shared task list mirrors the plan: one entry per plan task, with
+   `Depends on:` markers encoded as blocked-by edges so only unblocked tasks
+   are claimable.
+2. Spawn implementer teammates — at most 3, and never more than the number of
+   currently-unblocked independent tasks. Each is the typed `implementer`
+   agent, worktree-isolated, joined to the team with a distinct name. Each
+   teammate's standing instructions: claim one unblocked task, execute it on
+   its own branch (`<plan-branch>-task-N`) off the plan branch following the
+   task's TDD steps exactly, push the branch, mark the task complete, then
+   claim the next unblocked task or go idle.
+3. **Lead loop (you):** on each task-completion notification, run the
+   standard two-stage review from Phase B (spec-reviewer, then code-reviewer)
+   against that task's branch. Route review findings back as new blocked
+   tasks assigned to a fresh implementer dispatch. Merge each approved task
+   branch into the plan branch in dependency order — one merge at a time,
+   re-running the suite after each merge.
+4. When all plan tasks are complete and merged: send each teammate a shutdown
+   request, delete the team, and continue to Phase C as in sequential mode.
+5. Turn budgets, worktree isolation, and enforcement apply to teammates
+   exactly as to any typed implementer dispatch (see architecture.md
+   "Subagent operations", including the worktree hook-coverage note).
 
 ### Phase C: Wrap Up
 

--- a/tests/cli/template-content.test.ts
+++ b/tests/cli/template-content.test.ts
@@ -75,6 +75,21 @@ describe('skill templates — typed dispatch', () => {
     expect(content).toContain('Agent(subagent_type="code-reviewer"');
     expect(content).toContain('fall back to a general-purpose');
   });
+
+  it('plan-plus carries the parallelism/independence contract', () => {
+    const content = read('skills/plan-plus/SKILL.md');
+    expect(content).toContain('Depends on: Task');
+    expect(content).toContain('exhaustive');
+  });
+
+  it('sdd-plus offers team mode behind detection and config', () => {
+    const content = read('skills/sdd-plus/SKILL.md');
+    expect(content).toContain('agent-teams');
+    expect(content).toContain('team_execution');
+    expect(content).toContain('Team mode available');
+    expect(content).toContain('at most 3');
+    expect(content).toContain('sequential dispatch');
+  });
 });
 
 describe('skill templates — loop-aware vocabulary', () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -71,6 +71,11 @@ describe('config', () => {
       expect(config.rules.workflow?.protected_branches).toEqual(['master', 'main']);
       expect(config.rules.workflow?.isolation_strategy).toBe('auto');
     });
+
+    it('defaults team_execution to offer', async () => {
+      const config = await loadConfig('/nonexistent/.harness.yaml');
+      expect(config.rules.workflow?.team_execution).toBe('offer');
+    });
   });
 
   describe('mergeConfigs', () => {
@@ -115,6 +120,14 @@ describe('config', () => {
       } as HarnessConfig);
       expect(merged.rules.workflow?.branch_discipline).toBe('block');
       expect(merged.rules.workflow?.protected_branches).toEqual(['master', 'main']);
+    });
+
+    it('merges team_execution override while keeping other workflow defaults', () => {
+      const merged = mergeConfigs(structuredClone(DEFAULT_CONFIG), {
+        rules: { workflow: { team_execution: 'never' } },
+      } as HarnessConfig);
+      expect(merged.rules.workflow?.team_execution).toBe('never');
+      expect(merged.rules.workflow?.branch_discipline).toBe('advise');
     });
   });
 });

--- a/tests/session/environment.test.ts
+++ b/tests/session/environment.test.ts
@@ -1120,3 +1120,51 @@ describe('defaultMcpQuery (real-process integration)', () => {
     expect(result).toBeNull();
   });
 });
+
+describe('detectEnvironment agent-teams detection', () => {
+  const noToolsExec = makeExec({
+    'which rtk': new Error('not found'),
+    'which jcodemunch': new Error('not found'),
+    'which jcodemunch-mcp': new Error('not found'),
+    'which uvx': new Error('not found'),
+  });
+
+  it('detects agent teams from the experimental env flag', async () => {
+    const env = await detectEnvironment(
+      '/fake/cwd',
+      noToolsExec,
+      () => false,
+      () => undefined,
+      makeMcpQuery({}),
+      () => null,
+      { CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1' },
+    );
+    expect(env.agentTeamsAvailable).toBe(true);
+  });
+
+  it('reports agent teams unavailable when the flag is absent', async () => {
+    const env = await detectEnvironment(
+      '/fake/cwd',
+      noToolsExec,
+      () => false,
+      () => undefined,
+      makeMcpQuery({}),
+      () => null,
+      {},
+    );
+    expect(env.agentTeamsAvailable).toBe(false);
+  });
+
+  it('reports agent teams unavailable when the flag is not "1"', async () => {
+    const env = await detectEnvironment(
+      '/fake/cwd',
+      noToolsExec,
+      () => false,
+      () => undefined,
+      makeMcpQuery({}),
+      () => null,
+      { CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '0' },
+    );
+    expect(env.agentTeamsAvailable).toBe(false);
+  });
+});

--- a/tests/session/start.test.ts
+++ b/tests/session/start.test.ts
@@ -934,6 +934,36 @@ describe('handleSessionStart', () => {
       expect(output).toContain('headroom: proxy configured (context-layer compression)');
     });
 
+    it('reports agent-teams when the experimental flag is set', async () => {
+      vi.mocked(execSync).mockImplementation((cmd: string) => {
+        if (cmd === 'which rtk') throw new Error('not found');
+        if (cmd === 'which jcodemunch') return '/usr/bin/jcodemunch';
+        if (cmd.includes('list_repos')) return '{"repos":["local/test-project"]}';
+        return '';
+      });
+
+      const output = await startSession('/home/user/test-project', cache, {
+        envVars: { CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1' },
+      });
+
+      expect(output).toContain('agent-teams: available (experimental)');
+    });
+
+    it('omits the agent-teams line when the flag is absent', async () => {
+      vi.mocked(execSync).mockImplementation((cmd: string) => {
+        if (cmd === 'which rtk') throw new Error('not found');
+        if (cmd === 'which jcodemunch') return '/usr/bin/jcodemunch';
+        if (cmd.includes('list_repos')) return '{"repos":["local/test-project"]}';
+        return '';
+      });
+
+      const output = await startSession('/home/user/test-project', cache, {
+        envVars: {},
+      });
+
+      expect(output).not.toContain('agent-teams');
+    });
+
     it('renders the rtk version when known', async () => {
       vi.mocked(execSync).mockImplementation((cmd: string) => {
         if (cmd === 'which rtk') return '/opt/homebrew/bin/rtk';


### PR DESCRIPTION
## What

When Claude Code's experimental agent-teams feature is enabled, `sdd+` offers to execute a plan's **independent** tasks as parallel worktree-isolated `implementer` teammates with the session as lead reviewing and merging. When the feature is absent — or `team_execution: never`, or the offer is declined, or no two tasks are independent — `sdd+` degrades **byte-for-byte** to the existing sequential implementer → spec-reviewer → code-reviewer dispatch. Team mode is strictly additive.

Spec: `docs/superpowers/specs/2026-06-12-teams-aware-sdd-design.md`
Plan: `docs/superpowers/plans/2026-06-12-teams-aware-sdd.md`

## How it's wired (cockpit pattern: detect → offer → degrade)

- **Detect** — `Environment.agentTeamsAvailable` reads `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS === '1'` via the injectable env record in `detectEnvironment`; session start emits `agent-teams: available (experimental)`.
- **Config** — `workflow.team_execution: offer | auto | never` (default `offer`) gates use independently of detection.
- **Offer** — `sdd+` Phase A preflight computes task independence from the plan's contract (disjoint `**Files:**` lists AND no `Depends on:` marker either way). With ≥2 pairwise-independent tasks: `offer` asks once, `auto` proceeds silently.
- **Execute (Phase B-team)** — ≤3 worktree-isolated implementer teammates on `<plan-branch>-task-N` branches; the session (lead) runs two-stage review and merges approved branches in dependency order, re-running the suite after each merge.
- **plan+ contract** — `plan+` now requires exhaustive `**Files:**` lists and `Depends on:` markers so independence is computable.

## Changes

- `src/types.ts` — `Environment.agentTeamsAvailable`, `WorkflowRules.team_execution`
- `src/session/environment.ts` — flag detection (injectable env record)
- `src/session/start.ts` — panel line
- `src/config.ts` — `team_execution: 'offer'` default
- `templates/skills/plan-plus/SKILL.md` — independence contract
- `templates/skills/sdd-plus/SKILL.md` — team-mode preflight + Phase B-team procedure
- Docs (Task 7): README, getting-started ("Team mode (experimental)" section + config), architecture (Layer 3 sdd+ + the "Agent teams" section graduated from forward-looking to shipped + worktree hook-coverage note), skill-wrapping
- `docs/architecture.md` — empirical worktree hook-coverage probe results (Task 1)

## Verification

- `npx vitest run --coverage` — 1311 tests pass; coverage thresholds hold (exit 0)
- `npm run lint` (tsc) — clean
- `npm run lint:md` — 0 errors; internal links resolve; no filler words
- **Docs-consistency sweep** — three read-only `code-reviewer` agents (code↔docs, templates↔docs, cross-doc): two dimensions clean, one nit (README config example missing `team_execution`) fixed in `dde8ce0`
- Negative path: flag-unset and `never` covered by detection/config tests; degrade prose asserted by `template-content` tests

Rebased onto `master` (df0313e, post eval-harness + v0.6.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)