### PR TITLE
docs: document Release 2 features (typed-agent enforcement, superpowers detection, rtk global-hook)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,9 @@ npm run lint       # Type-check (tsc --noEmit)
 
 Four-layer middleware:
 
-1. **Tool Router** (`src/router/`) -- PreToolUse hook: intent classification, priority resolution (rtk > jcodemunch > claudeTool > fallback > allow), test-scope and branch-discipline checks
+1. **Tool Router** (`src/router/`) -- PreToolUse hook: intent classification, priority
+   resolution (rtk > jcodemunch > claudeTool > fallback > allow), test-scope,
+   branch-discipline, and typed-agent enforcement checks
 2. **Enforcement** (`src/enforcement/`) -- PostToolUse hook, composable pipeline: stale tests -> constitutional -> zero-defect
 3. **Skill Chain** (`src/skills/`) -- Phase tracker validates transitions (brain+ -> plan+ -> tdd+|sdd+ -> verify+ -> review+; debug+ standalone)
 4. **Scout** (`src/scout/`) -- Cross-repo indexing, CodebaseMap formatter, TTL cache
@@ -33,7 +35,7 @@ All types in `src/types.ts`. Important ones:
 - `EnforcementViolation` -- { level, message }; severity is structural, never sniffed from message text
 - `Resolution` -- allow, advise, block
 - `ToolRule` -- match pattern + resolutions per environment priority
-- `WorkflowRules` -- branch_discipline, protected_branches, isolation_strategy
+- `WorkflowRules` -- branch_discipline, protected_branches, isolation_strategy, typed_agent_enforcement
 - `CodebaseMap` -- structure, entryPoints, keyExports, dependencies, languages, symbols
 - `HarnessConfig` -- nested rules with enforcement levels
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ data as a separate **context layer** line:
   jcodemunch: 85K saved (23 queries, 150M total all-time)
   headroom: 40K saved (context layer — 42 requests, 40% compression, 78% cache hits; not summed with tool-layer savings)
   graphify: 913 nodes, 1349 edges, 62 communities (100% EXTRACTED, 0% INFERRED, 0% AMBIGUOUS)
+  superpowers: installed (v6.2.0)
 ```
 
 `/savings` reports every layer it detects side by side — rtk and jcodemunch on
@@ -244,6 +245,7 @@ rules:
     protected_branches: [master, main]
     isolation_strategy: auto   # auto | branch | worktree — auto picks worktree when the tree is dirty
     team_execution: offer      # offer | auto | never — parallel teammates for independent tasks (needs experimental agent-teams)
+    typed_agent_enforcement: advise  # block | advise | silent — during sdd+/review+, steer general-purpose dispatches to typed agents
 ```
 
 Each enforcement rule can be `block` (hook exits nonzero), `advise` (advisory

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -93,6 +93,11 @@ Emitted via hook protocol: advisory -> additionalContext JSON (exit 0)
 
 Git `commit`/`push` interception is not an intent type — it is handled by the
 branch-discipline step (Step 1.6, see "Branch discipline (commit-time)" below).
+A separate Step 1.7 check (`src/router/typed-agent.ts`, `checkTypedAgentDispatch`)
+intercepts `Task`/`Agent` dispatches during `sdd+`/`review+`: a missing or
+`general-purpose` `subagent_type` is steered to a typed agent (advise/block per
+`rules.workflow.typed_agent_enforcement`). superpowers' subagent-driven-development
+is general-purpose-native, so without this gate the typed agents are silently bypassed.
 
 ### Python environment detection
 
@@ -548,13 +553,21 @@ Loads `.harness.yaml` with layered merge (base config + local override). `getEnf
 
 ### Session (`src/session/`)
 
-`detectEnvironment()` checks for rtk, jcodemunch, graphify, and other tools via
+`detectEnvironment()` checks for rtk, jcodemunch, graphify, superpowers, and other tools via
 injectable `ExecFn`. `SessionCache` with a 4-hour env TTL persists to
 `/tmp/rig-session-{hash}.json` (hash of cwd + session id) for cross-process
 state sharing between hook invocations. Environment detection results, edited
 file tracking, phase, metrics baseline (including per-project graphify stats
 keyed by directory path), tool call counters, and a `toolsWarned` flag all
 persist. Deleting `/tmp/rig-session-*.json` forces immediate re-detection.
+
+**superpowers detection** (`superpowers.ts`): reads Claude Code's plugin registry
+(`~/.claude/plugins/installed_plugins.json`) for a `superpowers@*` key; session
+start reports `superpowers: installed (vX)` or warns with the `/plugin install`
+command (the skill chain requires it). **rtk global-hook deconfliction**
+(`rtk-global-hook.ts`): if rtk's own global PreToolUse hook is also installed
+(`~/.claude/settings.json`), session start hints removal — it double-rewrites
+commands rig's project hook already rewrites.
 
 **jcodemunch detection** (`environment.ts` + `claude-config.ts`) resolves a
 working transport in priority order:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -213,6 +213,7 @@ rules:
     protected_branches: [master, main]
     isolation_strategy: auto     # auto | branch | worktree
     team_execution: offer        # offer | auto | never — parallel teammates for independent tasks (needs the experimental agent-teams flag)
+    typed_agent_enforcement: advise  # block | advise | silent — during sdd+/review+, steer general-purpose dispatches to typed agents
 ```
 
 **Branch discipline (`rules.workflow`):** when you commit or push on a branch


### PR DESCRIPTION
## Summary

Docs-only follow-up to Release 2 (#65, merged). The R2-DOCS task did the present-state rework + version refs but **missed documenting the new Release 2 capabilities**. This closes that gap.

## Changes

- **README + getting-started** `.harness.yaml` config examples: add `typed_agent_enforcement: advise` (was missing alongside `branch_discipline`/`team_execution`).
- **README** session-start panel example: add the `superpowers: installed (vX)` line.
- **architecture.md** Layer 1 (router): document the Step 1.7 typed-agent gate (`checkTypedAgentDispatch`, `rules.workflow.typed_agent_enforcement`).
- **architecture.md** session layer: document **superpowers detection** (`installed_plugins.json`) + **rtk global-hook deconfliction** (`detectRtkGlobalHook`); add `superpowers` to the `detectEnvironment()` tool list.
- **CLAUDE.md**: add typed-agent enforcement to the Tool Router description + `typed_agent_enforcement` to `WorkflowRules`.

Docs-only — no code change, no test change. `markdownlint` clean (0 errors). A `docs:` commit, so it won't re-trigger a version bump (the `0.8.0` release-please PR #66 is separate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
