### PR TITLE
fix(init): stop writing stale Write(**/...) deny entries; migrate existing installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,15 @@ across machines.
 ### Permissions
 
 By default `rig init` only adds the secret-file **deny** list (`**/secrets/**`,
-`**/credentials/**`, `**/*.pem`, `**/*.key` for Read, Edit, Write). No allow entries
-are written — you control your own approval level.
+`**/credentials/**`, `**/*.pem`, `**/*.key` for Read and Edit — Claude Code
+treats `Edit(path)` as the umbrella rule covering all file-editing tools,
+including Write, so no separate `Write(path)` entry is needed). No allow
+entries are written — you control your own approval level.
+
+Versions before 0.7.2 also wrote redundant `Write(**/...)` deny entries, which
+Claude Code now flags at startup ("is not matched by file permission checks —
+only Edit(path) rules are"). Re-running `rig init` (no `--force` required)
+strips those stale entries from an existing `.claude/settings.json`.
 
 Use `--broad-permissions` to pre-authorize common tools and reduce repeated prompts:
 

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -240,6 +240,14 @@ const SECRET_DENY_LIST = [
   'Edit(**/credentials/**)',
   'Edit(**/*.pem)',
   'Edit(**/*.key)',
+];
+
+// Written by rig <=0.7.x. Claude Code's permission engine now treats Edit(path)
+// as the umbrella rule covering all file-editing tools (Edit, Write,
+// NotebookEdit), so a separate Write(path) deny rule is a redundant no-op that
+// prints a startup warning. Stripped from existing settings.json on every
+// rig init run so already-installed projects self-heal without manual edits.
+const STALE_DENY_ENTRIES = [
   'Write(**/secrets/**)',
   'Write(**/credentials/**)',
   'Write(**/*.pem)',
@@ -358,6 +366,9 @@ function updateSettingsJson(claudeDir: string, npxCommand: string, rtkAvailable:
       permissions.deny.push(entry);
     }
   }
+
+  // Migration: drop stale Write(**/...) deny entries from prior rig installs.
+  permissions.deny = permissions.deny.filter((entry) => !STALE_DENY_ENTRIES.includes(entry));
 
   writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
 }

--- a/tests/cli/init.test.ts
+++ b/tests/cli/init.test.ts
@@ -666,10 +666,51 @@ console.log('stale old hook');
       expect(deny).toContain('Edit(**/credentials/**)');
       expect(deny).toContain('Edit(**/*.pem)');
       expect(deny).toContain('Edit(**/*.key)');
-      expect(deny).toContain('Write(**/secrets/**)');
-      expect(deny).toContain('Write(**/credentials/**)');
-      expect(deny).toContain('Write(**/*.pem)');
-      expect(deny).toContain('Write(**/*.key)');
+    });
+
+    it('default init does not add Write(**/...) deny entries (Edit rules cover all file-editing tools)', async () => {
+      const claudeDir = join(tempDir, '.claude');
+      mkdirSync(claudeDir, { recursive: true });
+      writeFileSync(join(claudeDir, 'settings.json'), JSON.stringify({}));
+      await initCommand(tempDir, { force: false, exec: noTools });
+
+      const settings = JSON.parse(readFileSync(join(claudeDir, 'settings.json'), 'utf-8'));
+      const deny = settings.permissions.deny;
+      expect(deny).not.toContain('Write(**/secrets/**)');
+      expect(deny).not.toContain('Write(**/credentials/**)');
+      expect(deny).not.toContain('Write(**/*.pem)');
+      expect(deny).not.toContain('Write(**/*.key)');
+    });
+
+    it('re-init migrates away stale Write(**/...) deny entries from prior rig installs', async () => {
+      const claudeDir = join(tempDir, '.claude');
+      mkdirSync(claudeDir, { recursive: true });
+      writeFileSync(join(claudeDir, 'settings.json'), JSON.stringify({
+        permissions: {
+          allow: [],
+          deny: [
+            'Read(**/secrets/**)',
+            'Edit(**/secrets/**)',
+            'Write(**/secrets/**)',
+            'Write(**/credentials/**)',
+            'Write(**/*.pem)',
+            'Write(**/*.key)',
+            'Bash(rm *)', // unrelated user deny entry — must survive
+          ],
+        },
+      }));
+      await initCommand(tempDir, { force: false, exec: noTools });
+
+      const settings = JSON.parse(readFileSync(join(claudeDir, 'settings.json'), 'utf-8'));
+      const deny = settings.permissions.deny;
+      expect(deny).not.toContain('Write(**/secrets/**)');
+      expect(deny).not.toContain('Write(**/credentials/**)');
+      expect(deny).not.toContain('Write(**/*.pem)');
+      expect(deny).not.toContain('Write(**/*.key)');
+      // Untouched entries survive the migration
+      expect(deny).toContain('Read(**/secrets/**)');
+      expect(deny).toContain('Edit(**/secrets/**)');
+      expect(deny).toContain('Bash(rm *)');
     });
 
     // ── --broad-permissions flag ──


### PR DESCRIPTION
## Summary
- `rig init` writes a secret-file deny list (`Read`/`Edit`/`Write` for `**/secrets/**`, `**/credentials/**`, `**/*.pem`, `**/*.key`) into every project's `.claude/settings.json`.
- Claude Code's permission engine now treats `Edit(path)` as the umbrella rule covering all file-editing tools (Edit, Write, NotebookEdit), so the `Write(**/...)` entries are redundant no-ops. Claude Code prints a startup warning for each one: *"is not matched by file permission checks — only Edit(path) rules are"*.
- This warning was showing up on every session start in every project rig has been initialized in (confirmed in this repo and a downstream project), since `rig init` never removed stale entries — only added missing ones.
- `SECRET_DENY_LIST` no longer includes the `Write(**/...)` entries.
- `updateSettingsJson` now strips the four legacy `Write(**/...)` entries from an existing `settings.json` on every `rig init` run (**no `--force` required**), so already-initialized projects self-heal on next `rig init` rather than needing manual settings edits.
- README clarified: the deny list covers Read/Edit (Edit covers Write per Claude Code's model), plus a note that re-running `rig init` migrates old installs.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm test` — 1332/1332 passing, including two new/updated tests:
  - `default init does not add Write(**/...) deny entries (Edit rules cover all file-editing tools)`
  - `re-init migrates away stale Write(**/...) deny entries from prior rig installs` (also asserts unrelated user deny entries like `Bash(rm *)` survive the migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)