### PR TITLE
fix(enforcement): inspect Write tool content for constitutional checks

### DIFF
--- a/docs/archive/2026-06-17-2026-06-12-eval-harness-design.md
+++ b/docs/archive/2026-06-17-2026-06-12-eval-harness-design.md
@@ -1,5 +1,8 @@
 # Behavioral Eval Harness — Design
 
+> **Status:** Executed — design realized by the shipped eval harness (PR #45); archived 2026-06-17
+
+
 **Date:** 2026-06-12
 **Status:** Approved
 **Task:** #26.

--- a/docs/archive/2026-06-17-2026-06-12-eval-harness.md
+++ b/docs/archive/2026-06-17-2026-06-12-eval-harness.md
@@ -1,5 +1,8 @@
 # Behavioral Eval Harness Implementation Plan
 
+> **Status:** Executed — shipped in PR #45 / commit df0313e; full evals/ tree live; archived 2026-06-17
+
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. **Task 1 is a make-or-break spike with a STOP condition — do not build Tasks 2+ until it passes.**
 
 **Goal:** A local `npm run eval` harness that drives scripted `claude -p` sessions against fixture project briefs and asserts on skill-chain *behavior* the deterministic suite cannot reach (does `brain+` fire the loop opt-in for a fitting project and stay silent for a CLI tool; does an opted-in design contain the required sections), with model-robust invariants so a Fable-vs-Opus diff surfaces behavioral drift. Spec: `docs/superpowers/specs/2026-06-12-eval-harness-design.md`.

--- a/docs/archive/2026-06-17-2026-06-12-teams-aware-sdd-design.md
+++ b/docs/archive/2026-06-17-2026-06-12-teams-aware-sdd-design.md
@@ -1,5 +1,8 @@
 # Teams-Aware sdd+ — Design
 
+> **Status:** Executed — design realized by the shipped teams-aware sdd+; archived 2026-06-17
+
+
 **Date:** 2026-06-12
 **Status:** Approved — plan written
 (`docs/superpowers/plans/2026-06-12-teams-aware-sdd.md`); execution pending

--- a/docs/archive/2026-06-17-2026-06-12-teams-aware-sdd.md
+++ b/docs/archive/2026-06-17-2026-06-12-teams-aware-sdd.md
@@ -1,5 +1,8 @@
 # Teams-Aware sdd+ Implementation Plan
 
+> **Status:** Executed — shipped in 26573ef; types/config/session/skills live; archived 2026-06-17
+
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** When Claude Code's experimental agent-teams feature is enabled, `sdd+` offers to execute independent plan tasks as parallel worktree-isolated implementer teammates with the lead reviewing and merging; everything degrades byte-for-byte to sequential dispatch when absent. Spec: `docs/superpowers/specs/2026-06-12-teams-aware-sdd-design.md`.

--- a/docs/archive/2026-06-17-fix-post-tool-use-write-content-field.md
+++ b/docs/archive/2026-06-17-fix-post-tool-use-write-content-field.md
@@ -1,5 +1,8 @@
 # Plan — Fix PostToolUse Write-content field + refresh stale ai-news harness
 
+> **Status:** Executed — fix shipped in commit 677a63a (args.content ?? new_string in post-tool-use.ts); eval in 291ecef; archived 2026-06-17
+
+
 - **Branch:** `fix/post-tool-use-write-content-field` (claude-rig)
 - **Date:** 2026-06-17
 - **Source:** `/verify-harness` findings (brain+ design, approved: _Full fix + refresh ai-news_; cross-OS: _flag, don't hack_)

--- a/docs/archive/2026-06-17-graphify-design.md
+++ b/docs/archive/2026-06-17-graphify-design.md
@@ -1,5 +1,8 @@
 # Graphify Integration Redesign — Design Context
 
+> **Status:** Executed — investigation/design context consumed by the shipped graphify redesign; archived 2026-06-17
+
+
 ## Investigation Results
 
 ### Graphify CLI Lifecycle (exercised on ~/tools/hermes-agent)

--- a/docs/archive/2026-06-17-graphify-redesign.md
+++ b/docs/archive/2026-06-17-graphify-redesign.md
@@ -1,5 +1,8 @@
 # Plan: Graphify Integration Redesign
 
+> **Status:** Executed — all 10 tasks shipped across commits f6c0a42 to 1f5a57f; live in src/scout/graph-state.ts; archived 2026-06-17
+
+
 ## Constitutional Rules for This Plan
 
 - Use injectable `ExecFn` and `ExistsCheck` for all subprocess/filesystem calls — no hardcoded shell commands in source, no real filesystem in tests

--- a/docs/archive/2026-06-17-macos-jcodemunch-detection.md
+++ b/docs/archive/2026-06-17-macos-jcodemunch-detection.md
@@ -1,5 +1,8 @@
 # Plan: macOS jcodemunch Detection + Advisory Suppression Fixes
 
+> **Status:** Executed — shipped in PR #25 / commit f0d8467; uvx detection + basename + broad-permissions live; archived 2026-06-17
+
+
 **Date:** 2026-05-15
 **Status:** Approved — ready for tdd+
 

--- a/docs/archive/2026-06-17-multi-project-graphify-stats.md
+++ b/docs/archive/2026-06-17-multi-project-graphify-stats.md
@@ -1,5 +1,8 @@
 # Plan: Multi-Project Graphify Stats
 
+> **Status:** Executed — shipped in PR #11 / commit 294e3c1; Record type + accessors live; archived 2026-06-17
+
+
 **Branch:** `fix/multi-project-graphify-stats`
 **Date:** 2026-04-23
 

--- a/docs/archive/2026-06-17-savings-cache-discovery.md
+++ b/docs/archive/2026-06-17-savings-cache-discovery.md
@@ -1,5 +1,8 @@
 # Savings Cache Discovery Fix
 
+> **Status:** Executed — shipped in PR #12 / commits a80e723, 31fdbac; cwd + resolveGraphifyStats live; archived 2026-06-17
+
+
 ## Problem
 
 Two bugs prevent `/savings` from working on multi-project hosts:

--- a/docs/plans/fix-post-tool-use-write-content-field.md
+++ b/docs/plans/fix-post-tool-use-write-content-field.md
@@ -1,112 +1,145 @@
 # Plan — Fix PostToolUse Write-content field + refresh stale ai-news harness
 
-**Branch:** `fix/post-tool-use-write-content-field` (claude-rig)
-**Date:** 2026-06-17
-**Source:** `/verify-harness` findings (brain+ design, approved: *Full fix + refresh ai-news*; cross-OS: *flag, don't hack*)
+- **Branch:** `fix/post-tool-use-write-content-field` (claude-rig)
+- **Date:** 2026-06-17
+- **Source:** `/verify-harness` findings (brain+ design, approved: _Full fix + refresh ai-news_; cross-OS: _flag, don't hack_)
 
 ## Context
 
-`/verify-harness` on the ai-news project reported 4 harness bugs. Investigation of claude-rig
-**source** shows 3 are already fixed upstream; ai-news is broken because its **`dist/` is stale**
-(built 2026-05-18; source through today — `grep -c 'result.level' dist/*` = 0) and its **per-project
-wrappers were generated 2026-04-21** (old string-sniffing format). Both must refresh together or the
-new `{level}`-returning dist silently mismatches the old wrapper's `typeof result === 'string'` check.
+`/verify-harness` on the ai-news project reported 4 harness bugs. Investigation
+of claude-rig **source** shows 3 are already fixed upstream; ai-news is broken
+because its **`dist/` is stale** (built 2026-05-18; source through today —
+`grep -c 'result.level' dist/*` = 0) and its **per-project wrappers were
+generated 2026-04-21** (old string-sniffing format). Both must refresh together
+or the new `{level}`-returning dist silently mismatches the old wrapper's
+`typeof result === 'string'` check.
 
 | # | Bug | Source status |
-|---|-----|---------------|
-| 1 | Advise not surfaced to agent | ✅ FIXED `2f247f8` (template → `additionalContext` JSON stdout) |
-| 2 | Zero-defect dead (no tool_response/execFn) | ✅ FIXED `dcbb591` (7th `toolResponse` param + `execFn`) |
-| 3 | Write `content` ignored by constitutional check | ❌ **NOT FIXED** — `src/enforcement/post-tool-use.ts:137` |
-| 4 | `sed_i` block short-circuited by rtk rewrite | ✅ FIXED (hook.ts Step 1 runs file_modify block before Step 3) |
+| --- | --- | --- |
+| 1 | Advise not surfaced to agent | FIXED `2f247f8` (template emits `additionalContext` JSON to stdout) |
+| 2 | Zero-defect dead (no tool_response/execFn) | FIXED `dcbb591` (7th `toolResponse` param + `execFn`) |
+| 3 | Write `content` ignored by constitutional check | NOT FIXED — `src/enforcement/post-tool-use.ts:137` |
+| 4 | `sed_i` block short-circuited by rtk rewrite | FIXED (hook.ts Step 1 runs file_modify block before Step 3) |
 
 **Only real source change = #3.** Everything else is rebuild + regenerate + verify.
 
 ## Constitutional Rules for This Plan
 
-Working in `claude-rig` (a TypeScript tool — no Gmail/Claude/Telegram APIs). Applies claude-rig's
-own conventions, not ai-news's protected-component rules:
-- **Injectable `ExecFn`** for environment detection — never mock env detection (claude-rig CLAUDE.md).
-- **Structural severity** — `EnforcementViolation { level, message }`; level is derived by checks,
-  never sniffed from message text.
+Working in `claude-rig` (a TypeScript tool — no Gmail/Claude/Telegram APIs). Applies claude-rig's own conventions, not ai-news's protected-component rules:
+
+- **Injectable `ExecFn`** for environment detection — never mock env detection.
+- **Structural severity** — `EnforcementViolation { level, message }`; level is derived by checks, never sniffed from message text.
 - **Coverage gate**: 80% stmt/func/line, 75% branch (vitest.config.ts).
-- Cross-OS (user directive): keep changes OS-agnostic; **flag** pre-existing macOS-only failures,
-  fix only what this change broke.
+- Cross-OS (user directive): keep changes OS-agnostic; **flag** pre-existing macOS-only failures, fix only what this change broke.
 
 ## Mock Policy
 
-- **Unit tests (mocks OK):** all. Fix #3's test calls `handlePostToolUse` directly with hand-built
-  args — **no mocks needed** (pure function), which is ideal.
+- **Unit tests (mocks OK):** all. Fix #3's test calls `handlePostToolUse` directly with hand-built args — **no mocks needed** (pure function), which is ideal.
 - **No protected components** in scope (no live APIs touched).
 
 ## Tasks
 
 ### Task 0: Create branch
-**Files:** none (git only)
-**Note:** master has uncommitted `package.json`/`package-lock.json` (headroom-ai integration). Carry
-them onto the branch but **do not stage/commit them** with the fix — `git add` only specific files.
+
+**Files:** none (git only).
+
+**Note:** master has uncommitted `package.json`/`package-lock.json` (headroom-ai integration). Carry them onto the branch but **do not stage/commit them** with the fix — `git add` only specific files.
+
 - [ ] `git checkout -b fix/post-tool-use-write-content-field` (from claude-rig master)
 
 ### Task 1: RED — failing unit test for Write-content constitutional check
-**Files:** `tests/enforcement/post-tool-use.test.ts`
-**Test strategy:** new `it(...)` under the existing constitutional `describe`. Mirror the Edit+
-`new_string` test at `:165-177` but use **Write + `content`** on a stack-test path with a mock.
+
+**Files:** `tests/enforcement/post-tool-use.test.ts`.
+
+**Test strategy:** new `it(...)` under the existing constitutional `describe`. Mirror the Edit + `new_string` test at `:165-177` but use **Write + `content`** on a stack-test path with a mock.
+
 **Mock check:** none — pure function call with `new SessionCache()` + `structuredClone(DEFAULT_CONFIG)`.
-**Evidence:** `npm test -- tests/enforcement/post-tool-use.test.ts` → new test FAILS (content ignored
-→ no violation; `result` is null or lacks `no_mocks`).
-- [ ] Add test: `handlePostToolUse('Write', { file_path: 'tests/stack/foo.stack.test.ts', content: "jest.mock('../x.js');" }, tracker, cache, config)` → expect `result?.message` to contain `no_mocks`
-- [ ] Run scoped; confirm RED (AssertionError: expected null / no `no_mocks`)
-- [ ] Commit (RED)
+
+**Evidence:** scoped run fails (content ignored → no violation; `result` null or lacks `no_mocks`).
+
+- [ ] Add test calling `handlePostToolUse('Write', { file_path: 'tests/router/resolver.stack.test.ts', content: "jest.mock('../x.js');" }, ...)` expecting `no_mocks`.
+- [ ] Run scoped; confirm RED.
+- [ ] Commit (RED).
 
 ### Task 2: GREEN — fix content extraction
-**Files:** `src/enforcement/post-tool-use.ts` (line ~137)
-**Test strategy:** the Task 1 test now passes; existing Edit+`new_string` tests stay green (regression).
+
+**Files:** `src/enforcement/post-tool-use.ts` (line ~137).
+
+**Test strategy:** Task 1 test passes; existing Edit + `new_string` tests stay green (regression).
+
 **Mock check:** none.
-**Evidence:** scoped test PASSES; `npm test` full suite green (modulo pre-existing macOS flags).
-- [ ] Change `const content = (args.new_string as string) ?? '';` → `const content = (args.content as string) ?? (args.new_string as string) ?? '';`
-- [ ] Run scoped; confirm GREEN
-- [ ] Commit (GREEN)
+
+**Evidence:** scoped test passes; full suite green (modulo pre-existing macOS flags).
+
+- [ ] Change `(args.new_string as string) ?? ''` to `(args.content as string) ?? (args.new_string as string) ?? ''`.
+- [ ] Run scoped; confirm GREEN.
+- [ ] Commit (GREEN).
 
 ### Task 3: Rebuild dist + verify freshness
-**Files:** `dist/*` (gitignored — not committed)
-**Evidence:** `npm run build` exits 0; `grep -c 'result.level' dist/router/hook.js dist/enforcement/post-tool-use.js` > 0 for both.
-- [ ] `npm run build`
-- [ ] `grep -c 'result.level' dist/router/hook.js dist/enforcement/post-tool-use.js` → both ≥ 1
+
+**Files:** `dist/*` (gitignored — not committed).
+
+**Evidence:** `npm run build` exits 0; `grep -c 'result.level'` not meaningful on handlers — instead confirm `extractBashOutput` + `toolResponse` + object `level:` returns present in dist.
+
+- [ ] `npm run build`.
+- [ ] Verify new-source signatures land in dist.
 
 ### Task 4: Full vitest on Linux (cross-OS: flag, don't hack)
-**Evidence:** new test passes; no NEW failures introduced. Any pre-existing macOS-only failure logged
-as a separate finding (not patched).
-- [ ] `npm test` (full suite, with coverage)
-- [ ] If failures: classify mine vs pre-existing; flag pre-existing; do not OS-hack
+
+**Evidence:** new test passes; no NEW failures introduced. Pre-existing macOS-only failures logged as separate findings (not patched).
+
+- [ ] `npm test` (full suite, with coverage).
+- [ ] Classify failures mine vs pre-existing; flag pre-existing; do not OS-hack.
 
 ### Task 5: Eval coverage (deterministic)
-**Files:** `tests/eval/enforcement-eval.test.ts` (add scenario if gap)
-**Test strategy:** deterministic eval (no live `claude -p`) for the Write-content→constitutional path,
-or confirm existing evals already cover it.
+
+**Files:** `tests/eval/enforcement-eval.test.ts` (add scenario if gap).
+
+**Test strategy:** deterministic eval (no live `claude -p`) for the Write-content → constitutional path.
+
 **Mock check:** none.
-- [ ] Inspect `tests/eval/enforcement-eval.test.ts`; if no Write-content scenario, add one mirroring Task 1
-- [ ] `npm test -- tests/eval/` green
-- [ ] Commit
+
+- [ ] Add Write + content scenario mirroring Task 1 if none exists.
+- [ ] `npm test -- tests/eval/` green.
+- [ ] Commit.
 
 ### Task 6: Refresh ai-news installed wrappers
-**Files (target repo):** `ai-news/.claude/hooks/scripts/{pre,post}-tool-use.ts` (+ maybe `session-start.ts`, settings.json hooks)
-**Mechanism:** `node dist/cli/index.js init --dir /home/jerome/projects/ai-news` (NO `--force`).
-`copyGeneratedTemplate` always overwrites hooks; skills/agents/config respect `--force` (default false) → untouched.
-**Verify before:** confirm `init.ts:190-198` overwrites only generated hooks; `git -C ai-news status`
-shows ONLY hook files changed (no skill/config clobber).
-**Evidence:** `git -C ai-news status --short` lists only `.claude/hooks/scripts/*` (and settings.json hook lines).
-- [ ] Verify ai-news is on a branch or branch it (`fix/refresh-rig-hooks`) — wrappers are committed
-- [ ] Run `rig init --dir ai-news`; confirm surgical diff
-- [ ] Diff a regenerated wrapper: header `Generated:` = today; body has `result.level` / `additionalContext` / `input.tool_response`
+
+**Files (target repo):** `ai-news/.claude/hooks/scripts/{pre,post}-tool-use.ts` (+ settings.json hook lines).
+
+**Mechanism:** `node dist/cli/index.js init --dir <ai-news>` (no `--force`). `copyGeneratedTemplate` always overwrites hooks; skills/agents/config respect `--force` (default false) → untouched.
+
+**Evidence:** `git -C ai-news status` shows only hook files changed (no skill/config clobber).
+
+- [ ] Branch ai-news (`fix/refresh-rig-hooks`).
+- [ ] Run `rig init --dir ai-news`; confirm surgical diff.
+- [ ] Diff a regenerated wrapper: header `Generated:` today; body has `result.level` / `additionalContext` / `input.tool_response`.
 
 ### Task 7: Verify ai-news harness end-to-end
-**Evidence:** direct hook invocation (from `/verify-harness` method) now matches source contract.
-- [ ] Feed `sed -i 's/a/b/g' src/foo.py` to `ai-news/.claude/hooks/scripts/pre-tool-use.ts` → `[BLOCK]` exit 2
-- [ ] Feed `grep -rn x src/` → `additionalContext` JSON (advise) on stdout exit 0
-- [ ] Feed a Bash test run with failing `tool_response` to `post-tool-use.ts` → zero-defect violation
+
+**Evidence:** direct hook invocation matches source contract.
+
+- [ ] `sed -i 's/a/b/g' src/foo.py` → pre-tool-use → `[BLOCK]` exit 2.
+- [ ] `grep -rn x src/` → `additionalContext` JSON (advise) stdout exit 0.
+- [ ] Failing test `tool_response` → post-tool-use → zero-defect violation.
 
 ## Validation Checklist
-- [x] Every task has a test strategy (Tasks 1/2/5) or evidence criteria (3/4/6/7)
-- [x] No task mocks a protected component (no protected components in scope)
-- [x] Plan references exact file paths (no TBDs)
-- [x] Evidence criteria defined per task
-- [x] Constitutional + mock-policy sections present
+
+- [x] Every task has a test strategy (Tasks 1/2/5) or evidence criteria (3/4/6/7).
+- [x] No task mocks a protected component (none in scope).
+- [x] Plan references exact file paths (no TBDs).
+- [x] Evidence criteria defined per task.
+- [x] Constitutional + mock-policy sections present.
+
+## Known Issues (flagged, NOT fixed — per "flag, don't hack")
+
+- `tests/integration/session-start.test.ts > creates session cache file in /tmp`
+  times out (5000ms) on this Linux host. Pre-existing and unrelated to this
+  change: `git diff master..HEAD` touches only `post-tool-use.ts` (+ test + plan);
+  session-start code/test are byte-identical to master. Root cause: when
+  jcodemunch is installed on the host (it is here — 77 indexed repos), the
+  SessionStart hook auto-indexes the E2E tempDir (per the test's own `afterAll`
+  comment), and that real `index_folder` exceeds vitest's 5000ms default.
+  Likely green on the macOS dev machine where the timeout was tuned. Suggested
+  fix for a separate PR: raise the test timeout or stub auto-index in the
+  fixture. Full-suite result on Linux: 1326 passed, 1 failed (this).

--- a/docs/plans/fix-post-tool-use-write-content-field.md
+++ b/docs/plans/fix-post-tool-use-write-content-field.md
@@ -1,0 +1,112 @@
+# Plan — Fix PostToolUse Write-content field + refresh stale ai-news harness
+
+**Branch:** `fix/post-tool-use-write-content-field` (claude-rig)
+**Date:** 2026-06-17
+**Source:** `/verify-harness` findings (brain+ design, approved: *Full fix + refresh ai-news*; cross-OS: *flag, don't hack*)
+
+## Context
+
+`/verify-harness` on the ai-news project reported 4 harness bugs. Investigation of claude-rig
+**source** shows 3 are already fixed upstream; ai-news is broken because its **`dist/` is stale**
+(built 2026-05-18; source through today — `grep -c 'result.level' dist/*` = 0) and its **per-project
+wrappers were generated 2026-04-21** (old string-sniffing format). Both must refresh together or the
+new `{level}`-returning dist silently mismatches the old wrapper's `typeof result === 'string'` check.
+
+| # | Bug | Source status |
+|---|-----|---------------|
+| 1 | Advise not surfaced to agent | ✅ FIXED `2f247f8` (template → `additionalContext` JSON stdout) |
+| 2 | Zero-defect dead (no tool_response/execFn) | ✅ FIXED `dcbb591` (7th `toolResponse` param + `execFn`) |
+| 3 | Write `content` ignored by constitutional check | ❌ **NOT FIXED** — `src/enforcement/post-tool-use.ts:137` |
+| 4 | `sed_i` block short-circuited by rtk rewrite | ✅ FIXED (hook.ts Step 1 runs file_modify block before Step 3) |
+
+**Only real source change = #3.** Everything else is rebuild + regenerate + verify.
+
+## Constitutional Rules for This Plan
+
+Working in `claude-rig` (a TypeScript tool — no Gmail/Claude/Telegram APIs). Applies claude-rig's
+own conventions, not ai-news's protected-component rules:
+- **Injectable `ExecFn`** for environment detection — never mock env detection (claude-rig CLAUDE.md).
+- **Structural severity** — `EnforcementViolation { level, message }`; level is derived by checks,
+  never sniffed from message text.
+- **Coverage gate**: 80% stmt/func/line, 75% branch (vitest.config.ts).
+- Cross-OS (user directive): keep changes OS-agnostic; **flag** pre-existing macOS-only failures,
+  fix only what this change broke.
+
+## Mock Policy
+
+- **Unit tests (mocks OK):** all. Fix #3's test calls `handlePostToolUse` directly with hand-built
+  args — **no mocks needed** (pure function), which is ideal.
+- **No protected components** in scope (no live APIs touched).
+
+## Tasks
+
+### Task 0: Create branch
+**Files:** none (git only)
+**Note:** master has uncommitted `package.json`/`package-lock.json` (headroom-ai integration). Carry
+them onto the branch but **do not stage/commit them** with the fix — `git add` only specific files.
+- [ ] `git checkout -b fix/post-tool-use-write-content-field` (from claude-rig master)
+
+### Task 1: RED — failing unit test for Write-content constitutional check
+**Files:** `tests/enforcement/post-tool-use.test.ts`
+**Test strategy:** new `it(...)` under the existing constitutional `describe`. Mirror the Edit+
+`new_string` test at `:165-177` but use **Write + `content`** on a stack-test path with a mock.
+**Mock check:** none — pure function call with `new SessionCache()` + `structuredClone(DEFAULT_CONFIG)`.
+**Evidence:** `npm test -- tests/enforcement/post-tool-use.test.ts` → new test FAILS (content ignored
+→ no violation; `result` is null or lacks `no_mocks`).
+- [ ] Add test: `handlePostToolUse('Write', { file_path: 'tests/stack/foo.stack.test.ts', content: "jest.mock('../x.js');" }, tracker, cache, config)` → expect `result?.message` to contain `no_mocks`
+- [ ] Run scoped; confirm RED (AssertionError: expected null / no `no_mocks`)
+- [ ] Commit (RED)
+
+### Task 2: GREEN — fix content extraction
+**Files:** `src/enforcement/post-tool-use.ts` (line ~137)
+**Test strategy:** the Task 1 test now passes; existing Edit+`new_string` tests stay green (regression).
+**Mock check:** none.
+**Evidence:** scoped test PASSES; `npm test` full suite green (modulo pre-existing macOS flags).
+- [ ] Change `const content = (args.new_string as string) ?? '';` → `const content = (args.content as string) ?? (args.new_string as string) ?? '';`
+- [ ] Run scoped; confirm GREEN
+- [ ] Commit (GREEN)
+
+### Task 3: Rebuild dist + verify freshness
+**Files:** `dist/*` (gitignored — not committed)
+**Evidence:** `npm run build` exits 0; `grep -c 'result.level' dist/router/hook.js dist/enforcement/post-tool-use.js` > 0 for both.
+- [ ] `npm run build`
+- [ ] `grep -c 'result.level' dist/router/hook.js dist/enforcement/post-tool-use.js` → both ≥ 1
+
+### Task 4: Full vitest on Linux (cross-OS: flag, don't hack)
+**Evidence:** new test passes; no NEW failures introduced. Any pre-existing macOS-only failure logged
+as a separate finding (not patched).
+- [ ] `npm test` (full suite, with coverage)
+- [ ] If failures: classify mine vs pre-existing; flag pre-existing; do not OS-hack
+
+### Task 5: Eval coverage (deterministic)
+**Files:** `tests/eval/enforcement-eval.test.ts` (add scenario if gap)
+**Test strategy:** deterministic eval (no live `claude -p`) for the Write-content→constitutional path,
+or confirm existing evals already cover it.
+**Mock check:** none.
+- [ ] Inspect `tests/eval/enforcement-eval.test.ts`; if no Write-content scenario, add one mirroring Task 1
+- [ ] `npm test -- tests/eval/` green
+- [ ] Commit
+
+### Task 6: Refresh ai-news installed wrappers
+**Files (target repo):** `ai-news/.claude/hooks/scripts/{pre,post}-tool-use.ts` (+ maybe `session-start.ts`, settings.json hooks)
+**Mechanism:** `node dist/cli/index.js init --dir /home/jerome/projects/ai-news` (NO `--force`).
+`copyGeneratedTemplate` always overwrites hooks; skills/agents/config respect `--force` (default false) → untouched.
+**Verify before:** confirm `init.ts:190-198` overwrites only generated hooks; `git -C ai-news status`
+shows ONLY hook files changed (no skill/config clobber).
+**Evidence:** `git -C ai-news status --short` lists only `.claude/hooks/scripts/*` (and settings.json hook lines).
+- [ ] Verify ai-news is on a branch or branch it (`fix/refresh-rig-hooks`) — wrappers are committed
+- [ ] Run `rig init --dir ai-news`; confirm surgical diff
+- [ ] Diff a regenerated wrapper: header `Generated:` = today; body has `result.level` / `additionalContext` / `input.tool_response`
+
+### Task 7: Verify ai-news harness end-to-end
+**Evidence:** direct hook invocation (from `/verify-harness` method) now matches source contract.
+- [ ] Feed `sed -i 's/a/b/g' src/foo.py` to `ai-news/.claude/hooks/scripts/pre-tool-use.ts` → `[BLOCK]` exit 2
+- [ ] Feed `grep -rn x src/` → `additionalContext` JSON (advise) on stdout exit 0
+- [ ] Feed a Bash test run with failing `tool_response` to `post-tool-use.ts` → zero-defect violation
+
+## Validation Checklist
+- [x] Every task has a test strategy (Tasks 1/2/5) or evidence criteria (3/4/6/7)
+- [x] No task mocks a protected component (no protected components in scope)
+- [x] Plan references exact file paths (no TBDs)
+- [x] Evidence criteria defined per task
+- [x] Constitutional + mock-policy sections present

--- a/src/enforcement/post-tool-use.ts
+++ b/src/enforcement/post-tool-use.ts
@@ -133,8 +133,10 @@ function runPostToolChecks(
         cache.recordEditTurn(filePath, turn);
       }
 
-      // Constitutional check on edited test files
-      const content = (args.new_string as string) ?? '';
+      // Constitutional check on edited test files. Edit delivers the inserted
+      // text in `new_string`; Write delivers the full file body in `content`.
+      // Read both or Write-created files skip the check entirely.
+      const content = (args.content as string) ?? (args.new_string as string) ?? '';
       const constitutional = checkConstitutional(filePath, content, config);
       if (constitutional) violations.push(constitutional);
     }

--- a/tests/enforcement/post-tool-use.test.ts
+++ b/tests/enforcement/post-tool-use.test.ts
@@ -177,6 +177,24 @@ describe('handlePostToolUse', () => {
     expect(result?.message).toContain('no_mocks');
   });
 
+  it('checks constitutional on stack test files written via Write (content, not new_string)', () => {
+    // The Write tool delivers file content in `content`, not `new_string`.
+    // Constitutional inspection must read `content` or the check is dormant for
+    // every file created via Write.
+    const result = handlePostToolUse(
+      'Write',
+      {
+        file_path: 'tests/router/resolver.stack.test.ts',
+        content: "jest.mock('../src/router/resolver.js');",
+      },
+      tracker,
+      cache,
+      config,
+    );
+    expect(result).not.toBeNull();
+    expect(result?.message).toContain('no_mocks');
+  });
+
   it('combines multiple violations into single output', () => {
     // Edit a stack test file with a mock
     const result = handlePostToolUse(

--- a/tests/eval/enforcement-eval.test.ts
+++ b/tests/eval/enforcement-eval.test.ts
@@ -69,6 +69,27 @@ const ENFORCEMENT_SCENARIOS: EnforcementScenario[] = [
     expectedViolation: false,
   },
   {
+    id: 'enforce_mock_in_stack_test_via_write',
+    description: 'vi.mock in stack test file created via Write (content) → constitutional violation',
+    tool: 'Write',
+    args: {
+      file_path: '/project/tests/stack/database.stack.test.ts',
+      content: 'vi.mock("../src/database", () => ({ db: {} }))',
+    },
+    expectedViolation: true,
+    expectedMatch: 'mock',
+  },
+  {
+    id: 'enforce_mock_in_unit_test_via_write',
+    description: 'vi.mock in unit test file created via Write (content) → no constitutional violation',
+    tool: 'Write',
+    args: {
+      file_path: '/project/tests/unit/calculator.test.ts',
+      content: 'vi.mock("../src/external-api", () => ({ fetch: vi.fn() }))',
+    },
+    expectedViolation: false,
+  },
+  {
     id: 'enforce_test_failure',
     description: 'test command with failure output → zero-defect violation',
     tool: 'Bash',


### PR DESCRIPTION
## Summary

`handlePostToolUse` read only `args.new_string` for the edited file body, so files created via the **Write** tool — which delivers content in `args.content` — silently skipped the constitutional checks (`no_mocks`, `evidence_only`). This reads `args.content ?? args.new_string`.

## Why
Found while diagnosing a stale-harness install in another project: every existing constitutional test (unit + eval) used `Edit` + `new_string`; the `Write` + `content` path was untested and broken.

## Changes
- `src/enforcement/post-tool-use.ts`: `const content = (args.content as string) ?? (args.new_string as string) ?? '';`
- `tests/enforcement/post-tool-use.test.ts`: regression test — Write to a stack-test path with a mock now fires `no_mocks` (fails `expected null not to be null` before the fix).
- `tests/eval/enforcement-eval.test.ts`: Write+content eval scenarios (stack→violate, unit→don't), mirroring the existing Edit pair (would have scored 0.0 pre-fix).

## Verification
- Scoped unit: 51/51 pass. Eval: 10/10 pass, overall-score gate holds.
- Full `vitest` suite on Linux: **1326 passed, 1 failed** — the failure is pre-existing and unrelated (`tests/integration/session-start.test.ts` E2E times out at 5000ms because the SessionStart hook auto-indexes the tempDir via jcodemunch on hosts where jcodemunch is installed; session-start code is byte-identical to `master`). Flagged, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
