### PR TITLE
fix: bring rig current with rtk/jcodemunch/graphify/headroom (Release 1 — stabilize)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 ![Docs Quality](https://github.com/franklywatson/claude-rig/actions/workflows/docs.yml/badge.svg)
 
 A cockpit for your [Claude Code](https://claude.ai/code) tooling stack.
-[rtk](https://github.com/franklywatson/rtk),
-[jcodemunch](https://github.com/franklywatson/jcodemunch),
+[rtk](https://github.com/rtk-ai/rtk),
+[jcodemunch](https://github.com/jgravelle/jcodemunch-mcp),
 [graphify](https://github.com/safishamsi/graphify),
 [Headroom](https://github.com/chopratejas/headroom), and
 [superpowers](https://github.com/obra/superpowers) are each excellent
@@ -43,7 +43,7 @@ Rig installs the cockpit into a Claude Code project:
 - **Tool Router** -- intercepts shell commands via PreToolUse hooks, transparently rewrites
   `grep`/`find`/`cat`/`git` to rtk when available (via `updatedInput` paired with `permissionDecision: "allow"`,
   default permission mode only — `bypassPermissions` ignores the rewrite);
-  advises on native Read/Grep/Glob when jcodemunch is indexed; blocks `sed -i` and `rtk cat` on code files
+  advises on native Read/Grep/Glob when jcodemunch is indexed; blocks `sed -i` and rtk code-reading (`rtk read`/`rtk smart`) on code files
 - **Enforcement Pipeline** -- PostToolUse hooks check stale tests, constitutional rules (real dependencies in stack/E2E tests),
   and zero-defect status (with pre-existing failure classification); a PreToolUse test-scope check redirects full-suite runs
   to scoped tests during `tdd+`/`sdd+`, and configurable branch/PR discipline with worktree-aware isolation advice guards
@@ -78,8 +78,8 @@ structural instead of persuasive, and projects that fit can graduate from
 - [Claude Code](https://claude.ai/code) CLI
 - Node.js 18+
 - [superpowers](https://github.com/obra/superpowers) -- base skills framework (required; all skill chain skills wrap `superpowers:*` skills)
-- [rtk](https://github.com/franklywatson/rtk) -- token-optimized command proxy (strongly recommended; tool router redirects `grep`/`find`/`cat` through rtk when available)
-- [jcodemunch](https://github.com/franklywatson/jcodemunch) -- indexed code search MCP server
+- [rtk](https://github.com/rtk-ai/rtk) -- token-optimized command proxy (strongly recommended; tool router redirects `grep`/`find`/`cat` through rtk when available)
+- [jcodemunch](https://github.com/jgravelle/jcodemunch-mcp) -- indexed code search MCP server
   (strongly recommended; powers the scout agent and tool router fallback). Detected via PATH or,
   failing that, the MCP server command registered in Claude Code's own config (`claude mcp list`)
   -- wheel-URL `uvx --from` installs work out of the box.
@@ -100,14 +100,17 @@ at different stages of the token pipeline and can run in the same project:
 | Saves tokens by | Routing to cheaper tools *before* output is produced | Compressing context *after* it exists, before the API |
 | Also provides | Enforcement, skill chain, scout agent | Conversation compression, KV-cache alignment, memory |
 
-**The one conflict to avoid:** plain `headroom wrap claude` runs `rtk init --global`,
-which installs rtk's own *global* Bash-rewriting PreToolUse hook -- stacking a second
-rewriter on top of rig's project-level routing in every project on the machine.
+**The one conflict to avoid:** historically, plain `headroom wrap claude` ran
+`rtk init --global`, installing rtk's own *global* Bash-rewriting PreToolUse hook
+and stacking a second rewriter on rig's project-level routing in every project.
+Recent headroom (main / post-0.33) makes rtk **opt-in** (`--rtk` or `HEADROOM_RTK=1`),
+so plain `wrap claude` no longer touches rtk by default; against currently-released
+0.32.0 the old behavior still holds.
 
 **Recommendation:** let rig own the tool-routing seam and Headroom own the
 compression seam:
 
-- Trial per-invocation with `headroom wrap claude --no-context-tool` (skips the rtk hook), or
+- Trial per-invocation with `headroom wrap claude` (on recent headroom rtk is opt-in by default; `--no-context-tool`/`--no-rtk` are deprecated no-ops there), or
 - Install durably with `headroom init claude`, which configures only the proxy and does not touch rtk.
 
 Rig detects Headroom automatically: when the proxy is configured for a project
@@ -234,7 +237,7 @@ rules:
     native_read: advise        # advise jcodemunch for Read on code files
     native_grep: advise        # advise jcodemunch for Grep
     native_glob: advise        # advise jcodemunch for Glob on code patterns
-    rtk_cat_code: block        # block rtk cat on code files
+    rtk_cat_code: block        # block rtk read/smart on code files
   workflow:
     branch_discipline: advise  # block | advise | silent — git commit/push on a protected branch
     protected_branches: [master, main]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -127,13 +127,15 @@ on the Grep tool.
 `rtk rewrite` follows a four-code permission protocol (rtk
 `src/hooks/rewrite_cmd.rs`): exit 0 + stdout = rewrite (safe to auto-allow),
 exit 1 = no RTK equivalent, exit 2 = deny rule matched, exit 3 + stdout =
-"Ask" verdict (rewrite valid, must not be auto-allowed). Rig uses exit-0 and
-exit-3 rewrites identically — the hook emits `updatedInput` paired with
-`permissionDecision: "allow"`, which auto-approves the rewritten command in
-place of the original (Claude Code ignores `updatedInput` unless a
-`permissionDecision` accompanies it). This only takes effect in default
-permission mode; in `bypassPermissions` the `updatedInput` is ignored and the
-original command runs unmodified. Exits 1 and 2 fall through silently to
+"Ask"/Default verdict (rewrite valid, must not be auto-allowed). Rig treats
+the two differently: an exit-0 rewrite is emitted as `updatedInput` paired
+with `permissionDecision: "allow"` (auto-approve); an exit-3 rewrite is
+emitted as `updatedInput` **without** `permissionDecision`, so Claude Code
+prompts the user (matching rtk's own `process_claude_payload`; rtk 0.36+ maps
+unrated commands to Default→exit 3, so exit-3 is the common case — auto-
+allowing it would defeat rtk's least-privilege default). This only takes
+effect in default permission mode; in `bypassPermissions` the `updatedInput`
+is ignored and the original command runs unmodified. Exits 1 and 2 fall through silently to
 rig's own rules by design (stdout is never used on exit 2).
 Anything outside the protocol (exit 3 without output, other exit codes,
 signals, ENOENT) is appended as a JSON line to

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -84,7 +84,7 @@ Emitted via hook protocol: advisory -> additionalContext JSON (exit 0)
 | `native_read` | `Read` tool on code files (no offset/limit) | jcodemunch `get_file_outline` or `get_symbol` |
 | `native_grep` | `Grep` tool | jcodemunch `search_text` |
 | `native_glob` | `Glob` tool on code file patterns | jcodemunch `get_file_tree` |
-| `rtk_cat_code` | `rtk cat` on code files | Block, redirect to jcodemunch |
+| `rtk_cat_code` | rtk code-reading (`rtk read`/`rtk smart`/`rtk cat`) on code files | Block, redirect to jcodemunch |
 | `text_search` | Bash `grep`, `rg` | rtk or jcodemunch `search_text` |
 | `file_discovery` | Bash `find`, `fd` | jcodemunch `get_file_tree` |
 | `file_read` | Bash `cat`, `head`, `tail` | rtk or jcodemunch `get_symbol` |
@@ -716,9 +716,9 @@ Key design decisions:
   in `~/.code-index/config.jsonc`). Session-start emits a `[WARNING]` when files
   are skipped, but search quality may be degraded for large projects until the
   limit is increased.
-- graphify build may fail on very large codebases (6000+ files) due to Python
-  AST recursion limits during tree-sitter traversal. The scout agent falls back
-  to jcodemunch-only analysis and reports the failure.
+- graphify has no file-count or AST-recursion limit; only the HTML
+  visualization is skipped above 5000 nodes (graph.json + GRAPH_REPORT.md
+  are always produced).
 - **Absolute paths and permission prompts**: Claude Code's system prompt (since
   v2.1.97) requires agents to use absolute paths unconditionally. Each new
   absolute path in a Bash command triggers a permission prompt unless pre-authorized.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,10 +12,10 @@
 
 Strongly recommended:
 
-- [rtk](https://github.com/franklywatson/rtk) -- token-optimized command proxy.
+- [rtk](https://github.com/rtk-ai/rtk) -- token-optimized command proxy.
   The tool router redirects shell commands through rtk when available,
   saving 60-90% on token usage for common dev operations.
-- [jcodemunch](https://github.com/franklywatson/jcodemunch) -- indexed code
+- [jcodemunch](https://github.com/jgravelle/jcodemunch-mcp) -- indexed code
   search MCP server. Powers the scout agent for cross-repo indexing and
   serves as the tool router's fallback for `grep`/`find`/`cat` redirection.
   Rig detects it via PATH or via the MCP server command registered in Claude
@@ -30,9 +30,9 @@ Strongly recommended:
   god nodes (core abstractions ranked by connection density), module communities
   (clustered subsystems), and dependency path queries via MCP tools. Graphify
   rebuilds via its own git hooks; rig detects the existing graph and auto-builds
-  on first use if needed. Note: graphify may fail on very large codebases
-  (6000+ files) due to Python AST recursion limits during tree-sitter traversal.
-  The scout agent falls back to jcodemunch-only analysis in this case.
+  on first use if needed. Note: graphify has no file-count or AST-recursion
+  limit; only the HTML visualization is skipped above 5000 nodes (graph.json
+  and GRAPH_REPORT.md are always produced).
 
 ## Install and initialize
 

--- a/docs/plans/release-1-stabilize.md
+++ b/docs/plans/release-1-stabilize.md
@@ -1,0 +1,161 @@
+# Release 1 — Stabilize (Workstreams A + B)  ·  v2 (post-verification)
+
+**Source design:** `brain+` validated design, 2026-07-29 (memory `rig-dep-sync-design`).
+**Scope:** Workstream A (Tier 0 correctness) + Workstream B (Tier 1 cleanup). No structural changes — `rtk hook claude` delegation (C) and typed-agent PreToolUse hook (D) are Release 2.
+**Goal:** make rig correct and truthful against the current state of its five dependencies. Low-risk, fast to ship.
+**Suggested target:** `0.7.4` (patch — all `fix:`/`docs:`/`chore:`; release-please decides).
+
+> **v2 changes:** every dependency-side claim now **verified against actual `~/tools` source** (2026-07-29, 5 adversarial verifiers — see Verification section). Three tasks widened after a rig-side completeness sweep found the v1 file lists incomplete (A3, A4, B2). Task 3 (A1) improved: the correct fix preserves the rewrite rather than sacrificing it.
+
+## Verification (2026-07-29)
+
+Five read-only adversarial verifiers tried to **falsify** each load-bearing claim against the real source. Result: **every claim a task rests on is CONFIRMED; no task invalidated.** One PARTIAL (rtk `cat`) refines rationale, not the fix.
+
+| Claim | Verdict | Evidence |
+|---|---|---|
+| rtk `Default`(no rule)→exit 3, security test enforces it | CONFIRMED | `permissions.rs:19` ("default to ask"); `rewrite_cmd.rs:58-62` (`_=>Ask`), `:175-185` (test), `:153-156` (security comment, rtk-ai/rtk#1155); CHANGELOG 0.36.0 |
+| rtk emits `updatedInput` w/o `permissionDecision` on exit 3 | CONFIRMED | `hook_cmd.rs:390-443` `process_claude_payload` (inserts `permissionDecision:"allow"` only when allow=true); `rtk-rewrite.sh:81-101` |
+| rtk `cat` removed; reading is `rtk read`/`rtk smart` | PARTIAL (core✓, mechanism✗) | `main.rs:85-855` no `Cat`; `Read`(101)/`Smart`(120) present; `registry.rs:1333` rewrites `cat`→`rtk read`. But literal `rtk cat` is **not** clap-rejected — `run_fallback`(`main.rs:1290-1423`) passthrough-runs raw `cat`. |
+| rtk repo `rtk-ai/rtk`; `gain` cumulative at `summary.total_saved` | CONFIRMED | `Cargo.toml:10`; `gain.rs:517-526` |
+| jcodemunch `get_symbol`/`get_symbols`→`get_symbol_source` | CONFIRMED | commit `d040bf1` (2026-03-24); `server.py:1581` registers, `:5406` dispatches; zero hits for old names. (The CHANGELOG lines `:11256,11261` are historical `[1.0.0]` highlights.) |
+| jcodemunch repo `jgravelle/jcodemunch-mcp`; no bare `jcodemunch` CLI | CONFIRMED | `pyproject.toml [project.urls]`; `[project.scripts]` = `jcodemunch-mcp`/`gcm`/`munch-bench` only |
+| graphify writes no `.rebuild.lock`; no recursion/file cap | CONFIRMED | exhaustive grep: zero `rebuild.lock`/`flock`/`FileLock`/`setrecursionlimit`/`MAX_FILES`/`6000`; only `MAX_NODES_FOR_VIZ=5000` (`export.py:25`), try/except'd (`watch.py:108-118`) |
+| headroom `wrap` rtk opt-in on main (102 commits past v0.32.0) | CONFIRMED | `wrap.py:716-856` `_rtk_opt_in`/`_setup_rtk`; `init.py` zero rtk refs; perf schema intact |
+| superpowers: 9 skills exact, no typed agents, general-purpose dispatch | CONFIRMED | all `skills/<name>/SKILL.md:2`; no `.claude/agents/`; SDD templates use `Subagent (general-purpose):` |
+
+## Constitutional Rules for This Plan
+
+- **No mocks for environment detection** — injectable `ExecFn` / `ExecRewriteFn` (CLAUDE.md). Unit-test mocks OK for pure logic; the rtk/graphify/jcodemunch seams use injectable fakes, never `vi.mock`.
+- **Evidence before claims** — show test output before reporting done.
+- **Every source change → corresponding test change** (stale-tests, `grace_period: 0`).
+- **Zero-defect** — `npm test` green before commit; a failing RED run during `tdd+` is expected (advisory).
+
+## Mock Policy
+
+- **Unit tests (injectable fakes ok):** all of it. rtk rewrite via injectable `ExecRewriteFn`; graphify/jcodemunch detection via injectable `ExecFn`. No real subprocesses, no network.
+- **Protected/real-dep components:** none in this release.
+
+## Independence contract
+
+Serialize within a chain (shared file), parallelize across:
+
+| Chain | Tasks | Shared file(s) forcing serialization |
+|-------|-------|--------------------------------------|
+| 1 | T1 → T2 | `src/router/rules.ts`, `tests/router/rules.test.ts` |
+| 2 | T3 | `src/router/hook.ts`, `src/types.ts`, `templates/hooks/pre-tool-use.ts` |
+| 3 | T4 → T5 | `src/session/environment.ts`, `tests/session/environment.test.ts` |
+| 4 | T6 | docs + `src/session/start.ts` (start.ts is rig-code, but only T6 touches it) |
+
+No cross-chain file overlap. (T2 also touches README/architecture docs, as does T6 — if run in parallel, serialize the doc commits or have T6 own all doc edits; simplest: T6 after T2.)
+
+---
+
+## Task 1: Rename stale `get_symbol`/`get_symbols` → `get_symbol_source` (A2)
+
+Verified: commit `d040bf1` (2026-03-24) merged both into `get_symbol_source`; old names have no registration/dispatch. **Trap:** the implementation *file* is still `tools/get_symbol.py` (didn't rename) — only the advertised MCP tool name changed. Don't be fooled by the filename.
+
+**Files:** `templates/agents/scout.md`, `templates/agents/code-reviewer.md`, `templates/agents/spec-reviewer.md` (`tools:` line ~4 — replace `mcp__jcodemunch__get_symbol,mcp__jcodemunch__get_symbols` → `mcp__jcodemunch__get_symbol_source`), `src/router/rules.ts:35` (advisory `reason`: `get_symbol` → `get_symbol_source`)
+**Test strategy:** `tests/cli/template-content.test.ts` (assert rendered `tools:` has `get_symbol_source`, not bare `get_symbol`/`get_symbols`); `tests/router/rules.test.ts` (advisory text).
+**Mock check:** none — string assertions.
+- [ ] RED: add the two assertions → fail.
+- [ ] Confirm fail.
+- [ ] GREEN: rename in the 3 templates + `rules.ts:35`.
+- [ ] Confirm pass; commit `fix(agents): rename stale get_symbol→get_symbol_source after jcodemunch consolidation (d040bf1)`.
+
+## Task 2: Retarget `rtk_cat_code` rule → `rtk read`/`rtk smart` (A3)  ·  *widened in v2*
+
+Verified: rtk has no `cat` subcommand; the rewrite engine maps `cat`→`rtk read` (`registry.rs:1333`), so the common path produces `rtk read`, which the current `^rtk\s+cat` rule never catches. A literal `rtk cat <file>` degrades to raw passthrough `cat` (not clap-rejected, as v1 claimed). Retargeting catches the real code-reading path.
+
+**Decision: keep the `rtk_cat_code` intent/config key as-is** (it's a user-facing `.harness.yaml` key — `tool_routing.rtk_cat_code`; renaming breaks user config for no behavioral gain). Only retarget the match regex + message text. Renaming the intent is an optional future cleanup.
+
+**Depends on: Task 1** (shared `rules.ts` + `rules.test.ts`).
+**Files (wider than v1):**
+- `src/router/rules.ts:70-85` (the rule: regex `^rtk\s+cat\s+(\S+)` → `^rtk\s+(?:read|smart)\s+(\S+)`; refresh `reason` to "rtk read/smart on code files wastes tokens…")
+- `src/router/rules.ts:137` (**second stale spot, missed in v1**: the `file_read` rule's rtk resolution advises `tool: 'rtk cat'` → change to `'rtk read'`)
+- Tests: `tests/router/rules.test.ts` (the rtk_cat_code cases ~197-209 AND the file_read "advises rtk cat" case ~42-48 → `rtk read`), `tests/router/hook.test.ts:191-202`, `tests/router/rewrite.test.ts:320-324`, `tests/integration/pre-tool-use.test.ts:122-141`, `tests/eval/scenarios.ts:414-417`, `tests/eval/session-state-eval.test.ts:111`, `tests/eval/score.test.ts:28`, `tests/config.test.ts:27`
+- Docs: `README.md:46,237`, `docs/architecture.md:38,87` (reword "rtk cat" → "rtk read on code files"; keep the `rtk_cat_code` config key name)
+**Test strategy:** `rules.test.ts` — matches `rtk read src/foo.ts` + `rtk smart src/foo.ts` on code, not `rtk read README.md`; file_read rtk resolution advises `rtk read`. Eval/config/hook tests updated to the new tool string.
+**Mock check:** none — static rules.
+- [ ] RED: update rtk_cat_code + file_read tests to new matchers/strings → fail.
+- [ ] Confirm fail.
+- [ ] GREEN: retarget regex (`:76`), refresh reason (`:82`), fix file_read advisory (`:137`); update the ~8 test files + 2 docs.
+- [ ] Confirm full `npm test` pass; commit `fix(router): retarget rtk_cat_code to rtk read/smart (rtk cat removed; literal rtk cat passthrough-runs raw cat)`.
+
+## Task 3: Stop auto-allowing rtk exit-3 rewrites — preserve rewrite, prompt user (A1)  ·  *improved in v2*
+
+Verified load-bearing: `Default`→exit 3, security-enforced. **v2 improvement:** rtk's own native Claude path (`process_claude_payload`, `hook_cmd.rs:390-443`) emits `updatedInput` **without** `permissionDecision` on Ask/Default (inserts `"allow"` only when `allow==true`). So the correct minimal fix is **not** pass-through (which loses the rewrite) — it's **emit the rewrite without `permissionDecision`**, matching rtk byte-for-byte. This keeps the token optimization *and* prompts the user. Superseded by Release 2 C (`rtk hook claude` delegation) — include only as a bleed-stop.
+
+**Files:** `src/types.ts` (`RewriteResult` + `ExecRewriteFn`), `src/router/hook.ts` (`makeDefaultExecRewrite` ~59-108, `tryRtkRewrite` ~118-131, Step 3 ~268-276), `templates/hooks/pre-tool-use.ts` (~55-64), `tests/router/hook.test.ts`, `tests/router/rewrite.test.ts`, `tests/cli/` (template emission)
+**Test strategy:** `hook.test.ts` — injectable `ExecRewriteFn` simulating exit 0 (Allow) vs exit 3 (Ask/Default): returned `RewriteResult` carries `autoAllow:true` (exit 0) vs `autoAllow:false` (exit 3), both with the rewritten `command`. `tests/cli` — emission pairs `permissionDecision:"allow"` only when `autoAllow`; for `autoAllow:false` emits `updatedInput` **without** `permissionDecision`.
+**Mock check:** injectable `ExecRewriteFn` (throws `{status:3,stdout}` / returns string) — not a component mock.
+- [ ] RED: assert exit-3 `autoAllow===false` + emission omits `permissionDecision` → fail.
+- [ ] Confirm fail.
+- [ ] **Evidence step (largely pre-answered):** rtk ships exactly this (`process_claude_payload` omits `permissionDecision` on Ask; `test_claude_json_output_structure` comment: "permissionDecision is only set when an explicit allow rule matches"). Still do a scratch CC 2.1.220 check that `updatedInput` without `permissionDecision` prompts-and-applies (not run-original). If it only run-originals, exit-3 rewrites are lost until Release 2 — still safe (no auto-allow).
+- [ ] GREEN: add `autoAllow:boolean` to `RewriteResult`; `ExecRewriteFn`/`tryRtkRewrite` return `{command, autoAllow}` (exit 0→true, exit 3→false, exit 1/2→null); thread through Step 3; `pre-tool-use.ts` emits `permissionDecision:"allow"` only when `autoAllow`, else `updatedInput` alone. Keep the `/tmp/rig-rtk-rewrite-failures.log` diag path.
+- [ ] Confirm full `npm test` pass; commit `fix(router): stop auto-allowing rtk exit-3 rewrites — emit rewrite without permissionDecision (matches rtk Ask semantics)`.
+
+## Task 4: Remove dead graphify `.rebuild.lock` branch (A4)  ·  *widened in v2*
+
+Verified: graphify writes no `.rebuild.lock` anywhere (no `flock`/`FileLock` either). The lock-based "building" branch is dead; the 5s polling loop remains the race-guard.
+
+**Depends on: Task 5 is its peer in chain 3 (serialize T4→T5).**
+**Files (wider than v1):**
+- `src/session/environment.ts:7` (drop `rebuildLockPath` import), `:210-224` (delete the lock block + fix the false comment at `:210-212`)
+- `src/constants.ts:11` (`REBUILD_LOCK_REL`), `:18` (`rebuildLockPath`) — remove both
+- `src/scout/graph-state.ts` (drop any `rebuildLockPath` import/use — verify)
+- **`templates/agents/scout.md:76-78, 111, 120`** (missed in v1: a build-state table + notes that reference `.rebuild.lock` — rewrite to drop lock references)
+- **`tests/scout/scout-template.test.ts:44-45`** (missed in v1: asserts the template *contains* `.rebuild.lock` — update/remove)
+- **`tests/session/environment.test.ts:831, 843, 859`** (missed in v1: three cases asserting lock-based building-state — remove/replace)
+**Test strategy:** `environment.test.ts` — assert lock-file presence no longer affects state; `scout-template.test.ts` — assert the scout template no longer mentions `.rebuild.lock`; `npm run lint` confirms no dangling `rebuildLockPath` import.
+**Mock check:** injectable `existsCheck`/`statCheck`/`mtimeCheck`.
+- [ ] RED: add "lock presence doesn't change state" + "template has no .rebuild.lock" assertions → fail.
+- [ ] Confirm fail.
+- [ ] GREEN: delete lock block/comment/import/constants; rewrite scout template build-state table (drop lock rows); fix the 3 env tests + scout-template test.
+- [ ] Confirm `npm run lint` + `npm test`; commit `fix(graphify): drop dead .rebuild.lock detection (upstream removed it; build emits only graph.json/GRAPH_REPORT.md/graph.html)`.
+
+## Task 5: Remove dead bare-`jcodemunch` CLI probe (B4)  ·  *confirmed dead in v2*
+
+Verified: `[project.scripts]` has only `jcodemunch-mcp`/`gcm`/`munch-bench` — no bare `jcodemunch`. The `which jcodemunch` first probe always fails and falls through. (v1 hedged "verify" — now confirmed, so just remove.)
+
+**Depends on: Task 4** (shared `environment.ts` + `environment.test.ts`).
+**Files:** `src/session/environment.ts:248-257` (the `try { exec('which jcodemunch') … }` step-1 block of `detectJcodemunch`), `tests/session/environment.test.ts`
+**Test strategy:** `environment.test.ts` — assert detection proceeds to the MCP-config/binary/uvx chain (step 1 gone); transport resolution unchanged.
+**Mock check:** injectable `ExecFn` failing `which jcodemunch`.
+- [ ] RED: test that step 1 is gone / detection starts at MCP config → fail.
+- [ ] GREEN: remove the bare-`jcodemunch` try-block; detection starts at the MCP registration lookup.
+- [ ] Confirm pass; commit `chore(session): drop dead bare-jcodemunch CLI probe (only jcodemunch-mcp/gcm/munch-bench exist)`.
+
+## Task 6: Correct stale dependency docs + install URLs (B1 + B2 + B3)  ·  *widened in v2*
+
+Three doc-truth fixes. **v2 adds:** user-facing install URLs in `src/session/start.ts` (code, not just docs) and their tests.
+
+**Files:** `README.md`, `docs/getting-started.md`, `docs/architecture.md`, `docs/troubleshooting.md`, **`src/session/start.ts:273,276`** (+ `tests/session/start.test.ts` asserting the warning text)
+**Test strategy:** docs-quality CI lint; `start.test.ts` updated to the new URLs; a grep-assertion test that stale strings are absent and corrected ones present.
+**Mock check:** none.
+- [ ] **B1 — graphify recursion myth:** `docs/getting-started.md:34`, `docs/troubleshooting.md:178`, `docs/architecture.md:719` — replace "6000+ files … AST recursion limits" with: no file-count/recursion cap; only HTML viz skipped above 5000 nodes (JSON + report always produced).
+- [ ] **B2 — repo URLs (widened):** change `franklywatson/rtk`→`rtk-ai/rtk` and `franklywatson/jcodemunch`→`jgravelle/jcodemunch-mcp` in `README.md:8,9,81,82`, `docs/getting-started.md:15,18`, **and `src/session/start.ts:273,276`** (the runtime install-warning URLs) + their `start.test.ts` assertions.
+  - **DISCIPLINE — do NOT change:** `franklywatson/claude-rig` (rig's *own* repo — README:3,4,5,135; getting-started:41; design-process:13), `franklywatson/agentic-patterns` (out of scope/unverified — README:57,380; architecture.md:17), or test fixtures (`environment.test.ts:462,478`; `start.test.ts:847`).
+- [ ] **B3 — headroom wrap/rtk conflict:** `README.md:103,110` — reword: plain `headroom wrap claude` no longer runs `rtk init --global` by default on main/post-0.33 (rtk opt-in via `--rtk`/`HEADROOM_RTK=1`); `--no-context-tool`/`--no-rtk` are now deprecated no-ops. (Against released 0.32.0 the old behavior still holds — phrase as "recent headroom makes rtk opt-in".)
+- [ ] Confirm docs lint + grep test + `start.test.ts` pass; commit `docs: sync rtk/graphify/jcodemunch/headroom references + install URLs to current upstream`.
+
+---
+
+## Validation (Phase C, re-run honestly)
+
+- [ ] Every task has a test strategy ✓
+- [ ] No task mocks a protected component ✓ (injectable fakes only)
+- [ ] **Plan references complete, exact file paths** ✓ (v1 was incomplete on A3/A4/B2 — now fixed via the rig-side sweep; each widened task lists every test/doc touched)
+- [ ] Evidence criteria defined per task ✓ (Task 3's CC-semantics step now largely pre-answered by rtk source)
+- [ ] Active enforcement rules section present ✓
+- [ ] Independence contract complete ✓ (chain 1 = T1→T2; chain 3 = T4→T5; T3, T6 independent; T6 after T2 if parallel)
+
+## Execution notes
+
+- Feature branch `fix/dep-sync-stabilize`, not `master` (branch-discipline).
+- Each task = one conventional commit; release-please bundles into the release PR.
+- **Prefer `/tdd+` (sequential) over `/sdd+`** for this release: tdd+ runs in-session with no subagent dispatch, sidestepping the typed-agent→general-purpose revert that Release 2 D fixes. The 4 chains are independent (team-mode candidates post-Release 2).
+- `npm test` (1100+ tests) green + `npm run lint` clean before each commit.
+
+## Next
+
+After Release 1 ships, plan Release 2 (Workstreams C + D + E): `rtk hook claude` delegation, typed-agent PreToolUse hook, superpowers detection.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -175,9 +175,9 @@ in this project, so `graphify-out/graph.json` does not exist or is a placeholder
 graphify update .
 ```
 
-Run this from the project root. For large projects (6000+ files), graphify may
-hit Python AST recursion limits — the scout agent falls back to jcodemunch-only
-analysis in that case and reports the failure.
+Run this from the project root. graphify has no file-count or AST-recursion
+limit; only the HTML visualization is skipped above 5000 nodes (graph.json
+and GRAPH_REPORT.md are always produced).
 
 ### Rig's automatic self-check
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,11 +8,9 @@ import { join } from 'node:path';
 export const GRAPHIFY_OUT_DIR = 'graphify-out';
 export const GRAPH_JSON_REL = `${GRAPHIFY_OUT_DIR}/graph.json`;
 export const GRAPH_REPORT_REL = `${GRAPHIFY_OUT_DIR}/GRAPH_REPORT.md`;
-export const REBUILD_LOCK_REL = `${GRAPHIFY_OUT_DIR}/.rebuild.lock`;
 
 /** graph.json files smaller than this are placeholders, not real graphs. */
 export const GRAPHIFY_PLACEHOLDER_THRESHOLD = 1024; // bytes
 
 export const graphJsonPath = (dir: string): string => join(dir, GRAPHIFY_OUT_DIR, 'graph.json');
 export const graphReportPath = (dir: string): string => join(dir, GRAPHIFY_OUT_DIR, 'GRAPH_REPORT.md');
-export const rebuildLockPath = (dir: string): string => join(dir, GRAPHIFY_OUT_DIR, '.rebuild.lock');

--- a/src/router/hook.ts
+++ b/src/router/hook.ts
@@ -10,7 +10,7 @@ import { checkTestScope } from '../enforcement/test-scope.js';
 import { checkBranchDisciplineCommand } from './branch-discipline.js';
 import type { ExecFn } from '../session/worktree.js';
 
-export type ExecRewriteFn = (rtkPath: string, args: string[]) => string | null;
+export type ExecRewriteFn = (rtkPath: string, args: string[]) => { command: string; autoAllow: boolean } | null;
 export type ExistsCheckFn = (path: string) => boolean;
 
 export interface HookOptions {
@@ -41,15 +41,15 @@ const defaultWriteDiag = (line: string): void => {
  *   2           deny rule matched — pass through (never use stdout)
  *   3 + stdout  "Ask" verdict — rewrite valid, but must not be auto-allowed
  *
- * rig emits each rewrite as updatedInput paired with permissionDecision
- * "allow" (see templates/hooks/pre-tool-use.ts): Claude Code only applies
- * updatedInput when a permissionDecision is present, so "allow" auto-approves
- * the rewritten command in place of the original. This makes exit 3 equivalent
- * to exit 0 here. rtk maps commands without an explicit allow rule — notably
- * all git commands — to Ask, so dropping exit-3 output would lose the most
- * common rewrites. Rewrites only take effect in permission modes that consult
- * the hook's decision (default mode) — not bypassPermissions, where
- * updatedInput is ignored and the original command runs unmodified.
+ * rig emits each rewrite as updatedInput. For exit 0 (Allow) and python-env
+ * rewrites it pairs permissionDecision:"allow" (auto-approve); for exit 3
+ * (Ask/Default) it emits updatedInput WITHOUT permissionDecision so Claude
+ * Code prompts the user — matching rtk's own hook (process_claude_payload).
+ * rtk 0.36+ maps unrated commands (notably all git commands) to Default→exit 3,
+ * so exit-3 rewrites are common and must NOT be auto-allowed (rtk-ai/rtk#1155).
+ * Rewrites only take effect in permission modes that consult the hook's
+ * decision (default mode) — not bypassPermissions, where updatedInput is
+ * ignored and the original command runs unmodified.
  *
  * Anything outside the protocol — exit 3 without output, other exit codes,
  * signals, ENOENT — is appended as a JSON line to the diagnostic log so
@@ -60,18 +60,23 @@ export function makeDefaultExecRewrite(
   writeDiag: (line: string) => void = defaultWriteDiag,
   rawExec: RawExecFileFn = execFileSync as unknown as RawExecFileFn,
 ): ExecRewriteFn {
-  return (rtkPath: string, args: string[]): string | null => {
+  return (rtkPath: string, args: string[]) => {
     try {
       const result = rawExec(rtkPath, args, {
         encoding: 'utf-8',
         timeout: 5000,
         stdio: ['pipe', 'pipe', 'pipe'],
       });
-      return result.trim() || null;
+      const rewritten = result.trim();
+      // Exit 0 (Allow): safe to auto-allow.
+      return rewritten ? { command: rewritten, autoAllow: true } : null;
     } catch (err) {
       const e = err as { status?: number; signal?: string; code?: string; stdout?: unknown; stderr?: unknown };
 
-      // Exit 3 = rtk's "Ask" verdict: the rewrite is on stdout.
+      // Exit 3 = rtk's "Ask"/Default verdict: the rewrite is on stdout, but
+      // it must NOT be auto-allowed (rtk 0.36+ maps unrated commands here;
+      // security test rtk-ai/rtk#1155). Return the rewrite with autoAllow:false
+      // so the hook emits updatedInput without permissionDecision (prompt).
       if (e?.status === 3) {
         const stdout =
           typeof e.stdout === 'string'
@@ -80,7 +85,7 @@ export function makeDefaultExecRewrite(
               ? e.stdout.toString('utf-8')
               : '';
         const rewritten = stdout.trim();
-        if (rewritten) return rewritten;
+        if (rewritten) return { command: rewritten, autoAllow: false };
         // Exit 3 without output violates the protocol — fall through to diag.
       }
 
@@ -119,15 +124,15 @@ export function tryRtkRewrite(
   command: string,
   rtkPath: string,
   execRewrite: ExecRewriteFn = defaultExecRewrite,
-): string | null {
+): { command: string; autoAllow: boolean } | null {
   // Only attempt rewrite for commands rtk is designed to handle
   const binary = command.trimStart().split(/\s+/)[0] ?? '';
   if (!RTK_PREFIXES.some(p => command.trimStart().startsWith(p)) && binary !== 'git') {
     return null;
   }
-  const rewritten = execRewrite(rtkPath, ['rewrite', command]);
-  if (!rewritten || rewritten === command) return null;
-  return rewritten;
+  const rewrite = execRewrite(rtkPath, ['rewrite', command]);
+  if (!rewrite || rewrite.command === command) return null;
+  return rewrite;
 }
 
 function defaultEnv() {
@@ -260,7 +265,7 @@ export function handlePreToolUse(
     if (pythonEnv) {
       const rewritten = tryPythonRewrite(args.command, effectiveCwd, pythonEnv, resolvedOptions.existsCheck);
       if (rewritten) {
-        return { type: 'rewrite', command: rewritten, original: args.command };
+        return { type: 'rewrite', command: rewritten, original: args.command, autoAllow: true };
       }
     }
   }
@@ -268,9 +273,9 @@ export function handlePreToolUse(
   // Step 3: Transparent rewrite via rtk for Bash commands (skip compound commands)
   if (tool === 'Bash' && typeof args.command === 'string') {
     if (env.rtkAvailable && env.rtkPath && !isCompoundCommand(args.command)) {
-      const rewritten = tryRtkRewrite(args.command, env.rtkPath, resolvedOptions.execRewrite);
-      if (rewritten) {
-        return { type: 'rewrite', command: rewritten, original: args.command };
+      const rewrite = tryRtkRewrite(args.command, env.rtkPath, resolvedOptions.execRewrite);
+      if (rewrite) {
+        return { type: 'rewrite', command: rewrite.command, original: args.command, autoAllow: rewrite.autoAllow };
       }
     }
   }

--- a/src/router/rules.ts
+++ b/src/router/rules.ts
@@ -67,19 +67,24 @@ export function getDefaultRules(cwd?: string): ToolRule[] {
       enforcement: 'advise',
     },
 
-    // ── rtk cat on code files (close the bypass) ──
+    // ── rtk-driven code reading (close the bypass) ──
+    // rtk removed the `cat` subcommand: it rewrites `cat`→`rtk read`, and a
+    // literal `rtk cat <file>` degrades to a raw passthrough `cat`. The real
+    // code-reading commands are `rtk read` / `rtk smart` — block all of them
+    // on code files so jcodemunch (symbol-level) handles it instead. Intent
+    // name kept as `rtk_cat_code` for config stability (.harness.yaml key).
     {
       match: (tool: string, args: Record<string, unknown>) => {
         if (tool !== 'Bash') return false;
         const command = args.command as string | undefined;
         if (!command) return false;
-        const rtkCatMatch = command.match(/^rtk\s+cat\s+(\S+)/);
-        if (!rtkCatMatch) return false;
-        return isCodeFile(rtkCatMatch[1]);
+        const rtkCodeReadMatch = command.match(/^rtk\s+(?:cat|read|smart)\s+(\S+)/);
+        if (!rtkCodeReadMatch) return false;
+        return isCodeFile(rtkCodeReadMatch[1]);
       },
       intent: 'rtk_cat_code',
       resolutions: {
-        _: { action: 'block', reason: 'rtk cat on code files wastes tokens. Use jcodemunch get_file_outline for structure, get_symbol_source for definitions.' },
+        _: { action: 'block', reason: 'rtk read/smart (or passthrough rtk cat) on code files wastes tokens. Use jcodemunch get_file_outline for structure, get_symbol_source for definitions.' },
       },
       enforcement: 'block',
     },
@@ -134,7 +139,7 @@ export function getDefaultRules(cwd?: string): ToolRule[] {
       },
       intent: 'file_read',
       resolutions: {
-        rtk: { action: 'advise', tool: 'rtk cat', reason: 'rtk provides filtered, token-optimized file reading (60-90% savings)' },
+        rtk: { action: 'advise', tool: 'rtk read', reason: 'rtk provides filtered, token-optimized file reading via rtk read (60-90% savings)' },
         jcodemunch: { action: 'advise', tool: 'jcodemunch get_file_content', reason: 'jcodemunch provides cached, token-efficient file content (80-85% savings)' },
         claudeTool: { action: 'advise', tool: 'Read', reason: 'Use Claude Read tool instead of cat/head — cleaner output, no artifacts' },
         fallback: { action: 'allow' },

--- a/src/router/rules.ts
+++ b/src/router/rules.ts
@@ -32,7 +32,7 @@ export function getDefaultRules(cwd?: string): ToolRule[] {
       },
       intent: 'native_read',
       resolutions: {
-        jcodemunch: { action: 'advise', tool: 'jcodemunch get_file_outline or get_symbol', reason: 'For code files, get_file_outline returns structure with signatures (80-85% fewer tokens than full file read)' },
+        jcodemunch: { action: 'advise', tool: 'jcodemunch get_file_outline or get_symbol_source', reason: 'For code files, get_file_outline returns structure with signatures (80-85% fewer tokens than full file read)' },
         fallback: { action: 'allow' },
       },
       enforcement: 'advise',

--- a/src/session/environment.ts
+++ b/src/session/environment.ts
@@ -155,20 +155,11 @@ function parseGraphifyVersion(output: string): string | undefined {
   return output.match(/(\d+\.\d+\.\d+)/)?.[1];
 }
 
-const defaultMtimeCheck = (path: string): Date | undefined => {
-  try {
-    return statSync(path).mtime;
-  } catch {
-    return undefined;
-  }
-};
-
 export function detectGraphify(
   cwd: string,
   exec: ExecFn,
   existsCheck: (path: string) => boolean = existsSync,
   statCheck: (path: string) => { size: number } | undefined = defaultStatCheck,
-  mtimeCheck: (path: string) => Date | undefined = defaultMtimeCheck,
 ): GraphifyDetectResult {
   // Check for graphify CLI — package installs as 'graphifyy' (double-y)
   let cliBinary: string | null = null;

--- a/src/session/environment.ts
+++ b/src/session/environment.ts
@@ -4,7 +4,6 @@ import { existsSync, statSync } from 'node:fs';
 import type { Environment, GraphBuildInfo, JcodemunchTransport } from '../types.js';
 import {
   graphJsonPath,
-  rebuildLockPath,
   GRAPH_JSON_REL,
   GRAPHIFY_PLACEHOLDER_THRESHOLD,
 } from '../constants.js';
@@ -207,21 +206,9 @@ export function detectGraphify(
     // Placeholder or tiny file — treat as absent
   }
 
-  // graphify leaves .rebuild.lock behind after completed builds: a lock with a
-  // graph newer than it is stale (finished build); a lock newer than the graph
-  // (or with no valid graph) means a rebuild is in progress.
-  const lockPath = rebuildLockPath(cwd);
-  if (existsCheck(lockPath)) {
-    if (!graphValid) {
-      return { state: 'building', _cliFound: cliAvailable, cliVersion };
-    }
-    const graphMtime = mtimeCheck(graphPath);
-    const lockMtime = mtimeCheck(lockPath);
-    if (graphMtime && lockMtime && lockMtime > graphMtime) {
-      return { state: 'building', _cliFound: cliAvailable, cliVersion };
-    }
-    // Stale lock (or mtimes unavailable) — the valid graph wins
-  }
+  // graphify 0.4.31 writes no .rebuild.lock; graph validity alone determines
+  // ready/absent. The build-in-progress race is handled by the polling loop in
+  // scout/graph-state.ts, not a lockfile.
 
   if (graphValid) {
     return { state: 'ready', graphPath: GRAPH_JSON_REL, _cliFound: cliAvailable, cliVersion };

--- a/src/session/start.ts
+++ b/src/session/start.ts
@@ -270,10 +270,10 @@ export async function handleSessionStart(
   // One-time warning for missing tools
   if (!cache.getToolsWarned()) {
     if (!env.rtkAvailable) {
-      lines.push('[WARNING] rtk is not installed. Install for 60-90% token savings on dev operations: https://github.com/franklywatson/rtk');
+      lines.push('[WARNING] rtk is not installed. Install for 60-90% token savings on dev operations: https://github.com/rtk-ai/rtk');
     }
     if (!env.jcodemunchAvailable) {
-      lines.push('[WARNING] jcodemunch was not detected. Install for indexed code search: https://github.com/franklywatson/jcodemunch');
+      lines.push('[WARNING] jcodemunch was not detected. Install for indexed code search: https://github.com/jgravelle/jcodemunch-mcp');
       lines.push("  If installed as an MCP server, verify its registration with 'claude mcp list'.");
       if (hasOrphanedIndexData(deps.homeDir ?? homedir(), deps.readdir ?? readdirSync)) {
         lines.push('[WARNING] jcodemunch index data found at ~/.code-index but no working transport detected.');

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,14 @@ export interface RewriteResult {
   type: 'rewrite';
   command: string;
   original: string;
+  /**
+   * Whether the hook may auto-approve the rewritten command
+   * (permissionDecision:"allow"). rtk exit 0 (Allow) → true; rtk exit 3
+   * (Ask/Default — no matching allow rule, rtk-ai/rtk#1155) → false, so the
+   * hook emits updatedInput WITHOUT permissionDecision and Claude Code prompts.
+   * Python-env rewrites (venv/uv path resolution) → true (safe path fix).
+   */
+  autoAllow: boolean;
 }
 
 // ── Resolution Types ──

--- a/templates/agents/code-reviewer.md
+++ b/templates/agents/code-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: code-reviewer
 description: "Use when dispatched by review+ or sdd+ to review completed work against its plan or requirements. Reviews a git range for plan alignment and code quality. Do not invoke proactively — this agent is dispatched explicitly by the skill chain."
-tools: "mcp__jcodemunch__get_repo_outline,mcp__jcodemunch__get_file_tree,mcp__jcodemunch__get_file_outline,mcp__jcodemunch__search_symbols,mcp__jcodemunch__get_symbol,mcp__jcodemunch__get_symbols,mcp__jcodemunch__search_text,mcp__jcodemunch__list_repos,mcp__graphify__query_graph,mcp__graphify__get_community,mcp__graphify__god_nodes,mcp__graphify__shortest_path,mcp__graphify__graph_stats,Read,Glob,Grep,Bash"
+tools: "mcp__jcodemunch__get_repo_outline,mcp__jcodemunch__get_file_tree,mcp__jcodemunch__get_file_outline,mcp__jcodemunch__search_symbols,mcp__jcodemunch__get_symbol_source,mcp__jcodemunch__search_text,mcp__jcodemunch__list_repos,mcp__graphify__query_graph,mcp__graphify__get_community,mcp__graphify__god_nodes,mcp__graphify__shortest_path,mcp__graphify__graph_stats,Read,Glob,Grep,Bash"
 model: inherit
 maxTurns: 75
 ---

--- a/templates/agents/scout.md
+++ b/templates/agents/scout.md
@@ -1,7 +1,7 @@
 ---
 name: scout
 description: "PROACTIVELY use when starting any non-trivial implementation task, when context about the codebase is needed before making changes, or when the user references unfamiliar code. Context harvesting agent that maps codebase structure using jcodemunch, graphify, and rtk for token-efficient exploration."
-tools: "mcp__jcodemunch__get_repo_outline,mcp__jcodemunch__get_file_tree,mcp__jcodemunch__get_file_outline,mcp__jcodemunch__search_symbols,mcp__jcodemunch__get_symbol,mcp__jcodemunch__get_symbols,mcp__jcodemunch__search_text,mcp__jcodemunch__list_repos,mcp__jcodemunch__index_folder,mcp__graphify__query_graph,mcp__graphify__get_community,mcp__graphify__god_nodes,mcp__graphify__shortest_path,mcp__graphify__graph_stats,Read,Glob,Grep,Bash"
+tools: "mcp__jcodemunch__get_repo_outline,mcp__jcodemunch__get_file_tree,mcp__jcodemunch__get_file_outline,mcp__jcodemunch__search_symbols,mcp__jcodemunch__get_symbol_source,mcp__jcodemunch__search_text,mcp__jcodemunch__list_repos,mcp__jcodemunch__index_folder,mcp__graphify__query_graph,mcp__graphify__get_community,mcp__graphify__god_nodes,mcp__graphify__shortest_path,mcp__graphify__graph_stats,Read,Glob,Grep,Bash"
 model: inherit
 maxTurns: 30
 ---

--- a/templates/agents/scout.md
+++ b/templates/agents/scout.md
@@ -226,8 +226,8 @@ the response), report:
 
 ### graphify build failure
 
-If `graphify update` fails for a directory (e.g., Python recursion limit on large codebases,
-or the resulting graph.json is still under 1KB indicating a placeholder), report:
+If `graphify update` fails for a directory (e.g., the resulting graph.json is
+still under 1KB indicating a placeholder, or the build errored), report:
 
 ```
 [WARNING] graphify build failed for <directory>.

--- a/templates/agents/scout.md
+++ b/templates/agents/scout.md
@@ -73,9 +73,9 @@ Determine each directory's state from its `graphify-out/`:
 
 | State | On-disk indicator (per-directory) |
 | ----- | --------------------------------- |
-| ready | `<dir>/graphify-out/graph.json` exists and is >1KB — even when a `.rebuild.lock` is also present but **older** than `graph.json` (graphify leaves locks behind after completed builds; graph newer than lock = stale lock from a finished build) |
-| building | `<dir>/graphify-out/.rebuild.lock` is present and either no valid `graph.json` exists or the lock is **newer** than `graph.json` (another process owns this build — session-start, a git hook, or a parallel agent) |
-| absent | neither `graph.json` (>1KB) nor `.rebuild.lock` exists |
+| ready | `<dir>/graphify-out/graph.json` exists and is >1KB |
+| absent | no valid `graph.json` (>1KB) exists |
+| building | a `graphify update` is in progress this session (tracked in session state — graphify 0.4.31 writes no lockfile) |
 | failed | a previous `graphify update` attempt errored this session for this directory |
 
 Then act based on state AND the capability check from Step 0:
@@ -108,19 +108,14 @@ the CLI; reading does not.
    report the failure (see Alert Reporting). Other directories' graphs are
    unaffected.
 
-**building** (`<dir>/graphify-out/.rebuild.lock` newer than `graph.json`, or no valid graph):
+**building** (a `graphify update` is in progress this session):
 
 Another process owns this directory's build — do not run `graphify update`
 on it; the second invocation will conflict with the first. If `graph.json`
-is also present and >1KB, you may still read it (the lock indicates a
-*re*build, so the previous graph is on disk). Otherwise skip graph context
-for this directory and note `graph build in progress — retry next session`.
-Continue with any other directories whose state is independent.
-
-Note on stale locks: graphify does not clean up `.rebuild.lock` after a
-completed build, so a lock alongside a valid graph is common. Compare
-mtimes — `graph.json` newer than the lock means the build finished and the
-directory is actually **ready**, not building.
+is also present and >1KB, you may still read it (a *re*build leaves the
+previous graph on disk). Otherwise skip graph context for this directory
+and note `graph build in progress — retry next session`. Continue with any
+other directories whose state is independent.
 
 **failed:** skip graph context for this directory. Report the failure.
 

--- a/templates/agents/spec-reviewer.md
+++ b/templates/agents/spec-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: spec-reviewer
 description: "Use when dispatched by review+ or sdd+ to verify an implementation matches its specification — nothing more, nothing less. Do not invoke proactively — this agent is dispatched explicitly by the skill chain."
-tools: "mcp__jcodemunch__get_repo_outline,mcp__jcodemunch__get_file_tree,mcp__jcodemunch__get_file_outline,mcp__jcodemunch__search_symbols,mcp__jcodemunch__get_symbol,mcp__jcodemunch__get_symbols,mcp__jcodemunch__search_text,mcp__jcodemunch__list_repos,mcp__graphify__query_graph,mcp__graphify__get_community,mcp__graphify__god_nodes,mcp__graphify__shortest_path,mcp__graphify__graph_stats,Read,Glob,Grep,Bash"
+tools: "mcp__jcodemunch__get_repo_outline,mcp__jcodemunch__get_file_tree,mcp__jcodemunch__get_file_outline,mcp__jcodemunch__search_symbols,mcp__jcodemunch__get_symbol_source,mcp__jcodemunch__search_text,mcp__jcodemunch__list_repos,mcp__graphify__query_graph,mcp__graphify__get_community,mcp__graphify__god_nodes,mcp__graphify__shortest_path,mcp__graphify__graph_stats,Read,Glob,Grep,Bash"
 model: inherit
 maxTurns: 50
 ---

--- a/templates/hooks/pre-tool-use.ts
+++ b/templates/hooks/pre-tool-use.ts
@@ -45,22 +45,20 @@ import { readFileSync } from 'node:fs';
   loadConfig(resolve(cwd, '.harness.yaml')).then((config: any) => {
     const result = handlePreToolUse(input.tool_name, input.tool_input, cache, config);
 
-    // Transparent rewrite: output JSON with updatedInput.
-    // Claude Code only applies updatedInput when paired with a
-    // permissionDecision — "allow" auto-approves the rewritten command so it
-    // runs in place of the original. Without one the input is deferred and the
-    // ORIGINAL command runs unmodified, silently defeating every rtk rewrite.
+    // Transparent rewrite: output JSON with updatedInput. Auto-allow
+    // (permissionDecision:"allow") only for rewrites safe to auto-approve —
+    // rtk Allow (exit 0) and python-env path rewrites. For rtk Ask/Default
+    // (exit 3) emit updatedInput WITHOUT permissionDecision so Claude Code
+    // prompts the user (matches rtk's own hook; rtk-ai/rtk#1155).
     // (Only takes effect in permission modes that consult the hook's decision,
-    // i.e. default mode — not bypassPermissions.)
+    // i.e. default mode — not bypassPermissions, where updatedInput is ignored.)
     if (result && result.type === 'rewrite') {
-      const output = JSON.stringify({
-        hookSpecificOutput: {
-          hookEventName: 'PreToolUse',
-          permissionDecision: 'allow',
-          updatedInput: { command: result.command },
-        },
-      });
-      console.log(output);
+      const hookSpecificOutput = {
+        hookEventName: 'PreToolUse',
+        updatedInput: { command: result.command },
+        ...(result.autoAllow ? { permissionDecision: 'allow' } : {}),
+      };
+      console.log(JSON.stringify({ hookSpecificOutput }));
       process.exit(0);
     }
 

--- a/tests/cli/template-content.test.ts
+++ b/tests/cli/template-content.test.ts
@@ -165,3 +165,13 @@ describe('skill templates — savings aggregation', () => {
     expect(content).toContain('older than 24 hours');
   });
 });
+
+describe('hook templates — rtk rewrite auto-allow gate', () => {
+  it('pre-tool-use.ts pairs permissionDecision:allow ONLY when the rewrite is autoAllow', () => {
+    const content = read('hooks/pre-tool-use.ts');
+    // rtk exit 3 (Ask/Default) must NOT be auto-allowed — emit updatedInput
+    // without permissionDecision so Claude Code prompts (rtk-ai/rtk#1155).
+    expect(content).toContain('autoAllow');
+    expect(content).toMatch(/autoAllow\s*\?\s*\{\s*permissionDecision/);
+  });
+});

--- a/tests/cli/template-content.test.ts
+++ b/tests/cli/template-content.test.ts
@@ -56,6 +56,16 @@ describe('agent templates', () => {
     }
     expect(read('agents/scout.md')).toContain('maxTurns: 30');
   });
+
+  it('agent tool lists use get_symbol_source (jcodemunch consolidated get_symbol/get_symbols away in d040bf1)', () => {
+    for (const agent of ['scout', 'code-reviewer', 'spec-reviewer']) {
+      const content = read(`agents/${agent}.md`);
+      expect(content).toContain('mcp__jcodemunch__get_symbol_source');
+      // The exact old pair must be gone; get_symbol_source must not be a
+      // substring of either removed name (it isn't), so this is unambiguous.
+      expect(content).not.toContain('mcp__jcodemunch__get_symbol,mcp__jcodemunch__get_symbols');
+    }
+  });
 });
 
 describe('skill templates — typed dispatch', () => {

--- a/tests/eval/scenarios.ts
+++ b/tests/eval/scenarios.ts
@@ -102,43 +102,47 @@ export interface EvalScenario {
 // Simulates `rtk rewrite <command>` for eval tests.
 // Only rewrites commands that rtk's rules cover.
 
-export function mockRtkRewrite(rtkPath: string, args: string[]): string | null {
+export function mockRtkRewrite(rtkPath: string, args: string[]): { command: string; autoAllow: boolean } | null {
   const command = args[1]; // args = ['rewrite', command]
   if (!command) return null;
 
+  // All simulated rewrites auto-allow (this harness models rtk's Allow path;
+  // exit-3 Ask/Default semantics are unit-tested in tests/router/rewrite.test.ts).
+  const rewrite = (c: string) => ({ command: c, autoAllow: true });
+
   // cat/head/tail → rtk read
   if (/^\s*(cat|head|tail)\s+/.test(command)) {
-    return command.replace(/^\s*(cat|head|tail)\s+/, 'rtk read ');
+    return rewrite(command.replace(/^\s*(cat|head|tail)\s+/, 'rtk read '));
   }
 
   // grep/rg → rtk grep
   if (/^\s*(grep|rg)\s+/.test(command)) {
-    return command.replace(/^\s*(grep|rg)\s+/, 'rtk grep ');
+    return rewrite(command.replace(/^\s*(grep|rg)\s+/, 'rtk grep '));
   }
 
   // find → rtk find
   if (/^\s*find\s+/.test(command)) {
-    return command.replace(/^\s*find\s+/, 'rtk find ');
+    return rewrite(command.replace(/^\s*find\s+/, 'rtk find '));
   }
 
   // fd → rtk find (rtk treats fd as a find synonym)
   if (/^\s*fd\s+/.test(command)) {
-    return command.replace(/^\s*fd\s+/, 'rtk find ');
+    return rewrite(command.replace(/^\s*fd\s+/, 'rtk find '));
   }
 
   // ls → rtk ls
   if (/^\s*ls(\s|$)/.test(command)) {
-    return command.replace(/^\s*ls\s*/, 'rtk ls ');
+    return rewrite(command.replace(/^\s*ls\s*/, 'rtk ls '));
   }
 
   // git → rtk git
   if (/^\s*git\s+/.test(command)) {
-    return command.replace(/^\s*git\s+/, 'rtk git ');
+    return rewrite(command.replace(/^\s*git\s+/, 'rtk git '));
   }
 
   // gh → rtk gh
   if (/^\s*gh\s+/.test(command)) {
-    return command.replace(/^\s*gh\s+/, 'rtk gh ');
+    return rewrite(command.replace(/^\s*gh\s+/, 'rtk gh '));
   }
 
   // No rewrite for everything else (sed, npm, docker, echo, etc.)

--- a/tests/eval/score.test.ts
+++ b/tests/eval/score.test.ts
@@ -25,7 +25,7 @@ describe('scoreResult', () => {
   });
 
   it('scores 0.0 when expected advise but got null (allow)', () => {
-    const expected: ExpectedOutcome = { action: 'advise', tool: 'rtk cat' };
+    const expected: ExpectedOutcome = { action: 'advise', tool: 'rtk read' };
     expect(scoreResult(expected, null)).toBe(0.0);
   });
 

--- a/tests/eval/session-state-eval.test.ts
+++ b/tests/eval/session-state-eval.test.ts
@@ -108,7 +108,7 @@ const SESSION_STATE_SCENARIOS: SessionStateScenario[] = [
         graphifyStats: { nodes: 10, edges: 20, communities: 3, extractedPct: 90, inferredPct: 8, ambiguousPct: 2 },
       });
     },
-    expected: { action: 'advise', tool: 'rtk cat' },
+    expected: { action: 'advise', tool: 'rtk read' },
   },
   {
     id: 'state_graphify_with_python',

--- a/tests/helpers/hook-runner.ts
+++ b/tests/helpers/hook-runner.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'node:url';
 // Absolute path to the locally-installed tsx CLI. Resolving it from this file's
 // own location (not the subprocess cwd) keeps the spawn independent of where the
 // hook runs — the scaffolded tempDir projects under test have no node_modules.
-const TSX_BIN = fileURLToPath(new URL('../../node_modules/.bin/tsx', import.meta.url));
+export const TSX_BIN = fileURLToPath(new URL('../../node_modules/.bin/tsx', import.meta.url));
 import type { Environment, MetricsBaseline, SessionCacheFile } from '../../src/types.js';
 import { sessionCachePath } from '../../src/session/cache.js';
 

--- a/tests/integration/pre-tool-use.test.ts
+++ b/tests/integration/pre-tool-use.test.ts
@@ -4,7 +4,7 @@ import { execSync } from 'node:child_process';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { initCommand } from '../../src/cli/init.js';
-import { runHook } from '../helpers/hook-runner.js';
+import { runHook, TSX_BIN } from '../helpers/hook-runner.js';
 import { SessionCache, sessionCachePath } from '../../src/session/cache.js';
 import type { Environment } from '../../src/types.js';
 
@@ -83,7 +83,7 @@ describe('PreToolUse hook E2E', () => {
   it('handles malformed stdin gracefully', async () => {
     const { spawn } = await import('node:child_process');
     const result = await new Promise<{ exitCode: number }>((resolve) => {
-      const child = spawn('npx', ['tsx', hookPath], {
+      const child = spawn(process.execPath, [TSX_BIN, hookPath], {
         cwd: tempDir,
         stdio: ['pipe', 'pipe', 'pipe'],
       });

--- a/tests/integration/rtk-contract.test.ts
+++ b/tests/integration/rtk-contract.test.ts
@@ -80,7 +80,7 @@ describe.skipIf(!RTK)('rtk rewrite exit-code contract (installed binary)', () =>
     const execRewrite = makeDefaultExecRewrite(line => diagLines.push(line));
     const result = execRewrite(RTK!, ['rewrite', 'git status']);
 
-    expect(result).toBe('rtk git status');
+    expect(result?.command).toBe('rtk git status');
     expect(diagLines).toEqual([]);
   });
 
@@ -90,7 +90,7 @@ describe.skipIf(!RTK)('rtk rewrite exit-code contract (installed binary)', () =>
     const result = execRewrite(RTK!, ['rewrite', 'grep -r "TODO" src/']);
 
     expect(result).not.toBeNull();
-    expect(result!.startsWith('rtk grep')).toBe(true);
+    expect(result!.command.startsWith('rtk grep')).toBe(true);
     expect(diagLines).toEqual([]);
   });
 });

--- a/tests/integration/session-start.test.ts
+++ b/tests/integration/session-start.test.ts
@@ -57,7 +57,7 @@ describe('SessionStart hook E2E', () => {
     const cache = readSessionCache(tempDir);
     expect(cache).not.toBeNull();
     expect(cache!.updatedAt).toBeGreaterThan(0);
-  });
+  }, 60000); // cold run: real detection + indexing + graphify/mcp probes
 
   it('detects environment in cache', async () => {
     const result = await runHook(hookPath, {}, tempDir);

--- a/tests/router/hook.test.ts
+++ b/tests/router/hook.test.ts
@@ -233,7 +233,7 @@ describe('handlePreToolUse', () => {
       { existsCheck: (p) => p === '/project/.venv/bin/pytest' },
     );
     expect(result).not.toBeNull();
-    expect(result).toEqual({ type: 'rewrite', command: '.venv/bin/pytest tests/test_foo.py -v', original: 'pytest tests/test_foo.py -v' });
+    expect(result).toEqual({ type: 'rewrite', command: '.venv/bin/pytest tests/test_foo.py -v', original: 'pytest tests/test_foo.py -v', autoAllow: true });
   });
 
   it('rewrites to uv run when no venv but uv available and .py file in args', () => {
@@ -248,7 +248,7 @@ describe('handlePreToolUse', () => {
       { existsCheck: () => false },
     );
     expect(result).not.toBeNull();
-    expect(result).toEqual({ type: 'rewrite', command: 'uv run pytest tests/test_foo.py -v', original: 'pytest tests/test_foo.py -v' });
+    expect(result).toEqual({ type: 'rewrite', command: 'uv run pytest tests/test_foo.py -v', original: 'pytest tests/test_foo.py -v', autoAllow: true });
   });
 
   it('does not rewrite when no .py file in command', () => {
@@ -388,7 +388,7 @@ describe('handlePreToolUse with file-backed cache (long-running session)', () =>
 
     // A later hook invocation loads the cache from disk
     const cache = new SessionCache(testCwd);
-    const execRewrite = vi.fn(() => 'rtk grep -r pattern .');
+    const execRewrite = vi.fn(() => ({ command: 'rtk grep -r pattern .', autoAllow: true }));
     const result = handlePreToolUse(
       'Bash',
       { command: 'grep -r pattern .' },
@@ -403,6 +403,7 @@ describe('handlePreToolUse with file-backed cache (long-running session)', () =>
       type: 'rewrite',
       command: 'rtk grep -r pattern .',
       original: 'grep -r pattern .',
+      autoAllow: true,
     });
   });
 });

--- a/tests/router/rewrite.test.ts
+++ b/tests/router/rewrite.test.ts
@@ -8,19 +8,20 @@ import type { RewriteResult } from '../../src/types.js';
 
 const mockRewriteSuccess: ExecRewriteFn = (_rtkPath, args) => {
   const command = args[1];
-  if (/^(cat|head|tail)\s+/.test(command)) return command.replace(/^(cat|head|tail)\s+/, 'rtk read ');
-  if (/^grep\s+/.test(command)) return command.replace(/^grep\s+/, 'rtk grep ');
-  if (/^rg\s+/.test(command)) return command.replace(/^rg\s+/, 'rtk grep ');
-  if (/^find\s+/.test(command)) return command.replace(/^find\s+/, 'rtk find ');
-  if (/^git\s+/.test(command)) return command.replace(/^git\s+/, 'rtk git ');
-  if (/^ls(\s|$)/.test(command)) return command.replace(/^ls\s*/, 'rtk ls ');
-  if (/^gh\s+/.test(command)) return command.replace(/^gh\s+/, 'rtk gh ');
+  const rewrite = (c: string) => ({ command: c, autoAllow: true });
+  if (/^(cat|head|tail)\s+/.test(command)) return rewrite(command.replace(/^(cat|head|tail)\s+/, 'rtk read '));
+  if (/^grep\s+/.test(command)) return rewrite(command.replace(/^grep\s+/, 'rtk grep '));
+  if (/^rg\s+/.test(command)) return rewrite(command.replace(/^rg\s+/, 'rtk grep '));
+  if (/^find\s+/.test(command)) return rewrite(command.replace(/^find\s+/, 'rtk find '));
+  if (/^git\s+/.test(command)) return rewrite(command.replace(/^git\s+/, 'rtk git '));
+  if (/^ls(\s|$)/.test(command)) return rewrite(command.replace(/^ls\s*/, 'rtk ls '));
+  if (/^gh\s+/.test(command)) return rewrite(command.replace(/^gh\s+/, 'rtk gh '));
   return null;
 };
 
 const mockRewriteNone: ExecRewriteFn = () => null;
 
-const mockRewriteIdentical: ExecRewriteFn = (_rtkPath, args) => args[1];
+const mockRewriteIdentical: ExecRewriteFn = (_rtkPath, args) => ({ command: args[1], autoAllow: true });
 
 // ── makeDefaultExecRewrite diagnostics ──
 
@@ -35,7 +36,7 @@ describe('makeDefaultExecRewrite diagnostics', () => {
     const writeDiag = vi.fn();
     const rewrite = makeDefaultExecRewrite(writeDiag, () => 'rtk grep foo\n');
 
-    expect(rewrite('/usr/bin/rtk', ['rewrite', 'grep foo'])).toBe('rtk grep foo');
+    expect(rewrite('/usr/bin/rtk', ['rewrite', 'grep foo'])).toEqual({ command: 'rtk grep foo', autoAllow: true });
     expect(writeDiag).not.toHaveBeenCalled();
   });
 
@@ -49,22 +50,21 @@ describe('makeDefaultExecRewrite diagnostics', () => {
   });
 
   // rtk rewrite exit-code protocol (src/hooks/rewrite_cmd.rs in rtk):
-  //   0 + stdout  rewrite, safe to auto-allow
-  //   1           no RTK equivalent
-  //   2           deny rule matched
-  //   3 + stdout  "Ask" — rewrite valid, but the hook must not auto-allow.
-  // rig emits updatedInput paired with permissionDecision:"allow", which
-  // auto-approves the rewritten command — so an exit-3 rewrite is used exactly
-  // like an exit-0 rewrite. Field bug: rtk maps git commands to Ask (Default
-  // verdict), so dropping exit-3 output silently lost every git rewrite.
-  it('uses the stdout rewrite on exit 3 (rtk Ask verdict) without diagnostics', () => {
+  //   0 + stdout  rewrite, safe to auto-allow              → autoAllow:true
+  //   1           no RTK equivalent                         → null
+  //   2           deny rule matched                         → null
+  //   3 + stdout  "Ask"/Default — rewrite valid, must NOT  → autoAllow:false
+  //               auto-allow (rtk 0.36+ maps unrated cmds here; rtk-ai/rtk#1155)
+  // rig emits updatedInput WITHOUT permissionDecision for exit 3 so Claude
+  // Code prompts the user (matches rtk's own process_claude_payload).
+  it('returns the exit-3 (rtk Ask/Default) rewrite with autoAllow:false', () => {
     const writeDiag = vi.fn();
     const rewrite = makeDefaultExecRewrite(
       writeDiag,
       execError({ status: 3, stdout: 'rtk git status' }),
     );
 
-    expect(rewrite('/usr/bin/rtk', ['rewrite', 'git status'])).toBe('rtk git status');
+    expect(rewrite('/usr/bin/rtk', ['rewrite', 'git status'])).toEqual({ command: 'rtk git status', autoAllow: false });
     expect(writeDiag).not.toHaveBeenCalled();
   });
 
@@ -75,7 +75,7 @@ describe('makeDefaultExecRewrite diagnostics', () => {
       execError({ status: 3, stdout: Buffer.from('rtk git log --oneline\n') }),
     );
 
-    expect(rewrite('/usr/bin/rtk', ['rewrite', 'git log --oneline'])).toBe('rtk git log --oneline');
+    expect(rewrite('/usr/bin/rtk', ['rewrite', 'git log --oneline'])).toEqual({ command: 'rtk git log --oneline', autoAllow: false });
     expect(writeDiag).not.toHaveBeenCalled();
   });
 
@@ -143,7 +143,7 @@ describe('makeDefaultExecRewrite diagnostics', () => {
 describe('tryRtkRewrite', () => {
   it('returns rewritten command when exec returns a different string', () => {
     const result = tryRtkRewrite('cat file.ts', '/usr/bin/rtk', mockRewriteSuccess);
-    expect(result).toBe('rtk read file.ts');
+    expect(result).toEqual({ command: 'rtk read file.ts', autoAllow: true });
   });
 
   it('returns null when exec returns null (no rewrite)', () => {
@@ -163,17 +163,17 @@ describe('tryRtkRewrite', () => {
 
   it('rewrites grep to rtk grep', () => {
     const result = tryRtkRewrite('grep -r "TODO" src/', '/usr/bin/rtk', mockRewriteSuccess);
-    expect(result).toBe('rtk grep -r "TODO" src/');
+    expect(result).toEqual({ command: 'rtk grep -r "TODO" src/', autoAllow: true });
   });
 
   it('rewrites find to rtk find', () => {
     const result = tryRtkRewrite('find . -name "*.ts"', '/usr/bin/rtk', mockRewriteSuccess);
-    expect(result).toBe('rtk find . -name "*.ts"');
+    expect(result).toEqual({ command: 'rtk find . -name "*.ts"', autoAllow: true });
   });
 
   it('rewrites git to rtk git', () => {
     const result = tryRtkRewrite('git status', '/usr/bin/rtk', mockRewriteSuccess);
-    expect(result).toBe('rtk git status');
+    expect(result).toEqual({ command: 'rtk git status', autoAllow: true });
   });
 
   it('does not rewrite sed -i', () => {

--- a/tests/router/rules.test.ts
+++ b/tests/router/rules.test.ts
@@ -39,13 +39,14 @@ describe('getDefaultRules', () => {
     expect(findRule!.resolutions.jcodemunch).toBeDefined();
   });
 
-  it('file_read rules advise rtk cat when rtk available', () => {
+  it('file_read rules advise rtk read when rtk available', () => {
     const rules = getDefaultRules();
     const catRule = rules.find(r => r.intent === 'file_read');
     expect(catRule).toBeDefined();
     const rtkRes = catRule!.resolutions.rtk as { action: string; tool: string };
     expect(rtkRes.action).toBe('advise');
-    expect(rtkRes.tool).toBe('rtk cat');
+    // rtk removed `cat` (now `rtk read`); the file_read advisory must name the real command.
+    expect(rtkRes.tool).toBe('rtk read');
   });
 });
 
@@ -203,6 +204,16 @@ describe('native tool rules', () => {
     const match = findMatchingRule('Bash', { command: 'rtk cat /some/file.ts' }, rules);
     expect(match).toBeDefined();
     expect(match!.intent).toBe('rtk_cat_code');
+  });
+
+  it('matches rtk read and rtk smart on code files (rtk cat was removed; read/smart are the real code-reading commands)', () => {
+    for (const cmd of ['rtk read /some/file.ts', 'rtk smart /some/file.ts']) {
+      const match = findMatchingRule('Bash', { command: cmd }, rules);
+      expect(match, cmd).toBeDefined();
+      expect(match!.intent).toBe('rtk_cat_code');
+    }
+    // non-code files are never blocked
+    expect(findMatchingRule('Bash', { command: 'rtk read /some/readme.md' }, rules)).toBeUndefined();
   });
 
   it('does not match rtk cat on non-code file', () => {

--- a/tests/router/rules.test.ts
+++ b/tests/router/rules.test.ts
@@ -158,6 +158,11 @@ describe('native tool rules', () => {
     // No rtk or claudeTool resolution — agent is already on the native tool
     expect(rule!.resolutions.rtk).toBeUndefined();
     expect(rule!.resolutions.claudeTool).toBeUndefined();
+    // jcodemunch consolidated get_symbol/get_symbols → get_symbol_source (d040bf1).
+    // \b matches the bare trailing 'get_symbol' but not 'get_symbol_source'
+    // (no word boundary between 'l' and '_'), so this is a precise old-vs-new check.
+    expect(rule!.resolutions.jcodemunch.tool).toContain('get_symbol_source');
+    expect(rule!.resolutions.jcodemunch.tool).not.toMatch(/get_symbol\b/);
   });
 
   it('matches Grep tool to native_grep rule', () => {

--- a/tests/scout/scout-template.test.ts
+++ b/tests/scout/scout-template.test.ts
@@ -41,8 +41,8 @@ describe('scout agent template', () => {
     expect(template).toMatch(/CLI fallback|parse.*graph\.json|graph\.json.*directly/i);
   });
 
-  it('treats .rebuild.lock as the building-state indicator', () => {
-    expect(template).toContain('.rebuild.lock');
+  it('does not reference the removed .rebuild.lock (graphify stopped writing it)', () => {
+    expect(template).not.toContain('.rebuild.lock');
   });
 
   it('requires numeric symbol counts in the output', () => {

--- a/tests/session/environment.test.ts
+++ b/tests/session/environment.test.ts
@@ -828,7 +828,9 @@ describe('detectGraphify', () => {
     expect(env.graphifyGraphPath).toBe('graphify-out/graph.json');
   });
 
-  it('returns building when .rebuild.lock present and no valid graph', () => {
+  // graphify 0.4.31 writes no .rebuild.lock — a leftover lock must not affect
+  // state. Graph validity alone determines ready/absent.
+  it('ignores a stray .rebuild.lock when no valid graph exists (→ absent)', () => {
     const exec = makeExec({ 'which graphify': '/usr/local/bin/graphify' });
     const existsCheck = (path: string) => path === '/fake/cwd/graphify-out/.rebuild.lock';
 
@@ -836,27 +838,11 @@ describe('detectGraphify', () => {
       '/fake/cwd', exec, existsCheck, () => undefined,
       (path) => (path.endsWith('.rebuild.lock') ? new Date(2000) : undefined),
     );
-    expect(result.state).toBe('building');
+    expect(result.state).toBe('absent');
     expect(result._cliFound).toBe(true);
   });
 
-  it('returns ready when graph.json is newer than .rebuild.lock (stale lock from completed build)', () => {
-    // graphify leaves lock files behind after completed builds
-    const exec = makeExec({ 'which graphify': '/usr/local/bin/graphify' });
-    const existsCheck = (path: string) =>
-      path === '/fake/cwd/graphify-out/graph.json' ||
-      path === '/fake/cwd/graphify-out/.rebuild.lock';
-    const statCheck = (path: string) =>
-      path === '/fake/cwd/graphify-out/graph.json' ? { size: 5000 } : undefined;
-    const mtimeCheck = (path: string) =>
-      path.endsWith('graph.json') ? new Date(5000) : new Date(1000);
-
-    const result = detectGraphify('/fake/cwd', exec, existsCheck, statCheck, mtimeCheck);
-    expect(result.state).toBe('ready');
-    expect(result.graphPath).toBe('graphify-out/graph.json');
-  });
-
-  it('returns building when .rebuild.lock is newer than graph.json (active rebuild)', () => {
+  it('ignores a .rebuild.lock newer than graph.json — a valid graph is ready', () => {
     const exec = makeExec({ 'which graphify': '/usr/local/bin/graphify' });
     const existsCheck = (path: string) =>
       path === '/fake/cwd/graphify-out/graph.json' ||
@@ -867,7 +853,8 @@ describe('detectGraphify', () => {
       path.endsWith('graph.json') ? new Date(1000) : new Date(5000);
 
     const result = detectGraphify('/fake/cwd', exec, existsCheck, statCheck, mtimeCheck);
-    expect(result.state).toBe('building');
+    expect(result.state).toBe('ready');
+    expect(result.graphPath).toBe('graphify-out/graph.json');
   });
 
   it('captures the CLI version when the probe succeeds', () => {

--- a/tests/session/environment.test.ts
+++ b/tests/session/environment.test.ts
@@ -834,25 +834,20 @@ describe('detectGraphify', () => {
     const exec = makeExec({ 'which graphify': '/usr/local/bin/graphify' });
     const existsCheck = (path: string) => path === '/fake/cwd/graphify-out/.rebuild.lock';
 
-    const result = detectGraphify(
-      '/fake/cwd', exec, existsCheck, () => undefined,
-      (path) => (path.endsWith('.rebuild.lock') ? new Date(2000) : undefined),
-    );
+    const result = detectGraphify('/fake/cwd', exec, existsCheck, () => undefined);
     expect(result.state).toBe('absent');
     expect(result._cliFound).toBe(true);
   });
 
-  it('ignores a .rebuild.lock newer than graph.json — a valid graph is ready', () => {
+  it('a valid graph is ready even when a .rebuild.lock is present (lock ignored)', () => {
     const exec = makeExec({ 'which graphify': '/usr/local/bin/graphify' });
     const existsCheck = (path: string) =>
       path === '/fake/cwd/graphify-out/graph.json' ||
       path === '/fake/cwd/graphify-out/.rebuild.lock';
     const statCheck = (path: string) =>
       path === '/fake/cwd/graphify-out/graph.json' ? { size: 5000 } : undefined;
-    const mtimeCheck = (path: string) =>
-      path.endsWith('graph.json') ? new Date(1000) : new Date(5000);
 
-    const result = detectGraphify('/fake/cwd', exec, existsCheck, statCheck, mtimeCheck);
+    const result = detectGraphify('/fake/cwd', exec, existsCheck, statCheck);
     expect(result.state).toBe('ready');
     expect(result.graphPath).toBe('graphify-out/graph.json');
   });

--- a/tests/session/start.test.ts
+++ b/tests/session/start.test.ts
@@ -192,6 +192,7 @@ describe('handleSessionStart', () => {
     expect(output).toContain('WARNING');
     expect(output).toContain('rtk');
     expect(output).toContain('install');
+    expect(output).toContain('rtk-ai/rtk');
   });
 
   it('warns when jcodemunch was not detected', async () => {
@@ -205,6 +206,7 @@ describe('handleSessionStart', () => {
     expect(output).toContain('WARNING');
     expect(output).toContain('jcodemunch');
     expect(output).toContain('install');
+    expect(output).toContain('jgravelle/jcodemunch-mcp');
   });
 
   it('warns when both tools are not installed', async () => {


### PR DESCRIPTION
## Summary

Release 1 of the dependency-sync work: makes rig 0.7.3 correct and truthful against the current state of its five dependencies (rtk, jcodemunch-mcp, graphify, headroom, superpowers), all of which have moved significantly. Driven by a deep scout of the upstream sources plus an **adversarial verification pass** — five read-only verifiers tried to falsify every load-bearing claim against the actual source before any code was written (methodology + per-task table in [`docs/plans/release-1-stabilize.md`](docs/plans/release-1-stabilize.md)).

## Changes

| Area | Fix |
|---|---|
| **A1 — rtk exit-3 least-privilege** | rtk 0.36+ maps unrated commands to `Default`→exit 3 (rtk-ai/rtk#1155); rig was auto-allowing ~every rewrite. Threaded `autoAllow` through `ExecRewriteFn`→`RewriteResult`→emission: exit-0/python → `permissionDecision:"allow"`; exit-3 → `updatedInput` **without** it (prompt). Matches rtk's own `process_claude_payload`. |
| **A2 — jcodemunch rename** | `get_symbol`/`get_symbols` → `get_symbol_source` (consolidated in jcodemunch `d040bf1`); the stale names in scout/code-reviewer/spec-reviewer tool lists silently dropped symbol-source retrieval when `--broad-permissions` was off. |
| **A3 — rtk `cat` removed** | `rtk_cat_code` rule widened to `cat\|read\|smart` (rtk removed `cat`; code reading is now `rtk read`/`rtk smart`); file_read advisory fixed. Intent name kept for `.harness.yaml` config stability. |
| **A4 — graphify lockfile** | Removed dead `.rebuild.lock` detection (graphify 0.4.31 writes no lockfile); graph validity alone determines ready/absent. |
| **B1/B2/B3 — docs** | graphify "6000-file recursion" myth removed; repo URLs updated (`franklywatson/rtk`→`rtk-ai/rtk`, `franklywatson/jcodemunch`→`jgravelle/jcodemunch-mcp`, incl. the runtime install-warning URLs in `start.ts`); headroom `wrap`/rtk conflict reworded (rtk is now opt-in by default on recent headroom). |
| **test infra** | Fixed the long-"flaky" hook-E2E failures — root cause was `tsx` (a declared devDependency) **missing from node_modules**, so the local-binary spawn hit a non-existent path. Exported `TSX_BIN` + raised the session-start cold-run timeout (completes #60). |

## Deferred

- **B4 (bare-`jcodemunch` CLI probe)** — verification showed it's a *tested detection fallback*, not dead code; removing it is behavioral + high-ripple for ~no benefit. Left as a defensive fallback.

## Notes / follow-ups

- **Open verification item (non-blocking):** A1 rests on Claude Code prompting the user *with the rewritten command* when `updatedInput` is emitted without `permissionDecision`. Verified against rtk's source (its `process_claude_payload` ships exactly this in production) but not yet empirically confirmed against a live Claude Code session. Safe either way — worst case it prompts on the *original* command (correct security-wise, just not token-optimal) — and moot once Release 2 (Workstream C, `rtk hook claude` delegation) forwards rtk's own output verbatim. Flagged as Task-3's evidence step in the plan.
- Full suite **1334/1334 green**; `npm run lint` clean. Both a spec-compliance and a code-quality review pass (review fixes folded into `47e6d2d`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
