### PR TITLE
fix: stale-test advisory dedup + batched session-cache writes

### DIFF
--- a/src/enforcement/post-tool-use.ts
+++ b/src/enforcement/post-tool-use.ts
@@ -2,7 +2,7 @@ import { resolve } from 'node:path';
 import { FileTracker } from './file-tracker.js';
 import { SessionCache } from '../session/cache.js';
 import type { EnforcementViolation, HarnessConfig } from '../types.js';
-import { checkStaleTests } from './stale-test.js';
+import { checkStaleTests, staleSetKey } from './stale-test.js';
 import { checkConstitutional } from './constitutional.js';
 import { checkZeroDefect } from './zero-defect.js';
 import {
@@ -49,6 +49,23 @@ export function extractBashOutput(
  * channel for command output (see extractBashOutput).
  */
 export function handlePostToolUse(
+  tool: string,
+  args: Record<string, unknown>,
+  tracker: FileTracker,
+  cache: SessionCache,
+  config: HarnessConfig,
+  execFn?: ExecFn,
+  toolResponse?: unknown,
+): EnforcementViolation | null {
+  // Batch every cache mutation this invocation makes (turn counter,
+  // edited-file sets, turn-stamped history, stale key, metric counters) into a
+  // single session-cache file write instead of one write per setter.
+  return cache.transaction(() =>
+    runPostToolChecks(tool, args, tracker, cache, config, execFn, toolResponse),
+  );
+}
+
+function runPostToolChecks(
   tool: string,
   args: Record<string, unknown>,
   tracker: FileTracker,
@@ -122,9 +139,15 @@ export function handlePostToolUse(
       if (constitutional) violations.push(constitutional);
     }
 
-    // Stale test check
-    const stale = checkStaleTests(tracker, config);
-    if (stale) violations.push(stale);
+    // Stale test check — gated on a change to the stale source-file set so an
+    // unchanged (often growing) list is not re-emitted on every Edit/Write.
+    // updateStaleKey runs on every Edit/Write to track transitions, including
+    // the set clearing to empty (which resets the dedup so a later relapse
+    // re-fires); checkStaleTests still returns null when nothing is stale.
+    if (cache.updateStaleKey(staleSetKey(tracker, config))) {
+      const stale = checkStaleTests(tracker, config);
+      if (stale) violations.push(stale);
+    }
   }
 
   // Zero-defect check on test command output

--- a/src/enforcement/stale-test.ts
+++ b/src/enforcement/stale-test.ts
@@ -36,3 +36,18 @@ export function checkStaleTests(tracker: FileTracker, config: HarnessConfig): En
 
   return { level, message: lines.join('\n') };
 }
+
+/**
+ * Stable identity of the current stale source-file set: sorted, de-duplicated
+ * file paths joined by '|', or '' when nothing is stale. The PostToolUse
+ * handler feeds this to SessionCache.updateStaleKey so an unchanged stale set
+ * doesn't re-emit the (often growing) advisory on every Edit/Write. The set is
+ * de-duplicated because a file edited across several turns produces one
+ * getStaleSources entry per turn — without it, a third identical edit would
+ * look like a changed set.
+ */
+export function staleSetKey(tracker: FileTracker, config: HarnessConfig): string {
+  const gracePeriod = config.rules.stale_tests?.grace_period ?? 0;
+  const files = tracker.getStaleSources(gracePeriod).map(edit => edit.file);
+  return [...new Set(files)].sort().join('|');
+}

--- a/src/session/cache.ts
+++ b/src/session/cache.ts
@@ -45,6 +45,9 @@ export class SessionCache {
   private advisorySuppressCounts: Map<string, number> = new Map();
   private editTurnCounter = 0;
   private editHistory: EditHistoryEntry[] = [];
+  private lastStaleKey = '';
+  private saveSuppressed = false;
+  private saveDirty = false;
 
   constructor(cwd?: string, sessionId?: string) {
     this.cwd = cwd;
@@ -123,6 +126,42 @@ export class SessionCache {
 
   getEditHistory(): EditHistoryEntry[] {
     return [...this.editHistory];
+  }
+
+  /**
+   * Stale-test advisory dedup. Returns true when `key` differs from the last
+   * stale set we advised on (and stores the new key), false when unchanged.
+   * The handler passes the sorted unique set of stale source files; an empty
+   * key ('' — nothing stale) is stored too, so a set that clears and later
+   * re-appears re-fires instead of staying suppressed forever. Keeps the
+   * stale-test advisory from re-emitting an identical (often growing) list on
+   * every Edit/Write — the advisory-fatigue fix.
+   */
+  updateStaleKey(key: string): boolean {
+    if (key === this.lastStaleKey) return false;
+    this.lastStaleKey = key;
+    this.save();
+    return true;
+  }
+
+  /**
+   * Run `fn` with intermediate save()s suppressed, then write the cache file
+   * exactly once at the end — and only if a save was actually requested. A
+   * single PostToolUse invocation mutates several fields (turn counter,
+   * edited-file sets, turn-stamped history, stale key, metric counters);
+   * without batching, each setter rewrites the whole JSON file. Re-entrant
+   * calls flatten — only the outermost transaction performs the write.
+   */
+  transaction<T>(fn: () => T): T {
+    if (this.saveSuppressed) return fn(); // already inside a transaction
+    this.saveSuppressed = true;
+    this.saveDirty = false;
+    try {
+      return fn();
+    } finally {
+      this.saveSuppressed = false;
+      if (this.saveDirty) this.save();
+    }
   }
 
   setPhase(phase: string): void {
@@ -266,6 +305,7 @@ export class SessionCache {
     this.advisorySuppressCounts = new Map();
     this.editTurnCounter = 0;
     this.editHistory = [];
+    this.lastStaleKey = '';
     this.save();
   }
 
@@ -290,6 +330,7 @@ export class SessionCache {
       advisorySuppressCounts: Object.fromEntries(this.advisorySuppressCounts),
       editTurnCounter: this.editTurnCounter,
       editHistory: [...this.editHistory],
+      lastStaleKey: this.lastStaleKey,
     };
   }
 
@@ -330,12 +371,18 @@ export class SessionCache {
       this.advisorySuppressCounts = new Map(Object.entries(data.advisorySuppressCounts ?? {}));
       this.editTurnCounter = data.editTurnCounter ?? 0;
       this.editHistory = data.editHistory ?? [];
+      this.lastStaleKey = data.lastStaleKey ?? '';
     } catch {
       // Corrupt or unreadable file — start fresh
     }
   }
 
   private save(): void {
+    // Inside a transaction, defer the write and remember that one is due.
+    if (this.saveSuppressed) {
+      this.saveDirty = true;
+      return;
+    }
     if (!this.cwd) return;
     const path = sessionCachePath(this.cwd, this.sessionId);
     try {

--- a/src/types.ts
+++ b/src/types.ts
@@ -175,6 +175,9 @@ export interface SessionCacheFile {
   scoutedDirs?: string[];
   editTurnCounter?: number;
   editHistory?: EditHistoryEntry[];
+  /** Last stale source-file set the stale-test check advised on (sorted unique
+   *  paths joined by '|'), for advisory dedup across hook processes. */
+  lastStaleKey?: string;
 }
 
 /** A turn-stamped file edit, persisted for the cross-process stale-test

--- a/tests/enforcement/post-tool-use.test.ts
+++ b/tests/enforcement/post-tool-use.test.ts
@@ -433,6 +433,26 @@ describe('handlePostToolUse', () => {
       expect(third).not.toBeNull();
       expect(third?.message).toContain('STALE TEST');
     });
+
+    it('suppresses a repeat advisory when the stale set is unchanged (dedup)', () => {
+      expect(freshInvocation(cache, 'src/feature/widget.ts')).toBeNull();        // turn 1, exempt
+      const fires = freshInvocation(cache, 'src/feature/widget.ts');             // turn 2, {widget} → fire
+      expect(fires?.message).toContain('STALE TEST');
+      // turn 3, identical stale set {widget} → no repeat advisory (advisory fatigue fix)
+      expect(freshInvocation(cache, 'src/feature/widget.ts')).toBeNull();
+    });
+
+    it('re-fires when a new file joins the stale set', () => {
+      freshInvocation(cache, 'src/feature/widget.ts');                           // turn 1, exempt
+      expect(freshInvocation(cache, 'src/feature/widget.ts')?.message)           // turn 2, {widget} → fire
+        .toContain('STALE TEST');
+      // turn 3 edits gadget (its own creation turn is exempt); set still {widget} → suppressed
+      expect(freshInvocation(cache, 'src/feature/gadget.ts')).toBeNull();
+      // turn 4: gadget is now past its creation turn → set {widget, gadget} changed → re-fire
+      const grew = freshInvocation(cache, 'src/feature/gadget.ts');
+      expect(grew?.message).toContain('src/feature/gadget.ts');
+      expect(grew?.message).toContain('src/feature/widget.ts');
+    });
   });
 
   describe('session cache persistence of edits', () => {

--- a/tests/session/cache.test.ts
+++ b/tests/session/cache.test.ts
@@ -197,6 +197,34 @@ describe('SessionCache', () => {
       expect(cache.shouldAdvise('native_grep')).toBe(true);
     });
   });
+
+  describe('updateStaleKey (stale-test advisory dedup)', () => {
+    it('returns true on the first set and when the set changes, false when unchanged', () => {
+      expect(cache.updateStaleKey('a')).toBe(true);   // first non-empty set
+      expect(cache.updateStaleKey('a')).toBe(false);  // unchanged → suppress repeat
+      expect(cache.updateStaleKey('a|b')).toBe(true); // a new file joined the set
+      expect(cache.updateStaleKey('a|b')).toBe(false);
+    });
+
+    it('treats the empty set as a reset so a re-introduced set re-fires', () => {
+      expect(cache.updateStaleKey('a')).toBe(true);
+      expect(cache.updateStaleKey('')).toBe(true);    // set cleared (all covered)
+      expect(cache.updateStaleKey('')).toBe(false);   // still empty
+      expect(cache.updateStaleKey('a')).toBe(true);   // same set, but after a clear → re-fire
+    });
+
+    it('clears the stale key on reset', () => {
+      cache.updateStaleKey('a');
+      cache.reset();
+      expect(cache.updateStaleKey('a')).toBe(true);
+    });
+  });
+
+  describe('transaction (batched writes)', () => {
+    it('returns the callback result', () => {
+      expect(cache.transaction(() => 42)).toBe(42);
+    });
+  });
 });
 
 describe('SessionCache (file-backed)', () => {
@@ -228,6 +256,24 @@ describe('SessionCache (file-backed)', () => {
       { file: 'src/feature/widget.ts', category: 'source', turn: 1 },
     ]);
     expect(second.advanceEditTurn()).toBe(2);
+  });
+
+  it('transaction batches writes — disk stays at the pre-transaction state until it ends', () => {
+    const path = trackPath(sessionCachePath(testCwd));
+    const cache = new SessionCache(testCwd);
+    cache.setPhase('plan+'); // committed to disk before the transaction
+    cache.transaction(() => {
+      cache.setPhase('tdd+');
+      cache.advanceEditTurn();
+      // Mid-transaction: intermediate saves are suppressed, so disk is stale.
+      const onDisk = JSON.parse(readFileSync(path, 'utf-8')) as SessionCacheFile;
+      expect(onDisk.currentPhase).toBe('plan+');
+      expect(onDisk.editTurnCounter).toBe(0);
+    });
+    // After the transaction: a fresh hook process sees the committed state.
+    const reloaded = new SessionCache(testCwd);
+    expect(reloaded.getCurrentPhase()).toBe('tdd+');
+    expect(reloaded.getEditTurn()).toBe(1);
   });
 
   it('generates deterministic path from cwd', () => {


### PR DESCRIPTION
## What

Two fast-follows to the [PR #43](https://github.com/franklywatson/claude-rig/pull/43) review, both in the PostToolUse path. Fixes the headline item in #27.

### (1) Stale-test advisory dedup — the IMPORTANT one

The stale-test check re-emitted its advisory on **every** Edit/Write while any source file stayed uncovered — an identical, often growing list. This produced real advisory fatigue and token cost (it fired ~10× during this branch's own development).

Now the advisory is keyed on the stale source-file **set**:

- `staleSetKey(tracker, config)` returns the sorted **unique** stale file set (deduplicated because a file edited across N turns yields N `getStaleSources` entries — without it, a third identical edit would look like a changed set).
- `SessionCache.updateStaleKey(key)` fires only when the set changes (a new file goes stale) and suppresses repeats of an unchanged set.
- The set clearing to empty resets the dedup, so a file that goes stale → gets covered → relapses will re-fire.

### (2) Batched session-cache writes

A single PostToolUse invocation mutated several cache fields (turn counter, edited-file sets, turn-stamped history, stale key, metric counters), each setter rewriting the whole JSON file. `handlePostToolUse` now wraps its body (extracted verbatim to a private `runPostToolChecks`) in `cache.transaction()`, which suppresses intermediate `save()`s and writes once at the end — and only if a save was actually requested, so read-only tool calls still don't write.

## Tests

- `cache.test.ts`: `updateStaleKey` (change / unchanged / empty-reset / reset) and `transaction` (return value + disk-stays-stale-until-commit).
- `post-tool-use.test.ts`: dedup suppression of an unchanged stale set, and re-fire when a new file joins the set.
- Full suite + coverage gate green (`npx vitest run --coverage`, exit 0); tsc clean.

## Deferred (tracked separately)

The remaining #27 cleanups have **no behavioral payoff** and large mechanical churn (52 test call sites), so they're split out rather than bloating this fix: the `handlePostToolUse` options-object refactor, moving tracker construction inside (removing the empty-tracker accommodation), dropping the dead `EditHistoryEntry.category` field, and the pre-tool-use `'type' in result` narrow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)