### PR TITLE
refactor: drop dead EditHistoryEntry.category field

### DIFF
--- a/src/enforcement/post-tool-use.ts
+++ b/src/enforcement/post-tool-use.ts
@@ -130,7 +130,7 @@ function runPostToolChecks(
       const category = tracker.classifyFile(filePath);
       if (category === 'source' || category === 'test') {
         cache.addEditedFile(filePath, category);
-        cache.recordEditTurn(filePath, category, turn);
+        cache.recordEditTurn(filePath, turn);
       }
 
       // Constitutional check on edited test files

--- a/src/session/cache.ts
+++ b/src/session/cache.ts
@@ -118,9 +118,10 @@ export class SessionCache {
     return this.editTurnCounter;
   }
 
-  /** Record a turn-stamped edit for cross-process stale-test detection. */
-  recordEditTurn(file: string, category: 'source' | 'test', turn: number): void {
-    this.editHistory.push({ file, category, turn });
+  /** Record a turn-stamped edit for cross-process stale-test detection. The
+   *  file's category is reclassified on hydration, so it isn't stored here. */
+  recordEditTurn(file: string, turn: number): void {
+    this.editHistory.push({ file, turn });
     this.save();
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -181,10 +181,11 @@ export interface SessionCacheFile {
 }
 
 /** A turn-stamped file edit, persisted for the cross-process stale-test
- * turn model: one PostToolUse Edit/Write invocation = one turn. */
+ * turn model: one PostToolUse Edit/Write invocation = one turn. The tracker
+ * reclassifies each file on hydration (FileTracker.recordEdit), so only the
+ * path and turn are stored — no category. */
 export interface EditHistoryEntry {
   file: string;
-  category: 'source' | 'test';
   turn: number;
 }
 

--- a/tests/session/cache.test.ts
+++ b/tests/session/cache.test.ts
@@ -132,23 +132,23 @@ describe('SessionCache', () => {
     });
 
     it('records turn-stamped edits in history', () => {
-      cache.recordEditTurn('src/router/resolver.ts', 'source', 1);
-      cache.recordEditTurn('tests/router/resolver.test.ts', 'test', 2);
+      cache.recordEditTurn('src/router/resolver.ts', 1);
+      cache.recordEditTurn('tests/router/resolver.test.ts', 2);
       expect(cache.getEditHistory()).toEqual([
-        { file: 'src/router/resolver.ts', category: 'source', turn: 1 },
-        { file: 'tests/router/resolver.test.ts', category: 'test', turn: 2 },
+        { file: 'src/router/resolver.ts', turn: 1 },
+        { file: 'tests/router/resolver.test.ts', turn: 2 },
       ]);
     });
 
     it('clearEditedFiles clears the turn-stamped history too', () => {
-      cache.recordEditTurn('src/a.ts', 'source', 1);
+      cache.recordEditTurn('src/a.ts', 1);
       cache.clearEditedFiles();
       expect(cache.getEditHistory()).toEqual([]);
     });
 
     it('reset clears the counter and history', () => {
       cache.advanceEditTurn();
-      cache.recordEditTurn('src/a.ts', 'source', 1);
+      cache.recordEditTurn('src/a.ts', 1);
       cache.reset();
       expect(cache.getEditTurn()).toBe(0);
       expect(cache.getEditHistory()).toEqual([]);
@@ -247,13 +247,13 @@ describe('SessionCache (file-backed)', () => {
     trackPath(sessionCachePath(testCwd));
     const first = new SessionCache(testCwd);
     const turn = first.advanceEditTurn();
-    first.recordEditTurn('src/feature/widget.ts', 'source', turn);
+    first.recordEditTurn('src/feature/widget.ts', turn);
 
     // A later hook invocation (separate process) loads from disk.
     const second = new SessionCache(testCwd);
     expect(second.getEditTurn()).toBe(1);
     expect(second.getEditHistory()).toEqual([
-      { file: 'src/feature/widget.ts', category: 'source', turn: 1 },
+      { file: 'src/feature/widget.ts', turn: 1 },
     ]);
     expect(second.advanceEditTurn()).toBe(2);
   });


### PR DESCRIPTION
## What

Part of #30 (PR #43 review cleanups), scoped to the one unambiguous win.

`EditHistoryEntry.category` was written to the turn-stamped edit history and serialized to the session cache, but **never read**: the cross-process hydration path reclassifies every file via `FileTracker.recordEdit` → `classifyFile`, so the stored category was dead data. Removed from the type, `recordEditTurn`'s signature, the handler call site, and the cache tests.

Old cache files that still carry `category` load harmlessly — the extra field is ignored and hydration only reads `file`/`turn` — so no migration is needed.

## Verification

Full suite + coverage gate green (exit 0); tsc clean.

## Deliberately not in this PR

After digging into the rest of #30, two items are net-negative / no-ROI churn:

- **options-object refactor** — converting `handlePostToolUse`'s positional args to an object across **53 call sites** (4 files) makes every caller *more verbose* for a marginally cleaner signature; #47's `runPostToolChecks` split already relieved the param smell.
- **pre-tool-use `'type' in result` narrow** — the generated template types `result` as `any` (dynamic import), so the narrow adds no type safety.

**Tracker internalization** (removing the "empty-tracker accommodation" branch — genuine test-induced design damage) has real merit but the same 53-call-site cost; left as an explicit decision rather than bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)