### PR TITLE
fix: zero-defect is phase-aware — tdd+/sdd+ RED no longer blocks

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -253,6 +253,14 @@ Parses test output (vitest, jest, pytest patterns) for failure indicators. Class
 or unknown. Supports pre-existing failure classification via `git diff` — failures in untouched
 files are reported separately from regressions based on `zero_defect.unrelated_errors` config.
 
+The check is **phase-aware**, mirroring test scope control: during `tdd+`/`sdd+`
+a failing run is the expected RED step of red-green-refactor — indistinguishable
+from a regression to a pattern match — so a blocking violation is downgraded to
+advisory (the failures still surface, the loop is not halted). The block returns
+in `verify+`, where a green suite is mandatory. The phase comes from the session
+cache (`cache.getCurrentPhase()`); callers that pass no phase keep the strict
+behavior unchanged.
+
 **Files:** `src/enforcement/file-tracker.ts`, `src/enforcement/stale-test.ts`, `src/enforcement/test-scope.ts`, `src/enforcement/constitutional.ts`, `src/enforcement/zero-defect.ts`, `src/enforcement/post-tool-use.ts`
 
 ---

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -249,7 +249,7 @@ After each tool use, the post-tool-use hook runs three checks:
 
 1. **Stale tests** -- Did you edit source files without updating tests?
 2. **Constitutional** -- Are there mocks in stack/E2E test files? (mocks are appropriate in unit tests; configurable — set `no_mocks: silent` to disable)
-3. **Zero defect** -- Do the test results show failures?
+3. **Zero defect** -- Do the test results show failures? (phase-aware: during `tdd+`/`sdd+` a failing run is the expected RED step, so a block is downgraded to advisory; the block returns in `verify+`)
 
 Each check returns a violation message or null. Advise-level violations are
 emitted as agent-visible `additionalContext` (the agent sees them next to the

--- a/src/enforcement/post-tool-use.ts
+++ b/src/enforcement/post-tool-use.ts
@@ -160,7 +160,12 @@ function runPostToolChecks(
       const isTestCommand = /vitest|jest|pytest|mocha/.test(command);
       if (isTestCommand) {
         const changedFiles = cache.getChangedFiles();
-        const zeroDefect = checkZeroDefect(output, config, changedFiles.length > 0 ? changedFiles : undefined);
+        const zeroDefect = checkZeroDefect(
+          output,
+          config,
+          changedFiles.length > 0 ? changedFiles : undefined,
+          cache.getCurrentPhase(),
+        );
         if (zeroDefect) violations.push(zeroDefect);
       }
     }

--- a/src/enforcement/zero-defect.ts
+++ b/src/enforcement/zero-defect.ts
@@ -14,6 +14,13 @@ const FAILURE_LINE_PATTERNS = [
 ];
 
 /**
+ * Phases whose runs expect failing tests (the RED step of red-green-refactor).
+ * Mirrors SCOPED_PHASES in test-scope.ts and post-tool-use.ts — all three list
+ * the phases where a full-suite failure is not yet a defect to block on.
+ */
+const SCOPED_PHASES = ['tdd+', 'sdd+'];
+
+/**
  * Extract a test file path from a failure line.
  * Handles vitest/jest `FAIL tests/foo.test.ts` and pytest `FAILED tests/test_foo.py`.
  */
@@ -101,11 +108,19 @@ export function classifyFailures(testOutput: string, changedFiles: string[]): Cl
  * Check test output for failures and errors.
  * Returns null if clean, or a zero-defect violation carrying its level.
  * When changedFiles is provided, classifies failures as regressions vs pre-existing.
+ *
+ * Phase-aware: during a scoped-execution phase (tdd+/sdd+), a failing test is
+ * the expected RED step of red-green-refactor — indistinguishable from a
+ * regression to a pattern match — so blocking is downgraded to advisory. The
+ * block returns in verify+ (final verification), where a green suite is
+ * mandatory. Mirrors checkTestScope's phase gating. currentPhase is omitted by
+ * callers that don't track phase, leaving the strict behavior unchanged.
  */
 export function checkZeroDefect(
   testOutput: string,
   config: HarnessConfig,
   changedFiles?: string[],
+  currentPhase?: string | null,
 ): EnforcementViolation | null {
   const tolerance = config.rules.zero_defect?.tolerance ?? 'strict';
   const unrelatedErrors = config.rules.zero_defect?.unrelated_errors ?? 'block';
@@ -113,9 +128,15 @@ export function checkZeroDefect(
   const hasFailure = FAILURE_PATTERNS.some(p => p.test(testOutput));
   if (!hasFailure) return null;
 
+  // During tdd+/sdd+, failing tests are expected (RED). Cap the level at
+  // advisory so the loop isn't blocked on every RED run; the message formatters
+  // derive their level from this effective tolerance.
+  const inScopedPhase = currentPhase != null && SCOPED_PHASES.includes(currentPhase);
+  const effectiveTolerance = inScopedPhase ? 'permissive' : tolerance;
+
   // No changed files provided — use original behavior
   if (!changedFiles) {
-    return formatViolation(testOutput, tolerance);
+    return formatViolation(testOutput, effectiveTolerance);
   }
 
   // Classify failures
@@ -128,14 +149,14 @@ export function checkZeroDefect(
       return formatPreExistingMessage(preExisting);
     }
     // block: fall through to format all as violations
-    return formatViolation(testOutput, tolerance);
+    return formatViolation(testOutput, effectiveTolerance);
   }
 
   // Has regressions — always block on those
   const parts: EnforcementViolation[] = [];
 
   if (regressions.length > 0) {
-    parts.push(formatRegressionsMessage(regressions, tolerance));
+    parts.push(formatRegressionsMessage(regressions, effectiveTolerance));
   }
 
   if (preExisting.length > 0 && unrelatedErrors !== 'silent') {

--- a/tests/enforcement/post-tool-use.test.ts
+++ b/tests/enforcement/post-tool-use.test.ts
@@ -144,6 +144,22 @@ describe('handlePostToolUse', () => {
       );
       expect(result).toBeNull();
     });
+
+    it('threads the cache phase into zero-defect: a tdd+ RED run is advisory, not a block', () => {
+      config.rules.zero_defect = { tolerance: 'strict', unrelated_errors: 'block' };
+      cache.setPhase('tdd+');
+      const result = handlePostToolUse(
+        'Bash',
+        { command: 'npx vitest run' },
+        tracker,
+        cache,
+        config,
+        undefined,
+        'FAIL tests/a.test.ts\nTests: 1 failed',
+      );
+      expect(result).not.toBeNull();
+      expect(result?.level).toBe('advise');
+    });
   });
 
   it('checks constitutional on stack test file edits', () => {

--- a/tests/enforcement/zero-defect.test.ts
+++ b/tests/enforcement/zero-defect.test.ts
@@ -277,3 +277,40 @@ describe('checkZeroDefect with changedFiles', () => {
     expect(result?.message).not.toContain('old.test.ts');
   });
 });
