### PR TITLE
fix(release): anchor release-please to v* tags, not rig-v*

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "include-component-in-tag": false,
   "packages": {
     ".": {
       "release-type": "node",


### PR DESCRIPTION
## Problem

The first run of the new release workflow (added in #57) opened a release PR (#58) proposing **0.8.0** with the *entire project history* as release notes.

Root cause: release-please manifest mode defaults to `include-component-in-tag: true`, so it expected a component-prefixed tag `rig-v0.7.1`. Our tags are plain `v0.7.1`, so it couldn't anchor to the last release, walked all history, and re-counted already-shipped `feat:` commits → bogus minor bump.

## Fix

Set `include-component-in-tag: false` so release-please matches the existing `v*` tag scheme, anchors at `v0.7.1`, and only counts commits since the last real release.

After this merges, release-please re-evaluates: with only `ci:`/`fix:` commits since `v0.7.1`, it should retract #58 (no release warranted yet, or a `0.7.2` patch from this fix commit).

#58 will not be merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)