### PR TITLE
fix(verify-harness): S3/S4 check the real jcodemunch binary name

### DIFF
--- a/templates/skills/verify-harness/SKILL.md
+++ b/templates/skills/verify-harness/SKILL.md
@@ -18,8 +18,8 @@ Run each check and report PASS/FAIL with evidence.
 
 - [ ] **S1**: Session started without hook errors
 - [ ] **S2**: Run `which rtk` — report if available
-- [ ] **S3**: Run `which jcodemunch` — report if available
-- [ ] **S4**: Check if CWD is indexed: run `jcodemunch list_repos` if available
+- [ ] **S3**: Run `which jcodemunch-mcp` (or `which uvx`) — report if available
+- [ ] **S4**: Check if CWD is indexed: run `jcodemunch-mcp list-repos` if available
 - [ ] **S5**: Check `.harness.yaml` exists and parses
 
 ### Tool Router (PreToolUse Hook)


### PR DESCRIPTION
## Summary

Fixes two false-negative checks in the `verify-harness` skill template that probed the wrong binary name.

## Why

`jcodemunch-mcp` ships **no `jcodemunch` binary** — its console script is `jcodemunch-mcp`, invoked via `uvx jcodemunch-mcp` when not pipx/uv-tool installed (the macOS-vs-Linux install variance). claude-rig's detection (`environment.ts`) already handles all three forms — `jcodemunch` CLI → `jcodemunch-mcp` console script → `uvx` fallback (the macOS case was fixed in `f0d8467`). But the verify-harness skill's checks never got the memo:

- **S3** `which jcodemunch` → always fails (no such binary) on every `uvx`/`jcodemunch-mcp` install.
- **S4** `jcodemunch list_repos` → wrong binary name, and the CLI subcommand is `list-repos` (hyphen), not `list_repos`.

## Changes (`templates/skills/verify-harness/SKILL.md`)

- S3: `which jcodemunch` → `which jcodemunch-mcp` (or `which uvx`).
- S4: `jcodemunch list_repos` → `jcodemunch-mcp list-repos`.

## Verification

- `which jcodemunch-mcp` → `/home/jerome/.local/bin/jcodemunch-mcp` (this Linux box); `which uvx` also present.
- `jcodemunch-mcp list-repos` → exit 0, lists repos.
- markdownlint on the template: 0 errors.
- No test asserts the old S3/S4 text (the `which jcodemunch` hits in tests are exec mocks for `environment.ts` detection, not skill-content asserts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