+
+describe('checkZeroDefect phase awareness (tdd+/sdd+ RED exemption)', () => {
+  let config: HarnessConfig;
+
+  beforeEach(() => {
+    config = structuredClone(DEFAULT_CONFIG);
+    config.rules.zero_defect = { tolerance: 'strict', unrelated_errors: 'block' };
+  });
+
+  const failing = 'FAIL tests/widget.test.ts\nTests: 1 failed, 0 passed';
+
+  it('downgrades a strict block to advisory during tdd+ (the expected RED step)', () => {
+    const result = checkZeroDefect(failing, config, undefined, 'tdd+');
+    expect(result).not.toBeNull();
+    expect(result?.level).toBe('advise');
+  });
+
+  it('downgrades during sdd+ as well', () => {
+    expect(checkZeroDefect(failing, config, undefined, 'sdd+')?.level).toBe('advise');
+  });
+
+  it('still blocks during verify+ (final verification is where green is mandatory)', () => {
+    expect(checkZeroDefect(failing, config, undefined, 'verify+')?.level).toBe('block');
+  });
+
+  it('still blocks when no phase is set — default behavior unchanged', () => {
+    expect(checkZeroDefect(failing, config, undefined, null)?.level).toBe('block');
+    expect(checkZeroDefect(failing, config)?.level).toBe('block');
+  });
+
+  it('downgrades a regression block to advisory during tdd+ (changed-files path)', () => {
+    const output = 'FAIL tests/router/resolver.test.ts\nTests: 1 failed';
+    // resolver.test.ts is a changed file → normally a blocking regression
+    const result = checkZeroDefect(output, config, ['tests/router/resolver.test.ts'], 'tdd+');
+    expect(result?.level).toBe('advise');
+  });
+});


### PR DESCRIPTION
## What

Closes #28. Block-level zero-defect (`tolerance: strict`) blocked the **RED step** of red-green-refactor: a deliberately-failing test is indistinguishable from a regression to a pattern match, and `checkZeroDefect` had no phase awareness — unlike `checkTestScope`, which is already gated to `tdd+`/`sdd+`. Inline TDD fought the guardrail on every RED run (worked around this whole session by flipping the dogfood `.harness.yaml` to permissive).

## Fix (option a — mirrors test-scope's phase gating)

`checkZeroDefect` takes an optional `currentPhase`. During `tdd+`/`sdd+` a failing run is the expected RED step, so the **effective tolerance is capped at permissive** — failures still surface as an advisory, but the loop is not halted. The block returns in `verify+`, where a green suite is mandatory (`verify+` is not a scoped phase). The PostToolUse handler threads `cache.getCurrentPhase()` in.

Callers that pass no phase keep strict behavior **byte-for-byte**, so every existing test and the default path are unchanged.

`SCOPED_PHASES` mirrors the copies in `test-scope.ts` and `post-tool-use.ts` (noted in a comment); folding them into a single shared home is deferred with the #30 cleanup.

## Tests

- `zero-defect.test.ts`: `tdd+`/`sdd+` downgrade, `verify+`/no-phase still block, regression-path downgrade.
- `post-tool-use.test.ts`: handler threads the cache phase (a `tdd+` RED run is advisory, not a block).
- Full suite + coverage gate green (exit 0); tsc + markdownlint clean.

## Docs

architecture.md zero-defect section + getting-started overview note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)