### PR TITLE
chore: bump version to 0.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rig",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Agent harness that enforces tool routing, skill chains, and multi-agent discipline in Claude Code",
   "type": "module",
   "main": "dist/cli/index.js",


### PR DESCRIPTION
Release bump for the rtk-rewrite fix in #55 (updatedInput + permissionDecision: "allow").