### PR TITLE
feat(router): jcodemunch divert for high-value Bash reads/searches (Step 2.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Rig installs the cockpit into a Claude Code project:
 - **Tool Router** -- intercepts shell commands via PreToolUse hooks, transparently rewrites
   `grep`/`find`/`cat`/`git` to rtk when available (via `updatedInput` paired with `permissionDecision: "allow"`,
   default permission mode only — `bypassPermissions` ignores the rewrite);
-  advises on native Read/Grep/Glob when jcodemunch is indexed; blocks `sed -i` and rtk code-reading (`rtk read`/`rtk smart`) on code files
+  advises on native Read/Grep/Glob when jcodemunch is indexed; diverts high-value Bash reads/searches (big-file `cat`, identifier `grep`) to jcodemunch instead of rtk (`tool_routing.jcodemunch_divert`); blocks `sed -i` and rtk code-reading (`rtk read`/`rtk smart`) on code files
 - **Enforcement Pipeline** -- PostToolUse hooks check stale tests, constitutional rules (real dependencies in stack/E2E tests),
   and zero-defect status (with pre-existing failure classification); a PreToolUse test-scope check redirects full-suite runs
   to scoped tests during `tdd+`/`sdd+`, and configurable branch/PR discipline with worktree-aware isolation advice guards
@@ -240,6 +240,7 @@ rules:
     native_grep: advise        # advise jcodemunch for Grep
     native_glob: advise        # advise jcodemunch for Glob on code patterns
     rtk_cat_code: block        # block rtk read/smart on code files
+    jcodemunch_divert: advise  # advise | block | silent — divert high-value Bash shapes (big cat, identifier grep) to jcodemunch instead of rtk
   workflow:
     branch_discipline: advise  # block | advise | silent — git commit/push on a protected branch
     protected_branches: [master, main]

--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ Rig installs the cockpit into a Claude Code project:
 - **Tool Router** -- intercepts shell commands via PreToolUse hooks, transparently rewrites
   `grep`/`find`/`cat`/`git` to rtk when available (via `updatedInput` paired with `permissionDecision: "allow"`,
   default permission mode only — `bypassPermissions` ignores the rewrite);
-  advises on native Read/Grep/Glob when jcodemunch is indexed; diverts high-value Bash reads/searches (big-file `cat`, identifier `grep`) to jcodemunch instead of rtk (`tool_routing.jcodemunch_divert`); blocks `sed -i` and rtk code-reading (`rtk read`/`rtk smart`) on code files
+  advises on native Read/Grep/Glob when jcodemunch is indexed;
+  diverts high-value Bash reads/searches (big-file `cat`, identifier `grep`) to jcodemunch instead of rtk
+  (`tool_routing.jcodemunch_divert`); blocks `sed -i` and rtk code-reading (`rtk read`/`rtk smart`) on code files
 - **Enforcement Pipeline** -- PostToolUse hooks check stale tests, constitutional rules (real dependencies in stack/E2E tests),
   and zero-defect status (with pre-existing failure classification); a PreToolUse test-scope check redirects full-suite runs
   to scoped tests during `tdd+`/`sdd+`, and configurable branch/PR discipline with worktree-aware isolation advice guards

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,6 +55,14 @@ PreToolUse Hook (handlePreToolUse)
   +--------------------------------------+
      |
   +--------------------------------------+
+  | Step 2.5: jcodemunch divert          |
+  |   high-value Bash shape?             |
+  |   (big cat / identifier grep)        |
+  |   jm ready & not silent -> ADVISE jm |
+  |   else -> fall through to Step 3     |
+  +--------------------------------------+
+     |
+  +--------------------------------------+
   | Step 3: rtk transparent rewrite      |
   |   rtk available? -> redirect rtk     |
   +--------------------------------------+
@@ -90,6 +98,19 @@ Emitted via hook protocol: advisory -> additionalContext JSON (exit 0)
 | `file_read` | Bash `cat`, `head`, `tail` | rtk or jcodemunch `get_symbol` |
 | `file_modify` | Bash `sed -i`, `awk >` | Block, redirect to Edit tool |
 | `scout_explore` | `Agent` tool dispatching the `Explore` subagent | Advise scout subagent (jcodemunch + graphify) |
+
+**Step 2.5 — jcodemunch divert (pre-rewrite).** Before the rtk rewrite (Step 3),
+a pure heuristic (`src/router/jcodemunch-value.ts`, `scoreJcodemunchValue`)
+scores each non-compound Bash command. A high-value shape diverts to a
+jcodemunch advisory *instead of* the rtk rewrite: a big-file `cat` of a code
+file above `tool_routing.jcodemunch_divert_outline_bytes` (default 8192 B) →
+`get_file_outline`; a single-identifier `grep`/`rg` (lowercase-bearing, no regex
+metacharacters, not multi-`-e`, not `-l`) → `search_symbols`. Level follows
+`tool_routing.jcodemunch_divert` (advise | block | silent); suppressed advise
+turns and silent fall through to rtk so the cheap path still runs. The divert
+advisory cycle is shorter than the generic one (`DIVERT_READVISE_PERIOD = 3`,
+keyed per shape). This is what surfaces jcodemunch in Bash-heavy sessions where
+rtk would otherwise short-circuit every read/search.
 
 Git `commit`/`push` interception is not an intent type — it is handled by the
 branch-discipline step (Step 1.6, see "Branch discipline (commit-time)" below).

--- a/docs/superpowers/plans/2026-08-05-jcodemunch-nuanced-advisory.md
+++ b/docs/superpowers/plans/2026-08-05-jcodemunch-nuanced-advisory.md
@@ -288,6 +288,22 @@ describe('scoreJcodemunchValue — Shape A (cat outline)', () => {
     expect(scoreJcodemunchValue('find . -name "*.ts"', opts())).toBeNull();
     expect(scoreJcodemunchValue('git status', opts())).toBeNull();
   });
+
+  it('diverts cat -n (line-number flag does not change whole-file semantics)', () => {
+    expect(scoreJcodemunchValue('cat -n /x/big.ts', opts({ size: 20000 }))).toMatchObject({ shape: 'outline' });
+  });
+
+  it('does not divert at exactly the byte threshold (strict >)', () => {
+    expect(scoreJcodemunchValue('cat /x/big.ts', opts({ size: 8192 }))).toBeNull();
+  });
+
+  it('diverts one byte above the threshold', () => {
+    expect(scoreJcodemunchValue('cat /x/big.ts', opts({ size: 8193 }))).toMatchObject({ shape: 'outline' });
+  });
+
+  it('does not divert a quoted path with spaces (quote-naive parse — known v1 limitation)', () => {
+    expect(scoreJcodemunchValue('cat "src/my file.ts"', opts({ size: 20000 }))).toBeNull();
+  });
 });
 ```
 
@@ -419,6 +435,14 @@ describe('scoreJcodemunchValue — Shape B (identifier grep symbol search)', () 
   it('does not divert --files-with-matches (-l)', () => {
     expect(scoreJcodemunchValue('grep -rl FooBar .', opts())).toBeNull();
   });
+
+  it('diverts --regexp=PATTERN (the = form)', () => {
+    expect(scoreJcodemunchValue('grep --regexp=FooBar src/', opts())).toMatchObject({ shape: 'symbol', target: 'FooBar' });
+  });
+
+  it('does not divert multiple -e patterns (an OR query search_symbols cannot express)', () => {
+    expect(scoreJcodemunchValue('grep -e Foo -e Bar baz.ts', opts())).toBeNull();
+  });
 });
 ```
 
@@ -443,14 +467,25 @@ export function scoreJcodemunchValue(command: string, opts: DivertOptions): Dive
   // Shape B — symbol-shaped search (grep / rg, single identifier token)
   if (binary === 'grep' || binary === 'rg' || binary === 'greprx') {
     if (flags.has('-l') || flags.has('--files-with-matches')) return null;
-    // Pattern is the value of -e/--regexp if present, else the first positional.
-    let pattern: string | undefined;
+    // Collect every pattern source: space form (-e P / --regexp P) and the
+    // attached `=` form (--regexp=P). Multiple patterns form an OR query that
+    // search_symbols can't express → stay rtk (no divert).
     const tokens = command.trim().split(/\s+/);
-    const eIdx = tokens.findIndex(t => t === '-e' || t === '--regexp');
-    if (eIdx >= 0) pattern = tokens[eIdx + 1];
-    if (!pattern) pattern = positional[0];
-    if (!pattern) return null;
-    if (REGEX_METACHAR.test(pattern)) return null;   // regex/literal scan → rtk
+    const patterns: string[] = [];
+    for (let i = 1; i < tokens.length; i++) {
+      const t = tokens[i];
+      if (t === '-e' || t === '--regexp') {
+        const v = tokens[i + 1];
+        if (v !== undefined && !v.startsWith('-')) patterns.push(v);
+      } else if (t.startsWith('--regexp=')) {
+        patterns.push(t.slice('--regexp='.length));
+      }
+    }
+    const pattern = patterns.length === 1
+      ? patterns[0]
+      : (patterns.length === 0 ? positional[0] : undefined);
+    if (!pattern) return null;                        // multi-pattern OR, or none → rtk
+    if (REGEX_METACHAR.test(pattern)) return null;    // regex/literal scan → rtk
     if (!IDENT.test(pattern)) return null;            // multi-token / phrase → rtk
     return {
       shape: 'symbol',
@@ -562,6 +597,23 @@ describe('handlePreToolUse — jcodemunch divert (Step 2.5)', () => {
     }) as { type?: string };
     expect(result?.type).toBe('rewrite');
   });
+
+  it('does not divert a compound command (Step 2.5 skipped → pass-through)', () => {
+    const cache = new SessionCache();
+    cache.setEnvironment(makeEnv({ rtkAvailable: true, rtkPath: '/usr/bin/rtk', jcodemunchAvailable: true, jcodemunchCwdIndexed: true }));
+    const result = handlePreToolUse('Bash', { command: 'cat /x/big.ts && cat /y/big.ts' }, cache, config, undefined, { existsCheck: bigExists, statCheck: bigStat });
+    expect(result).toBeNull();
+  });
+
+  it('block level is never suppressed (blocks on every call)', () => {
+    const cache = new SessionCache();
+    cache.setEnvironment(makeEnv({ rtkAvailable: true, rtkPath: '/usr/bin/rtk', jcodemunchAvailable: true, jcodemunchCwdIndexed: true }));
+    const blockConfig = { ...config, rules: { ...config.rules, tool_routing: { ...config.rules.tool_routing, jcodemunch_divert: 'block' as const } } };
+    const first = handlePreToolUse('Bash', { command: 'cat /x/big.ts' }, cache, blockConfig, undefined, { existsCheck: bigExists, statCheck: bigStat });
+    const second = handlePreToolUse('Bash', { command: 'cat /x/big.ts' }, cache, blockConfig, undefined, { existsCheck: bigExists, statCheck: bigStat });
+    expect(first).toMatchObject({ level: 'block' });
+    expect(second).toMatchObject({ level: 'block' });
+  });
 });
 ```
 
@@ -598,8 +650,8 @@ export interface HookOptions {
   if (tool === 'Bash' && typeof args.command === 'string' && !isCompoundCommand(args.command)) {
     if (env.jcodemunchAvailable && env.jcodemunchCwdIndexed) {
       const outlineBytes = config.rules.tool_routing?.jcodemunch_divert_outline_bytes ?? 8192;
-      const exists = resolvedOptions.existsCheck ?? ((p) => { try { return statSync(p).isFile(); return true; } catch { return false; } });
-      const stat = resolvedOptions.statCheck ?? ((p) => { const s = statSync(p); return { size: s.size, isFile: s.isFile() }; });
+      const exists = resolvedOptions.existsCheck ?? ((p) => { try { return existsSync(p); } catch { return false; } });
+      const stat = resolvedOptions.statCheck ?? ((p) => { try { const s = statSync(p); return { size: s.size, isFile: s.isFile() }; } catch { return { size: 0, isFile: false }; } });
       const decision = scoreJcodemunchValue(args.command, { existsCheck: exists, statCheck: stat, outlineBytes });
       if (decision) {
         const level = config.rules.tool_routing?.jcodemunch_divert ?? 'advise';
@@ -612,7 +664,7 @@ export interface HookOptions {
             return {
               level,
               message: [
-                `${prefix} Tool Router: high-value jcodemunch opportunity (${decision.shape})`,
+                `${prefix} Tool Router: high-value jcodemunch opportunity (${decision.shape === 'outline' ? 'big-file outline' : 'symbol search'})`,
                 `advise: use ${decision.jmTool} — ${decision.reason}`,
                 level === 'block'
                   ? 'This operation is blocked by .harness.yaml. Use the recommended tool instead.'
@@ -626,7 +678,7 @@ export interface HookOptions {
   }
 ```
 
-(Use the existing `statSync` import at the top of `hook.ts`; if absent, add `import { statSync } from 'node:fs';`. The `exists`/`stat` defaults must not throw for non-existent paths — guard with try/catch as shown; refine so `exists` is a plain existence check, e.g. `existsSync(p)`, importing `existsSync` too.)
+(Add `import { appendFileSync, statSync, existsSync } from 'node:fs';` to `hook.ts` (only `appendFileSync` is imported today). The default `exists`/`stat` closures must not throw on missing paths — both are wrapped in try/catch; `stat` returns `{ size: 0, isFile: false }` on failure so a missing file reads as "not a code file / below threshold" rather than throwing.)
 
 - [ ] **Step 4: Run tests to verify they pass**
 

--- a/docs/superpowers/plans/2026-08-05-jcodemunch-nuanced-advisory.md
+++ b/docs/superpowers/plans/2026-08-05-jcodemunch-nuanced-advisory.md
@@ -1,0 +1,686 @@
+# Nuanced jcodemunch advisory (precision divert) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the router divert high-value Bash read/search commands (big-file `cat`, identifier `grep`) to jcodemunch instead of rewriting them to rtk, with shape-keyed higher-frequency advisory suppression.
+
+**Architecture:** A new pure heuristic module (`src/router/jcodemunch-value.ts`) scores a Bash command for jcodemunch value. A new Step 2.5 in `handlePreToolUse` calls it before the rtk rewrite (Step 3); on a high-value shape it returns a jcodemunch advisory (divert), otherwise it falls through to rtk unchanged. Suppression uses a new `DIVERT_READVISE_PERIOD = 3`, keyed by shape, via an optional `period` param on `shouldAdvise`.
+
+**Tech Stack:** TypeScript, vitest, rig's injectable-`ExecFn`/`existsCheck` pattern (no module mocks).
+
+**Spec:** `docs/superpowers/specs/2026-08-05-jcodemunch-nuanced-advisory-design.md`
+
+## Global Constraints
+
+- TypeScript strict; `npm run lint` (`tsc --noEmit`) must pass.
+- Coverage gate: ≥80% statements/functions/lines, ≥75% branches.
+- No mocks for environment/filesystem — use injectable `existsCheck` / `statCheck` / `execRewrite` seams (project convention; also the `no_mocks: advise` constitutional rule).
+- Severity is structural: advisories carry `level: 'advise' | 'block'`; never sniff message text.
+- Conventional commit messages (`feat:` / `test:` / `docs:`).
+
+## Constitutional Rules for This Plan
+
+From active `.harness.yaml` enforcement (skill templates anchor on session-start output):
+
+- **no_mocks (advise):** use injectable fakes for the filesystem and environment in unit tests; do not `vi.mock`/`jest.mock` the fs or config modules. Mocks are appropriate only for pure seams already designed for injection.
+- **evidence_only (block):** show real command/test output before claiming a task is done.
+- **stale_tests (advise):** every source-file change in this plan ships with its corresponding test change in the same task.
+
+## Mock Policy
+
+- **Stack/E2E (real deps):** none in this plan — no DB/payment/logger components.
+- **Unit tests (injectable fakes ok):** `scoreJcodemunchValue` (inject `existsCheck`/`statCheck`); `handlePreToolUse` Step 2.5 (inject `execRewrite`, `existsCheck`, `statCheck`, and `cache.setEnvironment(...)` for the env gate). These are designed injection seams, not mocks of protected components.
+
+## File Structure
+
+- **NEW** `src/router/jcodemunch-value.ts` — pure heuristic: `CODE_EXTENSIONS`, `DivertDecision`, `DivertOptions`, `scoreJcodemunchValue(command, opts)`. One responsibility: decide whether a Bash command is a high-value jcodemunch opportunity.
+- **NEW** `tests/router/jcodemunch-value.test.ts` — unit tests for both shapes + all no-divert cases.
+- `src/session/cache.ts` — add `DIVERT_READVISE_PERIOD`, optional `period` param on `shouldAdvise`.
+- `src/types.ts` — `ToolRoutingRules` gains `jcodemunch_divert`, `jcodemunch_divert_outline_bytes`.
+- `src/config.ts` — `DEFAULT_CONFIG.rules.tool_routing` gains the two keys (auto-flows into generated `.harness.yaml` via `init.ts:118` `yamlStringify(DEFAULT_CONFIG, …)`).
+- `src/router/hook.ts` — Step 2.5 wiring; `HookOptions` gains `statCheck?`.
+- `docs/architecture.md`, `README.md` — document the new Step 2.5 + divert heuristic.
+
+**Spec deviation (flagged for review):** the spec's "session-start active-rules output lists `jcodemunch_divert`" is **dropped**. `formatActiveRules` (`src/session/start.ts:351-373`) emits only `constitutional` + `branch_discipline`, not `tool_routing` rules; surfacing one `tool_routing` key there would be inconsistent. The divert is discoverable via its runtime advisories and the generated `.harness.yaml` defaults.
+
+---
+
+### Task 1: Divert re-advisory period on SessionCache
+
+**Files:**
+- Modify: `src/session/cache.ts:13` (new constant near `ADVISORY_READVISE_PERIOD`) and `src/session/cache.ts:247-265` (`shouldAdvise` signature/body)
+- Test: `tests/session/cache.test.ts` (extend the `shouldAdvise` describe at `:158`)
+
+**Interfaces:**
+- Produces: `export const DIVERT_READVISE_PERIOD = 3;` and `shouldAdvise(intent: string, period: number = ADVISORY_READVISE_PERIOD): boolean`. Existing single-arg callers are unchanged (default preserves the 1, 11, 21, … cycle).
+- Consumes: nothing new.
+
+**Depends on:** none. Parallelizable with Task 2 (disjoint files).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/session/cache.test.ts` inside the `shouldAdvise` describe block:
+
+```ts
+  describe('shouldAdvise (divert period)', () => {
+    it('advises on the 1st call, suppresses 2-3, re-advises on the 4th when period=3', () => {
+      expect(cache.shouldAdvise('jm_divert:outline', 3)).toBe(true);   // 1
+      expect(cache.shouldAdvise('jm_divert:outline', 3)).toBe(false);  // 2
+      expect(cache.shouldAdvise('jm_divert:outline', 3)).toBe(false);  // 3
+      expect(cache.shouldAdvise('jm_divert:outline', 3)).toBe(true);   // 4 (re-advise)
+      expect(cache.shouldAdvise('jm_divert:outline', 3)).toBe(false);  // 5
+    });
+
+    it('keeps the default period at 10 when no period is passed', () => {
+      expect(cache.shouldAdvise('native_grep')).toBe(true);            // 1
+      for (let i = 0; i < 9; i++) expect(cache.shouldAdvise('native_grep')).toBe(false);
+      expect(cache.shouldAdvise('native_grep')).toBe(true);            // 11
+    });
+
+    it('tracks divert shape keys independently', () => {
+      expect(cache.shouldAdvise('jm_divert:outline', 3)).toBe(true);
+      expect(cache.shouldAdvise('jm_divert:symbol', 3)).toBe(true);    // independent first call
+      expect(cache.shouldAdvise('jm_divert:outline', 3)).toBe(false);
+      expect(cache.shouldAdvise('jm_divert:symbol', 3)).toBe(false);
+    });
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/session/cache.test.ts -t "divert period"`
+Expected: FAIL — `DIVERT_READVISE_PERIOD` is not exported and `shouldAdvise` accepts no `period` arg (the `period=3` cases advise on the wrong cadence).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/session/cache.ts`, beside `ADVISORY_READVISE_PERIOD` (line 13):
+
+```ts
+/**
+ * Divert advisory re-advisory cycle length. Divert advisories surface more
+ * often than generic ones (every 3rd suppressed vs every 10th) because a
+ * high-value jcodemunch opportunity is worth re-surfacing through a session.
+ */
+export const DIVERT_READVISE_PERIOD = 3;
+```
+
+Change the `shouldAdvise` signature and use the param (lines 247-265):
+
+```ts
+  shouldAdvise(intent: string, period: number = ADVISORY_READVISE_PERIOD): boolean {
+    if (!this.advisedIntents.has(intent)) {
+      this.advisedIntents.add(intent);
+      this.save();
+      return true;
+    }
+    const suppressed = (this.advisorySuppressCounts.get(intent) ?? 0) + 1;
+    if (suppressed >= period) {
+      this.advisorySuppressCounts.set(intent, 0);
+      this.save();
+      return true;
+    }
+    this.advisorySuppressCounts.set(intent, suppressed);
+    this.save();
+    return false;
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/session/cache.test.ts`
+Expected: PASS (all `shouldAdvise` cases, old and new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/session/cache.ts tests/session/cache.test.ts
+git commit -m "feat(cache): add DIVERT_READVISE_PERIOD + period param to shouldAdvise"
+```
+
+---
+
+### Task 2: Config keys + types for the divert
+
+**Files:**
+- Modify: `src/types.ts:204-217` (`ToolRoutingRules`)
+- Modify: `src/config.ts:14-27` (`DEFAULT_CONFIG.rules.tool_routing`)
+- Test: `tests/config.test.ts` (`DEFAULT_CONFIG` describe at `:9`; native-keys test at `:23`)
+- Test: `tests/cli/init.test.ts` (generated `.harness.yaml` contains the keys)
+
+**Interfaces:**
+- Produces: `ToolRoutingRules.jcodemunch_divert?: EnforcementLevel` and `ToolRoutingRules.jcodemunch_divert_outline_bytes?: number`; defaults `'advise'` and `8192`. Generated `.harness.yaml` includes them automatically (Task 5 reads them; `init.ts:118` serializes `DEFAULT_CONFIG`).
+- Consumes: nothing new.
+
+**Depends on:** none. Parallelizable with Task 1.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/config.test.ts`, beside the native-keys test:
+
+```ts
+  it('has jcodemunch divert config keys', () => {
+    expect(DEFAULT_CONFIG.rules.tool_routing.jcodemunch_divert).toBe('advise');
+    expect(DEFAULT_CONFIG.rules.tool_routing.jcodemunch_divert_outline_bytes).toBe(8192);
+  });
+
+  it('merges jcodemunch_divert override over defaults', () => {
+    const merged = mergeConfigs(structuredClone(DEFAULT_CONFIG), {
+      rules: { tool_routing: { jcodemunch_divert: 'block' } },
+    });
+    expect(merged.rules.tool_routing.jcodemunch_divert).toBe('block');
+    expect(merged.rules.tool_routing.jcodemunch_divert_outline_bytes).toBe(8192); // preserved
+  });
+```
+
+In `tests/cli/init.test.ts`, add (adjust to that file's temp-project scaffold idiom):
+
+```ts
+  it('writes jcodemunch_divert keys into the generated .harness.yaml', () => {
+    // scaffold a temp project, run init, then read the generated config
+    const yaml = readFileSync(join(tmpDir, '.harness.yaml'), 'utf-8');
+    expect(yaml).toContain('jcodemunch_divert:');
+    expect(yaml).toContain('jcodemunch_divert_outline_bytes:');
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/config.test.ts tests/cli/init.test.ts -t "jcodemunch"`
+Expected: FAIL — the keys do not exist on `ToolRoutingRules` / `DEFAULT_CONFIG`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/types.ts`, add two fields to `ToolRoutingRules` (after `read_line_threshold?: number;`):
+
+```ts
+  jcodemunch_divert?: EnforcementLevel;
+  jcodemunch_divert_outline_bytes?: number;
+```
+
+In `src/config.ts`, add two lines inside `DEFAULT_CONFIG.rules.tool_routing` (after `read_line_threshold: 100,`):
+
+```ts
+      jcodemunch_divert: 'advise',
+      jcodemunch_divert_outline_bytes: 8192,
+```
+
+(No `init.ts` edit — it serializes `DEFAULT_CONFIG` via `yamlStringify` at line 118.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/config.test.ts tests/cli/init.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/types.ts src/config.ts tests/config.test.ts tests/cli/init.test.ts
+git commit -m "feat(config): add jcodemunch_divert + outline_bytes config keys"
+```
+
+---
+
+### Task 3: Heuristic module — Shape A (big-file `cat` outline)
+
+**Files:**
+- Create: `src/router/jcodemunch-value.ts`
+- Create: `tests/router/jcodemunch-value.test.ts`
+
+**Interfaces:**
+- Produces:
+  ```ts
+  export interface DivertDecision { shape: 'outline' | 'symbol'; jmTool: string; reason: string; target: string; }
+  export interface DivertOptions { existsCheck: (p: string) => boolean; statCheck: (p: string) => { size: number; isFile: boolean }; outlineBytes: number; }
+  export const CODE_EXTENSIONS: ReadonlySet<string>;
+  export function scoreJcodemunchValue(command: string, opts: DivertOptions): DivertDecision | null;
+  ```
+  For Shape A, returns `{ shape: 'outline', jmTool: 'mcp__jcodemunch__get_file_outline', target: <path>, reason: <…> }`.
+- Consumes: nothing (pure).
+
+**Depends on:** none. Parallelizable with Tasks 1, 2.
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/router/jcodemunch-value.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { scoreJcodemunchValue } from '../../src/router/jcodemunch-value.js';
+
+const opts = (overrides: Partial<{ size: number; exists: boolean }> = {}) => ({
+  existsCheck: () => overrides.exists ?? true,
+  statCheck: () => ({ size: overrides.size ?? 20000, isFile: true }),
+  outlineBytes: 8192,
+});
+
+describe('scoreJcodemunchValue — Shape A (cat outline)', () => {
+  it('diverts a big cat of a code file to get_file_outline', () => {
+    const d = scoreJcodemunchValue('cat /x/src/big.ts', opts({ size: 20000 }));
+    expect(d).toMatchObject({ shape: 'outline', jmTool: 'mcp__jcodemunch__get_file_outline', target: '/x/src/big.ts' });
+  });
+
+  it('does not divert a file below the outline byte threshold', () => {
+    expect(scoreJcodemunchValue('cat /x/src/small.ts', opts({ size: 100 }))).toBeNull();
+  });
+
+  it('does not divert a non-code file extension', () => {
+    expect(scoreJcodemunchValue('cat /x/notes.md', opts({ size: 20000 }))).toBeNull();
+  });
+
+  it('does not divert a missing file', () => {
+    expect(scoreJcodemunchValue('cat /x/missing.ts', opts({ exists: false }))).toBeNull();
+  });
+
+  it('does not divert multi-file cat', () => {
+    expect(scoreJcodemunchValue('cat /x/a.ts /x/b.ts', opts({ size: 20000 }))).toBeNull();
+  });
+
+  it('does not divert head or tail (slice reads)', () => {
+    expect(scoreJcodemunchValue('head /x/big.ts', opts({ size: 20000 }))).toBeNull();
+    expect(scoreJcodemunchValue('tail -n 50 /x/big.ts', opts({ size: 20000 }))).toBeNull();
+  });
+
+  it('does not divert a sed -n range print', () => {
+    expect(scoreJcodemunchValue("sed -n '10,20p' /x/big.ts", opts({ size: 20000 }))).toBeNull();
+  });
+
+  it('returns null for unrelated commands', () => {
+    expect(scoreJcodemunchValue('find . -name "*.ts"', opts())).toBeNull();
+    expect(scoreJcodemunchValue('git status', opts())).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/router/jcodemunch-value.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`src/router/jcodemunch-value.ts` (Shape A only this task; Shape B is Task 4):
+
+```ts
+import { extname } from 'node:path';
+
+const CODE_EXTENSIONS = new Set<string>([
+  '.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.py', '.go', '.rs', '.java',
+  '.kt', '.scala', '.rb', '.php', '.cs', '.c', '.cc', '.cpp', '.h', '.hpp',
+  '.swift', '.vue', '.svelte', '.elixir', '.ex', '.exs', '.clj', '.cljs',
+  '.hs', '.ml', '.fs', '.dart', '.lua', '.pl', '.r', '.jl',
+]);
+
+export interface DivertDecision {
+  shape: 'outline' | 'symbol';
+  jmTool: string;
+  reason: string;
+  target: string;
+}
+
+export interface DivertOptions {
+  existsCheck: (p: string) => boolean;
+  statCheck: (p: string) => { size: number; isFile: boolean };
+  outlineBytes: number;
+}
+
+const IDENT = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/** Tokenize a command into the binary + non-flag args + flag set (quote-naive, sufficient for v1). */
+function parse(command: string): { binary: string; positional: string[]; flags: Set<string> } {
+  const tokens = command.trim().split(/\s+/);
+  return {
+    binary: tokens[0] ?? '',
+    positional: tokens.slice(1).filter(t => !t.startsWith('-')),
+    flags: new Set(tokens.slice(1).filter(t => t.startsWith('-')).map(t => t.replace(/=.*$/, ''))),
+  };
+}
+
+export function scoreJcodemunchValue(command: string, opts: DivertOptions): DivertDecision | null {
+  const { binary, positional } = parse(command);
+
+  // Shape A — big-file structural read (`cat` only)
+  if (binary === 'cat') {
+    if (positional.length !== 1) return null;
+    const target = positional[0];
+    if (!opts.existsCheck(target)) return null;
+    const stat = opts.statCheck(target);
+    if (!stat.isFile) return null;
+    if (!CODE_EXTENSIONS.has(extname(target))) return null;
+    if (stat.size <= opts.outlineBytes) return null;
+    return {
+      shape: 'outline',
+      jmTool: 'mcp__jcodemunch__get_file_outline',
+      target,
+      reason: `${target} is large; the outline gives its structure for far fewer tokens than reading the whole file (rtk would still return every line).`,
+    };
+  }
+
+  return null; // Shape B added in Task 4
+}
+```
+
+(`IDENT` is defined here for Task 4; leaving it unused this task is fine — or defer its addition to Task 4. Prefer adding it in Task 4 to avoid an unused-symbol lint here.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/router/jcodemunch-value.test.ts`
+Expected: PASS (all Shape A cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/router/jcodemunch-value.ts tests/router/jcodemunch-value.test.ts
+git commit -m "feat(router): jcodemunch-value heuristic — Shape A (big-file cat outline)"
+```
+
+---
+
+### Task 4: Heuristic module — Shape B (identifier `grep` symbol search)
+
+**Files:**
+- Modify: `src/router/jcodemunch-value.ts` (extend `scoreJcodemunchValue`)
+- Modify: `tests/router/jcodemunch-value.test.ts` (add Shape B cases)
+
+**Interfaces:**
+- Produces: Shape B returns `{ shape: 'symbol', jmTool: 'mcp__jcodemunch__search_symbols', target: <pattern>, reason: <…> }`. Exports `IDENT` regex (or keeps it module-local).
+- Consumes: Task 3's `scoreJcodemunchValue`, `DivertOptions`, `parse`.
+
+**Depends on: Task 3** (same files — not parallelizable).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/router/jcodemunch-value.test.ts`:
+
+```ts
+describe('scoreJcodemunchValue — Shape B (identifier grep symbol search)', () => {
+  it('diverts a single-identifier grep to search_symbols', () => {
+    const d = scoreJcodemunchValue('grep -r calculateScore src/', opts());
+    expect(d).toMatchObject({ shape: 'symbol', jmTool: 'mcp__jcodemunch__search_symbols', target: 'calculateScore' });
+  });
+
+  it('still diverts with --word-regexp (-w)', () => {
+    expect(scoreJcodemunchValue('grep -rw FooBar .', opts())).toMatchObject({ shape: 'symbol' });
+  });
+
+  it('still diverts with rg and case-insensitive (-i)', () => {
+    expect(scoreJcodemunchValue('rg -i MyType src/', opts())).toMatchObject({ shape: 'symbol', target: 'MyType' });
+  });
+
+  it('does not divert a regex pattern (contains metacharacters)', () => {
+    expect(scoreJcodemunchValue('grep "foo.bar" src/', opts())).toBeNull();
+    expect(scoreJcodemunchValue('grep -r "a|b" .', opts())).toBeNull();
+  });
+
+  it('does not divert a multi-token / literal phrase pattern', () => {
+    expect(scoreJcodemunchValue('grep "some phrase" .', opts())).toBeNull();
+    expect(scoreJcodemunchValue('grep -r TODO .', opts())).toBeNull();
+  });
+
+  it('does not divert --files-with-matches (-l)', () => {
+    expect(scoreJcodemunchValue('grep -rl FooBar .', opts())).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/router/jcodemunch-value.test.ts -t "Shape B"`
+Expected: FAIL — `grep`/`rg` currently fall through to `null`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/router/jcodemunch-value.ts`, extend `scoreJcodemunchValue` (and use `flags` from `parse`). Add a `REGEX_METACHAR` test and the Shape B branch before the final `return null`:
+
+```ts
+const IDENT = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const REGEX_METACHAR = /[.*+?^${}()|[\]\\/]/;
+
+export function scoreJcodemunchValue(command: string, opts: DivertOptions): DivertDecision | null {
+  const { binary, positional, flags } = parse(command);
+
+  if (binary === 'cat') { /* …Shape A unchanged… */ }
+
+  // Shape B — symbol-shaped search (grep / rg, single identifier token)
+  if (binary === 'grep' || binary === 'rg' || binary === 'greprx') {
+    if (flags.has('-l') || flags.has('--files-with-matches')) return null;
+    // Pattern is the value of -e/--regexp if present, else the first positional.
+    let pattern: string | undefined;
+    const tokens = command.trim().split(/\s+/);
+    const eIdx = tokens.findIndex(t => t === '-e' || t === '--regexp');
+    if (eIdx >= 0) pattern = tokens[eIdx + 1];
+    if (!pattern) pattern = positional[0];
+    if (!pattern) return null;
+    if (REGEX_METACHAR.test(pattern)) return null;   // regex/literal scan → rtk
+    if (!IDENT.test(pattern)) return null;            // multi-token / phrase → rtk
+    return {
+      shape: 'symbol',
+      jmTool: 'mcp__jcodemunch__search_symbols',
+      target: pattern,
+      reason: `${pattern} looks like a symbol; mcp__jcodemunch__search_symbols ranks definitions/references better than a text grep.`,
+    };
+  }
+
+  return null;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/router/jcodemunch-value.test.ts`
+Expected: PASS (Shape A + Shape B).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/router/jcodemunch-value.ts tests/router/jcodemunch-value.test.ts
+git commit -m "feat(router): jcodemunch-value heuristic — Shape B (identifier grep symbol search)"
+```
+
+---
+
+### Task 5: Hook Step 2.5 — divert before the rtk rewrite
+
+**Files:**
+- Modify: `src/router/hook.ts` — `HookOptions` (add `statCheck?`), and insert Step 2.5 between Step 2 (`:271-280`) and Step 3 (`:282-290`)
+- Test: `tests/router/hook.test.ts` (new describe; reuse `makeEnv`/`SessionCache` idiom at `:30-66`)
+
+**Interfaces:**
+- Consumes: `scoreJcodemunchValue` (Task 3/4), `DIVERT_READVISE_PERIOD` (Task 1), `config.rules.tool_routing.jcodemunch_divert` + `.jcodemunch_divert_outline_bytes` (Task 2), `cache.shouldAdvise(key, period)`, `isCompoundCommand` (already imported).
+- Produces: on a high-value shape the hook returns an `EnforcementViolation` (`{ level: 'advise' | 'block', message }`) naming the jm tool and **does not** reach the rtk `execRewrite`. Suppressed turns fall through to Step 3 (rtk runs).
+
+**Depends on: Tasks 1, 2, 3, 4.** (Integration point — run after all of them.)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/router/hook.test.ts`:
+
+```ts
+import { statSync } from 'node:fs';
+import { scoreJcodemunchValue } from '../../src/router/jcodemunch-value.js'; // only if referenced
+
+describe('handlePreToolUse — jcodemunch divert (Step 2.5)', () => {
+  const bigExists = (p: string) => p === '/x/big.ts';
+  const bigStat = () => ({ size: 20000, isFile: true });
+
+  it('diverts a big cat to a jcodemunch advisory and does NOT call rtk', () => {
+    const cache = new SessionCache();
+    cache.setEnvironment(makeEnv({ rtkAvailable: true, rtkPath: '/usr/bin/rtk', jcodemunchAvailable: true, jcodemunchCwdIndexed: true }));
+    const rtkShouldNotRun = (): never => { throw new Error('rtk execRewrite must not be called on a divert'); };
+    const result = handlePreToolUse('Bash', { command: 'cat /x/big.ts' }, cache, config, undefined, {
+      execRewrite: rtkShouldNotRun,
+      existsCheck: bigExists,
+      statCheck: bigStat,
+    });
+    expect(result).toMatchObject({ level: 'advise' });
+    expect(JSON.stringify(result)).toContain('mcp__jcodemunch__get_file_outline');
+  });
+
+  it('falls through to rtk on a suppressed divert turn', () => {
+    const cache = new SessionCache();
+    cache.setEnvironment(makeEnv({ rtkAvailable: true, rtkPath: '/usr/bin/rtk', jcodemunchAvailable: true, jcodemunchCwdIndexed: true }));
+    const opts = { execRewrite: () => ({ command: 'rtk cat /x/big.ts', autoAllow: true }), existsCheck: bigExists, statCheck: bigStat };
+    expect(handlePreToolUse('Bash', { command: 'cat /x/big.ts' }, cache, config, undefined, opts)).toMatchObject({ level: 'advise' }); // 1st: divert
+    // 2nd + 3rd suppressed → rtk rewrite returned
+    for (let i = 0; i < 2; i++) {
+      const r = handlePreToolUse('Bash', { command: 'cat /x/big.ts' }, cache, config, undefined, opts) as { type?: string };
+      expect(r?.type).toBe('rewrite');
+    }
+  });
+
+  it('blocks at jcodemunch_divert: block', () => {
+    const cache = new SessionCache();
+    cache.setEnvironment(makeEnv({ rtkAvailable: true, rtkPath: '/usr/bin/rtk', jcodemunchAvailable: true, jcodemunchCwdIndexed: true }));
+    const blockConfig = { ...config, rules: { ...config.rules, tool_routing: { ...config.rules.tool_routing, jcodemunch_divert: 'block' as const } } };
+    const result = handlePreToolUse('Bash', { command: 'cat /x/big.ts' }, cache, blockConfig, undefined, { existsCheck: bigExists, statCheck: bigStat });
+    expect(result).toMatchObject({ level: 'block' });
+  });
+
+  it('falls through to rtk when jcodemunch_divert is silent', () => {
+    const cache = new SessionCache();
+    cache.setEnvironment(makeEnv({ rtkAvailable: true, rtkPath: '/usr/bin/rtk', jcodemunchAvailable: true, jcodemunchCwdIndexed: true }));
+    const silentConfig = { ...config, rules: { ...config.rules, tool_routing: { ...config.rules.tool_routing, jcodemunch_divert: 'silent' as const } } };
+    const result = handlePreToolUse('Bash', { command: 'cat /x/big.ts' }, cache, silentConfig, undefined, {
+      execRewrite: () => ({ command: 'rtk cat /x/big.ts', autoAllow: true }), existsCheck: bigExists, statCheck: bigStat,
+    }) as { type?: string };
+    expect(result?.type).toBe('rewrite');
+  });
+
+  it('does not divert when jcodemunch is not ready (rtk runs)', () => {
+    const cache = new SessionCache();
+    cache.setEnvironment(makeEnv({ rtkAvailable: true, rtkPath: '/usr/bin/rtk', jcodemunchAvailable: true, jcodemunchCwdIndexed: false }));
+    const result = handlePreToolUse('Bash', { command: 'cat /x/big.ts' }, cache, config, undefined, {
+      execRewrite: () => ({ command: 'rtk cat /x/big.ts', autoAllow: true }), existsCheck: bigExists, statCheck: bigStat,
+    }) as { type?: string };
+    expect(result?.type).toBe('rewrite');
+  });
+
+  it('does not divert a low-value grep (rtk runs)', () => {
+    const cache = new SessionCache();
+    cache.setEnvironment(makeEnv({ rtkAvailable: true, rtkPath: '/usr/bin/rtk', jcodemunchAvailable: true, jcodemunchCwdIndexed: true }));
+    const result = handlePreToolUse('Bash', { command: 'grep -r TODO .' }, cache, config, undefined, {
+      execRewrite: () => ({ command: 'rtk grep TODO .', autoAllow: true }),
+    }) as { type?: string };
+    expect(result?.type).toBe('rewrite');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/router/hook.test.ts -t "jcodemunch divert"`
+Expected: FAIL — Step 2.5 doesn't exist; big `cat` currently rewrites to rtk (the "does NOT call rtk" test throws / the rewrite-type assertions see rtk output).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/router/hook.ts`:
+
+1. Add to imports:
+```ts
+import { scoreJcodemunchValue } from './jcodemunch-value.js';
+import { DIVERT_READVISE_PERIOD } from '../session/cache.js';
+```
+
+2. Extend `HookOptions` (around `:17-22`) with a `statCheck`:
+```ts
+export interface HookOptions {
+  execRewrite?: ExecRewriteFn;
+  existsCheck?: ExistsCheckFn;
+  statCheck?: (p: string) => { size: number; isFile: boolean };
+  branchExec?: ExecFn;
+}
+```
+
+3. Insert Step 2.5 between Step 2 (`:271-280`) and Step 3 (`:282-290`):
+```ts
+  // Step 2.5: jcodemunch divert — for high-value Bash read/search shapes,
+  // advise jcodemunch INSTEAD of rewriting to rtk (Step 3). Suppressed turns
+  // and silent level fall through to Step 3 so rtk still optimizes them.
+  if (tool === 'Bash' && typeof args.command === 'string' && !isCompoundCommand(args.command)) {
+    if (env.jcodemunchAvailable && env.jcodemunchCwdIndexed) {
+      const outlineBytes = config.rules.tool_routing?.jcodemunch_divert_outline_bytes ?? 8192;
+      const exists = resolvedOptions.existsCheck ?? ((p) => { try { return statSync(p).isFile(); return true; } catch { return false; } });
+      const stat = resolvedOptions.statCheck ?? ((p) => { const s = statSync(p); return { size: s.size, isFile: s.isFile() }; });
+      const decision = scoreJcodemunchValue(args.command, { existsCheck: exists, statCheck: stat, outlineBytes });
+      if (decision) {
+        const level = config.rules.tool_routing?.jcodemunch_divert ?? 'advise';
+        if (level !== 'silent') {
+          const key = `jm_divert:${decision.shape}`;
+          if (level === 'advise' && !cache.shouldAdvise(key, DIVERT_READVISE_PERIOD)) {
+            // suppressed this turn — fall through to rtk
+          } else {
+            const prefix = level === 'block' ? '[BLOCK]' : '[ADVISE]';
+            return {
+              level,
+              message: [
+                `${prefix} Tool Router: high-value jcodemunch opportunity (${decision.shape})`,
+                `advise: use ${decision.jmTool} — ${decision.reason}`,
+                level === 'block'
+                  ? 'This operation is blocked by .harness.yaml. Use the recommended tool instead.'
+                  : 'Consider using the recommended tool for better efficiency.',
+              ].join('\n'),
+            };
+          }
+        }
+      }
+    }
+  }
+```
+
+(Use the existing `statSync` import at the top of `hook.ts`; if absent, add `import { statSync } from 'node:fs';`. The `exists`/`stat` defaults must not throw for non-existent paths — guard with try/catch as shown; refine so `exists` is a plain existence check, e.g. `existsSync(p)`, importing `existsSync` too.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/router/hook.test.ts`
+Expected: PASS (existing router tests + the new divert cases). Also run the full suite: `npm test`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/router/hook.ts tests/router/hook.test.ts
+git commit -m "feat(router): Step 2.5 jcodemunch divert for high-value Bash shapes"
+```
+
+---
+
+### Task 6: Documentation
+
+**Files:**
+- Modify: `docs/architecture.md` (Layer 1 flow + intent/routing table)
+- Modify: `README.md` (tool-routing description)
+
+**Interfaces:** none (docs only).
+
+**Depends on: Tasks 1–5** (describes the finished behavior).
+
+- [ ] **Step 1: Update `docs/architecture.md` Layer 1**
+
+In the Layer 1 flow diagram, add a "Step 2.5: jcodemunch divert" box between the python-env rewrite (Step 2) and the rtk rewrite (Step 3), with a one-line note: "high-value Bash shapes (big-file `cat`, identifier `grep`) → advise jcodemunch instead of rtk; suppressed/silent fall through to rtk." Add a row to the intent table for the divert (shapes `jm_divert:outline` / `jm_divert:symbol`, suppression period 3).
+
+- [ ] **Step 2: Update `README.md`**
+
+In the Tool Router bullet, note that high-value Bash read/search commands divert to jcodemunch (configurable via `tool_routing.jcodemunch_divert`), and add the two keys to the example `.harness.yaml` block.
+
+- [ ] **Step 3: Verify build + lint + full suite**
+
+Run: `npm run lint && npm test`
+Expected: lint clean; all tests pass; coverage gate met.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/architecture.md README.md
+git commit -m "docs: document jcodemunch divert (Step 2.5) in architecture + README"
+```
+
+---
+
+## Self-Review (run after writing, fixed inline)
+
+- **Spec coverage:** Shape A (Task 3) + Shape B (Task 4) ✓; Step 2.5 data flow (Task 5) ✓; config keys + defaults (Task 2) ✓; `DIVERT_READVISE_PERIOD = 3` shape-keyed suppression (Task 1) ✓; advisory message format (Task 5) ✓; testing strategy (every task) ✓; affected modules (File Structure) ✓. The spec's "session-start active-rules" item is intentionally dropped (documented deviation above).
+- **Placeholder scan:** none — every code step has concrete code; file paths are exact (`cache.ts:247`, `types.ts:204-217`, `config.ts:14-27`, `hook.ts:271-290`, `start.ts:351`).
+- **Type consistency:** `DivertDecision.shape` is `'outline' | 'symbol'` in Tasks 3/4/5; `shouldAdvise(intent, period)` signature consistent across Tasks 1 and 5; `jm_divert:${decision.shape}` keys (`jm_divert:outline` / `jm_divert:symbol`) consistent with Task 1 tests.
+- **Known implementation nuance for Task 5:** the default `exists`/`stat` closures must not throw on missing paths (the heuristic already guards via `existsCheck`, but the closure passed in should use `existsSync` + try/catch around `statSync`). Flagged in the task body.
+
+## Execution Handoff
+
+Plan saved to `docs/superpowers/plans/2026-08-05-jcodemunch-nuanced-advisory.md`. Per the user's instruction, the next step is a review sub-agent (spec + plan vs current implementation), then implementation via `/tdd+` (inline) or `/sdd+` (subagent-driven) — Task 4 depends on Task 3, and Task 5 depends on 1–4, so most of this plan is sequential; Tasks 1, 2, and 3 are the only parallelizable trio.

--- a/docs/superpowers/specs/2026-08-05-jcodemunch-nuanced-advisory-design.md
+++ b/docs/superpowers/specs/2026-08-05-jcodemunch-nuanced-advisory-design.md
@@ -18,7 +18,8 @@ across many sessions despite the tool being installed and indexed. Root cause:
   strict priority over jcodemunch for the Bash intents
   (`src/router/resolver.ts:27-35`).
 - jcodemunch advisories are therefore reachable **only** through the native
-  Read/Grep/Glob tools, and those are first-occurrence suppressed
+  Read/Grep/Glob tools (or through Bash intents when rtk declines a rewrite,
+  which it normally doesn't), and those are first-occurrence suppressed
   (`ADVISORY_READVISE_PERIOD = 10`, `src/session/cache.ts:13`, `:247-265`).
 - In Bash-heavy sessions (which rtk actively rewards by auto-allowing and
   token-optimizing), the agent rarely uses native tools, so no
@@ -147,9 +148,12 @@ Diverts to `mcp__jcodemunch__search_symbols` when **all** hold:
    `--files-with-matches` is present (that wants a file list — low value; rtk /
    `get_file_tree` territory).
 
-The pattern is identified as the first non-flag positional argument (or the
-value of `-e` / `--regexp` when present). Other flags (`-r`, `-i`, `--color`,
-etc.) do not block the divert.
+The pattern is identified from every pattern source — the first non-flag
+positional argument, the value of `-e` / `--regexp` (space form), and the
+attached `--regexp=PATTERN` (`=`) form. **Exactly one** pattern must be
+specified: multiple `-e` / `--regexp` flags form a multi-pattern OR query that
+`search_symbols` cannot express, so those do not divert. Other flags (`-r`,
+`-i`, `--color`, `-n`, etc.) do not block the divert.
 
 Why it is a clear win: the agent is looking for a symbol definition/references;
 `search_symbols` (BM25 + embeddings + AST) ranks and locates it, versus rtk
@@ -289,6 +293,11 @@ ExecFn").
   avoid false-positive diversions.
 - **File-size proxy for "large".** Bytes, not lines; threshold tunable via
   `jcodemunch_divert_outline_bytes`.
+- **Quote-naive command parsing.** `scoreJcodemunchValue` tokenizes on
+  whitespace, so quoted paths with spaces (`cat "src/my file.ts"`) are not
+  recognized as a single target and do not divert — a safe miss (no false
+  positive), accepted as a v1 limitation. Multi-pattern OR queries (`grep -e Foo
+  -e Bar`) and the `--regexp=PATTERN` form are handled.
 
 ## Future (deferred)
 

--- a/docs/superpowers/specs/2026-08-05-jcodemunch-nuanced-advisory-design.md
+++ b/docs/superpowers/specs/2026-08-05-jcodemunch-nuanced-advisory-design.md
@@ -141,8 +141,11 @@ Diverts to `mcp__jcodemunch__search_symbols` when **all** hold:
 
 1. The command is a non-compound `grep` or `rg` (the `text_search` intent).
 2. The search pattern is a **single identifier token**: matches
-   `^[A-Za-z_][A-Za-z0-9_]*$`. No spaces, no regex metacharacters
-   (`. * [ ] ( ) | \ + ? { } $ ^ /`). The `-w` / `--word-regexp` flag
+   `^[A-Za-z_][A-Za-z0-9_]*$`, with no spaces and no regex metacharacters
+   (`. * [ ] ( ) | \ + ? { } $ ^ /`), **and contains at least one lowercase
+   letter**. The lowercase requirement filters all-caps literal-scan markers
+   (TODO/FIXME/HACK) and constants in favor of CamelCase / snake_case symbol
+   names `search_symbols` actually indexes. The `-w` / `--word-regexp` flag
    reinforces symbol intent (still divert).
 3. The pattern is **not** the `--files-with-matches` case: neither `-l` nor
    `--files-with-matches` is present (that wants a file list — low value; rtk /
@@ -153,7 +156,9 @@ positional argument, the value of `-e` / `--regexp` (space form), and the
 attached `--regexp=PATTERN` (`=`) form. **Exactly one** pattern must be
 specified: multiple `-e` / `--regexp` flags form a multi-pattern OR query that
 `search_symbols` cannot express, so those do not divert. Other flags (`-r`,
-`-i`, `--color`, `-n`, etc.) do not block the divert.
+`-i`, `--color`, `-n`, etc.) do not block the divert. Short-flag clusters
+(`-rn`, `-rl`) are decomposed into individual flags, so `-l` hidden inside
+`-rl` still suppresses the divert.
 
 Why it is a clear win: the agent is looking for a symbol definition/references;
 `search_symbols` (BM25 + embeddings + AST) ranks and locates it, versus rtk

--- a/docs/superpowers/specs/2026-08-05-jcodemunch-nuanced-advisory-design.md
+++ b/docs/superpowers/specs/2026-08-05-jcodemunch-nuanced-advisory-design.md
@@ -1,0 +1,303 @@
+# Nuanced jcodemunch advisory (precision divert)
+
+- **Date:** 2026-08-05
+- **Status:** Approved design (awaiting implementation plan)
+- **Approach:** Approach 1 — precision divert, advise-level
+- **Originating investigation:** debug+ root-cause trace of `jcodemunch: 0 queries` in `/savings`
+
+## Background
+
+A debug+ investigation traced why jcodemunch's per-session query count sits at 0
+across many sessions despite the tool being installed and indexed. Root cause:
+
+- jcodemunch detection is healthy (`jcodemunchAvailable && jcodemunchCwdIndexed`
+  both true; transport resolved as `uvx jcodemunch-mcp` via Claude config).
+- The router rewrites every Bash `grep`/`find`/`cat`/`head`/`tail` command to rtk
+  and **short-circuits** (`src/router/hook.ts:286-288`) before the jcodemunch
+  advisory step (`src/router/hook.ts:304-333`). The resolver also gives rtk
+  strict priority over jcodemunch for the Bash intents
+  (`src/router/resolver.ts:27-35`).
+- jcodemunch advisories are therefore reachable **only** through the native
+  Read/Grep/Glob tools, and those are first-occurrence suppressed
+  (`ADVISORY_READVISE_PERIOD = 10`, `src/session/cache.ts:13`, `:247-265`).
+- In Bash-heavy sessions (which rtk actively rewards by auto-allowing and
+  token-optimizing), the agent rarely uses native tools, so no
+  `mcp__jcodemunch__*` call ever fires. The counter only increments on an actual
+  MCP call (`src/session/metrics.ts:221`); the `/savings` line reads jcodemunch's
+  own `session_calls` (`templates/skills/savings/SKILL.md:50-54`).
+
+This is by-design behavior, not a crash. The cost is real: in a Bash-heavy
+workflow the agent gets *cheaper grep* (rtk) but not *smarter indexed/symbol
+search* (jcodemunch).
+
+## Goal
+
+Make the router surface jcodemunch at genuinely high-value moments throughout a
+session — when jcodemunch is unambiguously the better tool than an rtk-rewritten
+Bash command — without nagging on commands where rtk is the right choice.
+
+## Non-goals
+
+- Do not remove or demote rtk. rtk keeps owning every Bash command that is not a
+  high-value divert.
+- Do not change the native-tool (Read/Grep/Glob) advisory path or its suppression.
+- No model-driven intent classification, no session-behavior state machine in v1
+  (deferred — see "Future").
+- No change to the `/savings` computation or the counter increment rule.
+
+## Core decision: divert, not add
+
+For high-value Bash shapes the router advises jcodemunch **instead of**
+rewriting to rtk, mirroring how native Read/Grep/Glob are handled today. This
+reuses the existing advisory emission path (no hook-protocol change) and is
+architecturally consistent.
+
+Consequence accepted by design: at `advise` level a divert *suppresses the rtk
+rewrite*, so if the agent ignores a fired nudge the **original** command runs
+unoptimized (no rtk). This cost is bounded — see "Suppression."
+
+## Architecture & data flow
+
+New **Step 2.5** in `handlePreToolUse` (`src/router/hook.ts`), placed after the
+python-rewrite (Step 2) and **before the rtk rewrite (Step 3)**, so a divert
+wins over rtk for high-value shapes. The heuristic lives in a new pure module
+`src/router/jcodemunch-value.ts`; the hook only calls it.
+
+```
+Bash cmd → Step 1 / 1.5 / 1.6  (blocks, test-scope, branch)   …unchanged
+         → Step 2    python rewrite                             …unchanged
+         → Step 2.5  NEW: if env.jcodemunchAvailable && env.jcodemunchCwdIndexed:
+                       decision = scoreJcodemunchValue(command, existsCheck, statCheck)
+                       if decision:
+                         level = config.rules.tool_routing.jcodemunch_divert   // advise|block|silent
+                         if level === 'silent': fall through → Step 3
+                         if level === 'advise' && !shouldAdvise(key, DIVERT_READVISE_PERIOD):
+                           fall through → Step 3          // suppressed: rtk still runs
+                         return advisory(level, decision)  // DIVERT; Step 3 skipped
+                       else: fall through → Step 3
+         → Step 3    rtk rewrite                                …unchanged
+         → Step 4/5  …unchanged
+```
+
+Gates and guards:
+
+- Only `tool === 'Bash'` with a string `args.command`.
+- **Compound commands skip divert** (same `isCompoundCommand` guard as Step 3).
+- Gate on `env.jcodemunchAvailable && env.jcodemunchCwdIndexed` — identical to
+  the resolver's jcodemunch branch. If jcodemunch is not ready, no divert and rtk
+  runs as today (graceful degradation unchanged).
+- Divert is a **pre-rewrite check parallel to python-rewrite**, not a new entry
+  in the rules array. The rules table stays clean.
+
+Key property: on suppressed turns rtk **still rewrites** the command (no token
+penalty). The unoptimized-command cost is paid only on turns where the advisory
+actually fires.
+
+## The heuristic — `scoreJcodemunchValue`
+
+Pure function:
+
+```ts
+interface DivertDecision {
+  shape: 'outline' | 'symbol';
+  jmTool: string;        // 'mcp__jcodemunch__get_file_outline' | '...__search_symbols'
+  reason: string;        // human-readable, used in the advisory message
+  target: string;        // file path or pattern, for the message
+}
+function scoreJcodemunchValue(
+  command: string,
+  existsCheck: (p: string) => boolean,
+  statCheck: (p: string) => { size: number; isFile: boolean },
+): DivertDecision | null
+```
+
+It returns a decision only for two high-confidence shapes. Everything else
+returns `null` (fall through to rtk).
+
+### Shape A — big-file structural read (`cat` only)
+
+Diverts to `mcp__jcodemunch__get_file_outline` when **all** hold:
+
+1. The command is a non-compound `cat` (the `file_read` intent). `head` and
+   `tail` are deliberately excluded — they imply the agent wants a slice (the
+   top or bottom of the file), not the whole file, so the outline is not the
+   better tool. `sed -n` range prints are likewise excluded (not `cat`).
+2. There is **exactly one** target file argument. Path resolves via
+   `existsCheck` to an existing **file** (not a dir, not missing). Multiple file
+   arguments (e.g. `cat a.ts b.ts`) do not divert.
+3. The target is a **code file** — extension in the code-extension set:
+   `.ts .js .tsx .jsx .mjs .cjs .py .go .rs .java .kt .scala .rb .php .cs .c .cc .cpp .h .hpp .swift .vue .svelte .elixir .ex .exs .erlang .clj .cljs .hs .ml .fs .dart .lua .pl .r .jl`.
+4. `statCheck(path).size > jcodemunch_divert_outline_bytes` (default **8192**
+   bytes ≈ 300 lines).
+
+Why it is a clear win: `cat` outputs the entire file; rtk would cheaply return
+all of it as undifferentiated text, while the outline gives the symbol skeleton
+for a fraction of the tokens and conveys structure.
+
+### Shape B — symbol-shaped search (`grep` / `rg`)
+
+Diverts to `mcp__jcodemunch__search_symbols` when **all** hold:
+
+1. The command is a non-compound `grep` or `rg` (the `text_search` intent).
+2. The search pattern is a **single identifier token**: matches
+   `^[A-Za-z_][A-Za-z0-9_]*$`. No spaces, no regex metacharacters
+   (`. * [ ] ( ) | \ + ? { } $ ^ /`). The `-w` / `--word-regexp` flag
+   reinforces symbol intent (still divert).
+3. The pattern is **not** the `--files-with-matches` case: neither `-l` nor
+   `--files-with-matches` is present (that wants a file list — low value; rtk /
+   `get_file_tree` territory).
+
+The pattern is identified as the first non-flag positional argument (or the
+value of `-e` / `--regexp` when present). Other flags (`-r`, `-i`, `--color`,
+etc.) do not block the divert.
+
+Why it is a clear win: the agent is looking for a symbol definition/references;
+`search_symbols` (BM25 + embeddings + AST) ranks and locates it, versus rtk
+returning raw matching lines.
+
+### Explicitly never divert (stay rtk)
+
+Resolved unambiguously by the predicates above: literal/regex scans (`TODO`,
+`console.log`, `password`, multi-token patterns, patterns with metacharacters),
+`find` / `ls` / `fd` discovery, git operations, `head` / `tail` (slice reads),
+`sed -n` range prints, small-file reads, non-code files, multi-file `cat`, and
+compound commands.
+
+## Config & suppression
+
+### Config (`.harness.yaml`)
+
+New keys under the existing `rules.tool_routing` block:
+
+```yaml
+rules:
+  tool_routing:
+    jcodemunch_divert: advise                 # advise | block | silent (default advise)
+    jcodemunch_divert_outline_bytes: 8192     # file-size threshold for Shape A
+```
+
+Extension points:
+
+- `src/types.ts` — `ToolRoutingRules` (lines 204-217): add
+  `jcodemunch_divert?: EnforcementLevel;` and
+  `jcodemunch_divert_outline_bytes?: number;`.
+- `src/config.ts` — `DEFAULT_CONFIG.rules.tool_routing` (lines 14-27): add
+  `jcodemunch_divert: 'advise'` and `jcodemunch_divert_outline_bytes: 8192`.
+  Layered merge already spreads `tool_routing` shallowly (line 79), so the new
+  keys merge correctly.
+- The divert step reads `config.rules.tool_routing.jcodemunch_divert` directly
+  (it is **not** an intent in the rules array, so it does not go through
+  `INTENT_CONFIG_KEYS` / `getEffectiveEnforcement` in `hook.ts:338-364`). A
+  small local resolver with the same `advise | block | silent` semantics is fine.
+
+Note: `read_line_threshold: 100` already exists for an unrelated purpose (native
+Read advising). `jcodemunch_divert_outline_bytes` is distinct and applies only
+to Shape A.
+
+### Suppression — "throughout a session"
+
+Divert advisories use a **separate, higher-frequency cycle** than generic
+advisories, and are **keyed by shape** so the two nudges track independently:
+
+- New constant `DIVERT_READVISE_PERIOD = 3` in `src/session/cache.ts` (alongside
+  `ADVISORY_READVISE_PERIOD = 10`).
+- Extend `shouldAdvise(intent: string, period = ADVISORY_READVISE_PERIOD): boolean`
+  with an optional `period` parameter (existing callers unaffected — default
+  preserves today's cycle of 1, 11, 21, …).
+- Shape keys: `jm_divert:outline` and `jm_divert:symbol`. The divert step calls
+  `shouldAdvise('jm_divert:outline', DIVERT_READVISE_PERIOD)` etc., producing a
+  cycle of 1, 4, 7, … for each shape independently.
+- `block` level is never suppressed (mirrors Step 5 behavior: only `advise`
+  calls `shouldAdvise`).
+
+The generic advisory cycle (`native_read` etc.) is untouched.
+
+## Advisory message format
+
+Advise-level (emitted as `additionalContext`, exit 0):
+
+```
+[ADVISE] Tool Router: high-value jcodemunch opportunity (big-file outline)
+advise: use mcp__jcodemunch__get_file_outline — <file> is large; the outline
+gives its structure for far fewer tokens than reading the whole file (rtk would
+still return every line).
+Consider using the recommended tool for better efficiency.
+```
+
+Block-level (stderr, exit 2): same content with the block framing used by the
+existing Step 5 messages (`This operation is blocked by .harness.yaml. Use the
+recommended tool instead.`).
+
+Severity remains structural (the hook switches on `level`, never on the
+`[ADVISE]`/`[BLOCK]` prefix — consistent with the existing contract documented
+at `src/router/hook.ts:153-165`).
+
+## Testing strategy
+
+No mocks for environment/filesystem — injectable `existsCheck` / `statCheck`
+(project convention: "No mocks for environment detection -- use injectable
+ExecFn").
+
+- **`scoreJcodemunchValue` unit tests** (new `tests/router/jcodemunch-value.test.ts`):
+  - Shape A divert (large `.ts` file, plain `cat`).
+  - Shape A no-divert: small file (< threshold), non-code extension, missing
+    file, multi-file `cat a.ts b.ts`, `head` / `tail` (excluded),
+    `sed -n '10,20p'` print.
+  - Shape B divert (single identifier token, `grep FooBar src/`, with and
+    without `-w`).
+  - Shape B no-divert: regex metachar (`grep "foo.bar"`), multi-token
+    (`grep "foo bar"`), literal scan (`grep TODO`), `-l` present.
+  - Never-divert intents: `find`, `ls`, `git`, compound commands.
+- **Hook integration** (`tests/router/hook.test.ts`):
+  - High-value `cat` with jm ready → returns `{ level: 'advise', … }` naming the
+    jm tool, and the rtk `execRewrite` is **not** invoked.
+  - Suppressed turn (second occurrence) → rtk rewrite is returned (rtk runs).
+  - `jcodemunch_divert: 'block'` → block path (exit-2 semantics).
+  - `jcodemunch_divert: 'silent'` → falls through, rtk runs.
+  - jm not ready (`jcodemunchCwdIndexed: false`) → no divert, rtk runs.
+  - Compound command → no divert.
+- **Suppression** (`tests/session/cache.test.ts`): `shouldAdvise(key, 3)`
+  advises on 1, 4, 7, …; the default period still advises on 1, 11, 21, …;
+  `jm_divert:outline` and `jm_divert:symbol` counters are independent.
+- **Config** (`tests/config.test.ts`): new keys parsed, merged with defaults,
+  absent-key falls back to defaults (`advise` / `8192`).
+- **Coverage gate:** maintain ≥80% statements/functions/lines, ≥75% branches.
+
+## Affected modules
+
+- NEW `src/router/jcodemunch-value.ts` — the heuristic + `DivertDecision`.
+- `src/router/hook.ts` — Step 2.5 wiring; reuse existing advisory return shape.
+- `src/session/cache.ts` — `DIVERT_READVISE_PERIOD`, optional `period` param on
+  `shouldAdvise`.
+- `src/types.ts` — `ToolRoutingRules` additions.
+- `src/config.ts` — `DEFAULT_CONFIG.rules.tool_routing` additions.
+- `templates/` — `.harness.yaml` template gains the two keys; session-start
+  active-rules output lists `jcodemunch_divert`; docs:
+  `docs/architecture.md` "Layer 1" (new Step 2.5 + the divert heuristic) and the
+  intent/routing table; `README.md` routing description.
+- `tests/` mirror of the above.
+
+## Tradeoffs & accepted costs
+
+- **Ignored advise-level diverts run unoptimized.** Bounded by suppression: only
+  ~1 of every 3 high-value-shape occurrences pays it; suppressed turns get rtk.
+  Set `jcodemunch_divert: block` to eliminate the unoptimized fallback (at the
+  cost of interrupting the cheap loop on every high-value shape).
+- **Two shapes only in v1.** Semantic/phrase search ("how is X used") and
+  reference/call-hierarchy questions are not detected; those remain rtk or
+  reachable via native tools / scout. This is a deliberate precision choice to
+  avoid false-positive diversions.
+- **File-size proxy for "large".** Bytes, not lines; threshold tunable via
+  `jcodemunch_divert_outline_bytes`.
+
+## Future (deferred)
+
+- **Approach 3 — behavioral scout-nudge layer.** A session-cache signal that,
+  after >K read/search ops in one module area, emits a one-time "dispatch the
+  scout agent (uses jcodemunch + graphify)" nudge. Catches the exploration
+  pattern per-command shape cannot see. Clean seam: additive on top of this v1.
+- **Phrase / reference queries** as additional divert shapes once v1's
+  precision is validated in dogfooding.
+- **Telemetry:** a divert counter (`jmDiverts`) in `metricCounters` to make the
+  divert hit-rate observable in `/savings` (the existing `jmCalls` already
+  rises when the agent follows a divert, which is the primary signal).

--- a/evals/README.md
+++ b/evals/README.md
@@ -47,6 +47,16 @@ Exit code is 0 iff every scenario passed (suitable for a CI gate later).
 | `loop-fit-positive` | headless nightly ATS-scoring service | brain+ **fires** the loop opt-in |
 | `loop-fit-negative` | one-off local CSV-reformatting CLI | brain+ does **not** offer the loop trajectory |
 | `loop-optin-sections` | the positive brief + a scripted "yes" | the design carries the signal-stack, primary/loop-boundary, and autonomy-ceiling sections |
+| `divert-jcodemunch-used` | a fixture TypeScript router the agent is asked to grep | the agent **follows the Step 2.5 divert** and calls an `mcp__jcodemunch__` tool to locate the symbol |
+
+The `divert-jcodemunch-used` scenario is the first to scaffold a fixture
+codebase (`scenario.projectFiles` → materialized into the temp project before
+`claude -p`, so session-start auto-indexes it) and the first to grade **tool-use
+structure** rather than assistant text: the invariant passes only when an
+`mcp__jcodemunch__*` tool call appears in the transcript. It closes the
+model-driven gap the deterministic router tests can't reach — *does the agent
+follow the divert advisory?* Run it with `npm run eval -- --scenario
+divert-jcodemunch-used` (needs local `claude` auth and jcodemunch installed).
 
 ## How grading stays model-robust
 
@@ -56,8 +66,11 @@ Exit code is 0 iff every scenario passed (suitable for a CI gate later).
 - **Loop-specific tokens.** The opt-in is detected via `agent-loop pattern` /
   `maintainer trajectory`, **not** `signal stack` (which brain+ emits in its
   general guidance for *every* project, so it is not a discriminator).
-- **Visible output only.** Grading runs on extracted assistant text, dropping
-  thinking blocks — the user sees the offer in visible output, not in reasoning.
+- **Visible output only (with one structural exception).** Grading runs on
+  extracted assistant text, dropping thinking blocks — the user sees the offer
+  in visible output, not in reasoning. The `divert-jcodemunch-used` scenario is
+  the exception: "followed the advisory" is observable only in the tool calls,
+  so it grades tool-use structure (an `mcp__jcodemunch__*` call) instead.
 - **Confined judge fallback.** Only the negative scenario consults a judge, and
   only for one forced binary fact ("did it propose a loop trajectory?"), to
   minimize the grader's own model-sensitivity.

--- a/evals/fixtures/divert-positive.md
+++ b/evals/fixtures/divert-positive.md
@@ -1,0 +1,9 @@
+# Fixture project: mini-router
+
+A small TypeScript HTTP routing module lives at `src/router.ts`. It exports a
+`routeRequest` entry point plus a route table, a few helpers, and the supporting
+types. The module is intentionally self-contained — this project exists to
+exercise code-search tooling against a real (if tiny) codebase, not to build a
+production router.
+
+Your task: locate `routeRequest` and report its parameter list.

--- a/evals/fixtures/divert-project/src/router.ts
+++ b/evals/fixtures/divert-project/src/router.ts
@@ -1,0 +1,136 @@
+// Mini HTTP request router — fixture codebase for the divert eval.
+// Self-contained on purpose; not production code.
+
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'HEAD' | 'OPTIONS';
+
+export interface RequestContext {
+  method: HttpMethod;
+  path: string;
+  headers: Record<string, string>;
+  query: URLSearchParams;
+  body?: string;
+}
+
+export interface RouteResult {
+  matched: boolean;
+  handlerName?: string;
+  params: Record<string, string>;
+  allowedMethods?: HttpMethod[];
+}
+
+export type Handler = (ctx: RequestContext, params: Record<string, string>) => RouteResult;
+
+interface CompiledRoute {
+  method: HttpMethod;
+  segments: Segment[];
+  handlerName: string;
+  handler: Handler;
+}
+
+type Segment = { kind: 'static'; value: string } | { kind: 'param'; name: string };
+
+/**
+ * Compile a path pattern like `/users/:id/posts` into ordered segments,
+ * separating static literals from named parameters.
+ */
+function compilePattern(pattern: string): Segment[] {
+  return pattern
+    .split('/')
+    .filter((s) => s.length > 0)
+    .map((s) => (s.startsWith(':') ? { kind: 'param' as const, name: s.slice(1) } : { kind: 'static' as const, value: s }));
+}
+
+/** Split a raw request path into non-empty segments. */
+function splitPath(path: string): string[] {
+  return path.split('/').filter((s) => s.length > 0);
+}
+
+/**
+ * Match a single route against path segments, returning its params on a hit.
+ * A hit requires equal length and per-segment agreement (static equal, param
+ * captures). This is the per-candidate test run by matchRoute.
+ */
+function matchOne(route: CompiledRoute, segments: string[]): Record<string, string> | null {
+  if (route.segments.length !== segments.length) return null;
+  const params: Record<string, string> = {};
+  for (let i = 0; i < route.segments.length; i++) {
+    const seg = route.segments[i];
+    if (seg.kind === 'static') {
+      if (seg.value !== segments[i]) return null;
+    } else {
+      params[seg.name] = decodeURIComponent(segments[i]);
+    }
+  }
+  return params;
+}
+
+/** Uppercase + trim a method string, defaulting to GET on empty input. */
+function normalizeMethod(raw: string | undefined): HttpMethod {
+  const upper = (raw ?? 'GET').trim().toUpperCase();
+  return (upper || 'GET') as HttpMethod;
+}
+
+/**
+ * Route table: registers (method, pattern) -> handler bindings and answers
+ * lookups via matchRoute. Methods are case-insensitive on registration.
+ */
+export class RouteTable {
+  private readonly routes: CompiledRoute[] = [];
+
+  register(method: HttpMethod, pattern: string, handlerName: string, handler: Handler): this {
+    this.routes.push({ method: normalizeMethod(method), segments: compilePattern(pattern), handlerName, handler });
+    return this;
+  }
+
+  /** Return every compiled route whose path matches, regardless of method. */
+  pathMatches(segments: string[]): CompiledRoute[] {
+    return this.routes.filter((r) => matchOne(r, segments) !== null);
+  }
+
+  /** Find the best route: exact method match wins; otherwise gather allowed
+   *  methods for a 405-style response. */
+  matchRoute(method: HttpMethod, segments: string[]): RouteResult {
+    const norm = normalizeMethod(method);
+    const pathMatches = this.pathMatches(segments);
+    const exact = pathMatches.find((r) => r.method === norm);
+    if (exact) {
+      const params = matchOne(exact, segments) ?? {};
+      return exact.handler({ method: norm, path: '/' + segments.join('/'), headers: {}, query: new URLSearchParams() }, params);
+    }
+    if (pathMatches.length > 0) {
+      return { matched: false, params: {}, allowedMethods: Array.from(new Set(pathMatches.map((r) => r.method))) };
+    }
+    return { matched: false, params: {} };
+  }
+}
+
+/**
+ * Entry point: route an incoming request against the table. This is the symbol
+ * the divert eval asks the agent to locate (parameter list below).
+ *
+ * routeRequest(ctx: RequestContext, table: RouteTable): RouteResult
+ */
+export function routeRequest(ctx: RequestContext, table: RouteTable): RouteResult {
+  return table.matchRoute(normalizeMethod(ctx.method), splitPath(ctx.path));
+}
+
+/** Build a RequestContext from raw, loosely-typed handler input. */
+export function buildContext(
+  method: string | undefined,
+  path: string,
+  headers: Record<string, string> = {},
+  query: URLSearchParams = new URLSearchParams(),
+  body?: string,
+): RequestContext {
+  return { method: normalizeMethod(method), path, headers, query, body };
+}
+
+/** Default table wired with a couple of sample routes for smoke checks. */
+export function defaultTable(): RouteTable {
+  const ok: Handler = (_ctx, params) => ({ matched: true, params });
+  return new RouteTable()
+    .register('GET', '/health', 'health', ok)
+    .register('GET', '/users/:id', 'getUser', ok)
+    .register('POST', '/users', 'createUser', ok)
+    .register('GET', '/users/:id/posts/:postId', 'getUserPost', ok);
+}

--- a/evals/grade.ts
+++ b/evals/grade.ts
@@ -51,21 +51,47 @@ export function matchLoopOptIn(text: string): boolean {
   return LOOP_OPTIN_TOKENS.some((re) => re.test(text));
 }
 
-/**
- * True iff an opted-in design carries all three required sections.
- *
- * Same presence-vs-structure caveat as matchLoopOptIn: this keys on free-text
- * concept presence, so a single shallow sentence naming all three concepts
- * would pass. Lower risk than the negative case (the sections scenario scripts
- * a "YES, include…" answer and asks for headed sections), but a stricter
- * heading-marker match is the tracked refinement.
- */
 export function matchSectionsPresent(text: string): boolean {
   const hasSignalStack = /signal stack/i.test(text);
   const hasBoundary =
     /(loop disabled|primary\/loop|operable with the loop|primary system[^.]{0,60}loop)/i.test(text);
   const hasCeiling = /autonomy ceiling/i.test(text);
   return hasSignalStack && hasBoundary && hasCeiling;
+}
+
+/**
+ * Recover the names of every tool the assistant INVOKED from a stream-json
+ * transcript (assistant content blocks of type `tool_use`). Unlike
+ * extractAssistantText (visible text), this reads tool-call structure — the
+ * surface needed to grade "did the agent follow the divert and actually call a
+ * jcodemunch tool?" rather than merely mention one.
+ */
+export function extractToolUseNames(jsonl: string): string[] {
+  const names: string[] = [];
+  for (const line of jsonl.trim().split('\n').filter(Boolean)) {
+    let o: unknown;
+    try {
+      o = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    const obj = o as { type?: string; message?: { content?: unknown } };
+    if (obj.type === 'assistant' && obj.message && Array.isArray(obj.message.content)) {
+      for (const c of obj.message.content as Array<{ type?: string; name?: unknown }>) {
+        if (c && c.type === 'tool_use' && typeof c.name === 'string') names.push(c.name);
+      }
+    }
+  }
+  return names;
+}
+
+/**
+ * True iff the agent invoked at least one jcodemunch MCP tool. The divert
+ * (Step 2.5) and the native-read/grep/glob advisories all steer here; a hit
+ * means the agent followed the nudge rather than falling back to raw Bash/Read.
+ */
+export function matchJcodemunchUsed(toolNames: string[]): boolean {
+  return toolNames.some((n) => n.startsWith('mcp__jcodemunch__'));
 }
 
 export type JudgeDriver = (prompt: string) => Promise<string>;

--- a/evals/runner.ts
+++ b/evals/runner.ts
@@ -4,7 +4,7 @@
 // canned transcripts.
 
 import { rmSync } from 'fs';
-import { extractAssistantText, matchLoopOptIn, matchSectionsPresent } from './grade.js';
+import { extractAssistantText, matchLoopOptIn, matchSectionsPresent, extractToolUseNames, matchJcodemunchUsed } from './grade.js';
 import { majorityPass, buildReport } from './reduce.js';
 import { SCENARIOS } from './scenarios.js';
 import type { Scenario, RunResult, ScenarioResult, EvalReport } from './types.js';
@@ -63,6 +63,15 @@ export async function gradeTranscript(
     case 'sections-present': {
       const ok = matchSectionsPresent(text);
       return { pass: ok, observed: ok ? 'all required sections present' : 'required sections missing' };
+    }
+    case 'jcodemunch-tool-used': {
+      // Tool-call structure (not visible text) is the grading surface: the
+      // divert/advisory is proven followed only by an actual mcp__jcodemunch__
+      // tool_use in the transcript. Deterministic — no judge needed.
+      const names = extractToolUseNames(transcript);
+      const jm = names.filter((n) => n.startsWith('mcp__jcodemunch__'));
+      const ok = jm.length > 0;
+      return { pass: ok, observed: ok ? `jcodemunch tool used (${jm.join(', ')})` : 'no mcp__jcodemunch__ tool call observed' };
     }
     default:
       return { pass: false, observed: `unknown invariant: ${(inv as { kind: string }).kind}` };

--- a/evals/scenarios.ts
+++ b/evals/scenarios.ts
@@ -55,4 +55,28 @@ export const SCENARIOS: Scenario[] = [
       },
     ],
   },
+  {
+    // Live-model reliability check for the Step 2.5 jcodemunch divert. Scaffolds
+    // a fixture codebase, invites a symbol search (which the router diverts to
+    // mcp__jcodemunch__search_symbols), and asserts the agent FOLLOWED the
+    // advisory — i.e. an mcp__jcodemunch__ tool_use appears in the transcript.
+    // The deterministic logic is covered by tests/router/; this is the
+    // model-driven gap those tests cannot reach. Run: npm run eval -- --scenario
+    // divert-jcodemunch-used (needs local claude auth + jcodemunch installed).
+    id: 'divert-jcodemunch-used',
+    mode: 'positive',
+    briefFile: 'evals/fixtures/divert-positive.md',
+    prompt:
+      'A small TypeScript project is in this directory (see BRIEF.md). Use grep or rg ' +
+      'to find where the function `routeRequest` is defined, then state its parameter list.',
+    invariants: [
+      {
+        kind: 'jcodemunch-tool-used',
+        description: 'the agent follows the Step 2.5 divert and locates the symbol via an mcp__jcodemunch__ tool',
+      },
+    ],
+    projectFiles: [
+      { dest: 'src/router.ts', src: 'evals/fixtures/divert-project/src/router.ts' },
+    ],
+  },
 ];

--- a/evals/session-driver.ts
+++ b/evals/session-driver.ts
@@ -2,11 +2,11 @@
 // headlessly → capture stream-json → track artifacts for teardown. Not imported
 // by unit tests (only buildClaudeArgs is pure-tested); exercised via `npm run eval`.
 
-import { mkdtempSync, writeFileSync, readFileSync, readdirSync, realpathSync } from 'fs';
+import { mkdtempSync, writeFileSync, readFileSync, readdirSync, realpathSync, mkdirSync } from 'fs';
 import { tmpdir } from 'os';
-import { join } from 'path';
+import { join, dirname } from 'path';
 import { execFileSync } from 'child_process';
-import type { Scenario } from './types.js';
+import type { Scenario, ProjectFile } from './types.js';
 import type { DriveSessionFn, Judge } from './runner.js';
 import { TeardownRegistry } from './runner.js';
 import { judgeNegative } from './grade.js';
@@ -40,6 +40,17 @@ export function sessionFragmentOwnedBy(jsonContent: string, ownedDirs: string[])
     return false;
   }
   return typeof parsed.cwd === 'string' && ownedDirs.includes(parsed.cwd);
+}
+
+/** Copy a scenario's fixture files into the scaffolded project (creating parent
+ *  dirs) so a routing/divert scenario has a real codebase to operate on. Runs
+ *  after `rig init` and before `claude -p`, so session-start auto-indexes them. */
+export function materializeProjectFiles(dir: string, files: ProjectFile[]): void {
+  for (const f of files) {
+    const dest = join(dir, f.dest);
+    mkdirSync(dirname(dest), { recursive: true });
+    writeFileSync(dest, readFileSync(join(process.cwd(), f.src), 'utf-8'));
+  }
 }
 
 /** Track /tmp/rig-session-*.json fragments OWNED BY `dir` (cwd-equality, not a
@@ -81,6 +92,7 @@ export function makeLiveDriver(reg: TeardownRegistry, timeoutMs = 300000): Drive
     const env = { ...process.env, CLAUDE_PROJECT_DIR: dir };
     execFileSync('rig', ['init'], { cwd: dir, stdio: 'ignore', env });
     writeFileSync(join(dir, 'BRIEF.md'), readFileSync(join(process.cwd(), scenario.briefFile), 'utf-8'));
+    if (scenario.projectFiles) materializeProjectFiles(dir, scenario.projectFiles);
     const out = execFileSync('claude', buildClaudeArgs(scenario.prompt, model), {
       cwd: dir,
       env,

--- a/evals/types.ts
+++ b/evals/types.ts
@@ -6,11 +6,20 @@
 export type InvariantKind =
   | 'loop-optin-present' // transcript fires the loop opt-in (loop-specific tokens)
   | 'loop-optin-absent' // transcript does NOT offer the loop trajectory
-  | 'sections-present'; // an opted-in design carries the three required sections
+  | 'sections-present' // an opted-in design carries the three required sections
+  | 'jcodemunch-tool-used'; // the agent followed a divert/advisory and called an mcp__jcodemunch__ tool
 
 export interface Invariant {
   kind: InvariantKind;
   description: string;
+}
+
+/** A file materialized into the scaffolded temp project before the run. */
+export interface ProjectFile {
+  /** Destination path within the temp project (POSIX, relative). */
+  dest: string;
+  /** Repo-relative source fixture path to copy from. */
+  src: string;
 }
 
 export interface Scenario {
@@ -21,6 +30,9 @@ export interface Scenario {
   /** The scripted prompt handed to `claude -p`. */
   prompt: string;
   invariants: Invariant[];
+  /** Extra files copied into the temp project after `rig init` (e.g. a fixture
+   *  codebase for routing/divert scenarios). Optional. */
+  projectFiles?: ProjectFile[];
 }
 
 export interface RunResult {

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,6 +24,8 @@ export const DEFAULT_CONFIG: HarnessConfig = {
       rtk_cat_code: 'block',
       scout_explore: 'advise',
       read_line_threshold: 100,
+      jcodemunch_divert: 'advise',
+      jcodemunch_divert_outline_bytes: 8192,
     },
     constitutional: {
       no_mocks: 'advise',

--- a/src/router/hook.ts
+++ b/src/router/hook.ts
@@ -1,9 +1,10 @@
 import { execFileSync, execSync } from 'node:child_process';
-import { appendFileSync } from 'node:fs';
+import { appendFileSync, statSync, existsSync } from 'node:fs';
 import type { EnforcementViolation, HarnessConfig, RewriteResult } from '../types.js';
-import { SessionCache } from '../session/cache.js';
+import { SessionCache, DIVERT_READVISE_PERIOD } from '../session/cache.js';
 import { findMatchingRule, getDefaultRules } from './rules.js';
 import { resolve } from './resolver.js';
+import { scoreJcodemunchValue } from './jcodemunch-value.js';
 import { tryPythonRewrite } from './python-rewrite.js';
 import { isCompoundCommand } from './intent.js';
 import { checkTestScope } from '../enforcement/test-scope.js';
@@ -17,6 +18,8 @@ export type ExistsCheckFn = (path: string) => boolean;
 export interface HookOptions {
   execRewrite?: ExecRewriteFn;
   existsCheck?: ExistsCheckFn;
+  /** Injectable stat for the jcodemunch-divert file-size check (testability). */
+  statCheck?: (p: string) => { size: number; isFile: boolean };
   /** Injectable exec for branch-discipline git probes (testability). */
   branchExec?: ExecFn;
 }
@@ -275,6 +278,41 @@ export function handlePreToolUse(
       const rewritten = tryPythonRewrite(args.command, effectiveCwd, pythonEnv, resolvedOptions.existsCheck);
       if (rewritten) {
         return { type: 'rewrite', command: rewritten, original: args.command, autoAllow: true };
+      }
+    }
+  }
+
+  // Step 2.5: jcodemunch divert — for high-value Bash read/search shapes,
+  // advise jcodemunch INSTEAD of rewriting to rtk (Step 3). Suppressed turns
+  // (advise level) and silent level fall through to Step 3 so rtk still
+  // optimizes them; block level always fires (never suppressed, never calls
+  // shouldAdvise). Compound commands skip this step (same guard as Step 3).
+  if (tool === 'Bash' && typeof args.command === 'string' && !isCompoundCommand(args.command)) {
+    if (env.jcodemunchAvailable && env.jcodemunchCwdIndexed) {
+      const outlineBytes = config.rules.tool_routing?.jcodemunch_divert_outline_bytes ?? 8192;
+      const exists = resolvedOptions.existsCheck ?? ((p: string) => { try { return existsSync(p); } catch { return false; } });
+      const stat = resolvedOptions.statCheck ?? ((p: string) => { try { const s = statSync(p); return { size: s.size, isFile: s.isFile() }; } catch { return { size: 0, isFile: false }; } });
+      const decision = scoreJcodemunchValue(args.command, { existsCheck: exists, statCheck: stat, outlineBytes });
+      if (decision) {
+        const level = config.rules.tool_routing?.jcodemunch_divert ?? 'advise';
+        if (level !== 'silent') {
+          // Block always fires; advise respects the per-shape divert cycle.
+          const fire = level === 'block' || cache.shouldAdvise(`jm_divert:${decision.shape}`, DIVERT_READVISE_PERIOD);
+          if (fire) {
+            const prefix = level === 'block' ? '[BLOCK]' : '[ADVISE]';
+            const label = decision.shape === 'outline' ? 'big-file outline' : 'symbol search';
+            return {
+              level,
+              message: [
+                `${prefix} Tool Router: high-value jcodemunch opportunity (${label})`,
+                `advise: use ${decision.jmTool} — ${decision.reason}`,
+                level === 'block'
+                  ? 'This operation is blocked by .harness.yaml. Use the recommended tool instead.'
+                  : 'Consider using the recommended tool for better efficiency.',
+              ].join('\n'),
+            };
+          }
+        }
       }
     }
   }

--- a/src/router/jcodemunch-value.ts
+++ b/src/router/jcodemunch-value.ts
@@ -1,0 +1,78 @@
+import { extname } from 'node:path';
+
+/**
+ * File extensions whose contents jcodemunch can outline as code symbols.
+ * Non-code files (logs, markdown, configs) are left to rtk — an outline of
+ * them is not meaningfully better than the raw text.
+ */
+const CODE_EXTENSIONS = new Set<string>([
+  '.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.py', '.go', '.rs', '.java',
+  '.kt', '.scala', '.rb', '.php', '.cs', '.c', '.cc', '.cpp', '.h', '.hpp',
+  '.swift', '.vue', '.svelte', '.elixir', '.ex', '.exs', '.clj', '.cljs',
+  '.hs', '.ml', '.fs', '.dart', '.lua', '.pl', '.r', '.jl',
+]);
+
+export interface DivertDecision {
+  /** 'outline' = big-file structural read; 'symbol' = identifier search. */
+  shape: 'outline' | 'symbol';
+  /** The jcodemunch MCP tool to recommend, e.g. mcp__jcodemunch__get_file_outline. */
+  jmTool: string;
+  /** Human-readable rationale, embedded in the advisory message. */
+  reason: string;
+  /** The file path (outline) or search pattern (symbol) the decision targets. */
+  target: string;
+}
+
+export interface DivertOptions {
+  existsCheck: (p: string) => boolean;
+  statCheck: (p: string) => { size: number; isFile: boolean };
+  /** File-size threshold (bytes) above which a `cat` diverts to get_file_outline. */
+  outlineBytes: number;
+}
+
+/**
+ * Tokenize a command into the binary, non-flag positional args, and a flag set.
+ * Quote-naive (v1): a quoted path with spaces splits into multiple positionals,
+ * which safely suppresses a divert rather than mis-routing. See spec tradeoffs.
+ */
+function parse(command: string): { binary: string; positional: string[]; flags: Set<string> } {
+  const tokens = command.trim().split(/\s+/);
+  return {
+    binary: tokens[0] ?? '',
+    positional: tokens.slice(1).filter(t => !t.startsWith('-')),
+    flags: new Set(tokens.slice(1).filter(t => t.startsWith('-')).map(t => t.replace(/=.*$/, ''))),
+  };
+}
+
+/**
+ * Decide whether a Bash command is a high-value jcodemunch opportunity.
+ * Returns a DivertDecision for a recognized high-value shape, or null to let
+ * the caller fall through to rtk (Step 3 of the router).
+ *
+ * Shape A (big-file `cat` outline) is implemented here; Shape B (identifier
+ * grep/rg symbol search) is added alongside in a later task.
+ */
+export function scoreJcodemunchValue(command: string, opts: DivertOptions): DivertDecision | null {
+  const { binary, positional } = parse(command);
+
+  // Shape A — big-file structural read (`cat` only).
+  // `head`/`tail` are excluded: they imply the agent wants a slice (top/bottom),
+  // not the whole file, so the outline is not the better tool.
+  if (binary === 'cat') {
+    if (positional.length !== 1) return null; // multi-file cat → stay rtk
+    const target = positional[0];
+    if (!opts.existsCheck(target)) return null;
+    const stat = opts.statCheck(target);
+    if (!stat.isFile) return null;
+    if (!CODE_EXTENSIONS.has(extname(target))) return null;
+    if (stat.size <= opts.outlineBytes) return null;
+    return {
+      shape: 'outline',
+      jmTool: 'mcp__jcodemunch__get_file_outline',
+      target,
+      reason: `${target} is large; the outline gives its structure for far fewer tokens than reading the whole file (rtk would still return every line).`,
+    };
+  }
+
+  return null;
+}

--- a/src/router/jcodemunch-value.ts
+++ b/src/router/jcodemunch-value.ts
@@ -92,23 +92,34 @@ export function scoreJcodemunchValue(command: string, opts: DivertOptions): Dive
   // constants in favor of CamelCase / snake_case names search_symbols handles).
   if (binary === 'grep' || binary === 'rg' || binary === 'greprx') {
     if (flags.has('-l') || flags.has('--files-with-matches')) return null;
-    // Collect every pattern source: space form (-e P / --regexp P) and the
-    // attached `=` form (--regexp=P). Multiple patterns form an OR query that
-    // search_symbols can't express → stay rtk (no divert).
+    // One pass collects explicit pattern sources (-e / --regexp, including the
+    // `--regexp=PATTERN` form) and the remaining positional args, SKIPPING the
+    // values of value-taking flags (e.g. `rg --type ts PAT` — `ts` is the type,
+    // not the search pattern) so a flag value is never mistaken for the pattern.
+    const VALUE_FLAGS = new Set(['-A', '-B', '-C', '-m', '-M', '-g', '-t', '--type', '--glob', '--max-count', '--max-columns', '--ignore', '--ignore-file', '--before-context', '--after-context', '--context']);
     const tokens = command.trim().split(/\s+/);
     const patterns: string[] = [];
+    const positionalArgs: string[] = [];
     for (let i = 1; i < tokens.length; i++) {
       const t = tokens[i];
       if (t === '-e' || t === '--regexp') {
         const v = tokens[i + 1];
         if (v !== undefined && !v.startsWith('-')) patterns.push(v);
+        i++; // consume the value so it isn't also treated as positional
       } else if (t.startsWith('--regexp=')) {
         patterns.push(t.slice('--regexp='.length));
+      } else if (t.startsWith('--') && t.includes('=')) {
+        // other --flag=value (e.g. --include=*.ts): value is attached, not positional
+      } else if (t.startsWith('-')) {
+        if (VALUE_FLAGS.has(t)) i++; // skip this flag's value token
+      } else {
+        positionalArgs.push(t);
       }
     }
+    // Multiple explicit patterns = an OR query search_symbols can't express → rtk.
     const pattern = patterns.length === 1
       ? patterns[0]
-      : (patterns.length === 0 ? positional[0] : undefined);
+      : (patterns.length === 0 ? positionalArgs[0] : undefined);
     if (!pattern) return null;                        // multi-pattern OR, or none → rtk
     if (REGEX_METACHAR.test(pattern)) return null;    // regex/literal scan → rtk
     if (!IDENT.test(pattern)) return null;            // multi-token / phrase → rtk

--- a/src/router/jcodemunch-value.ts
+++ b/src/router/jcodemunch-value.ts
@@ -12,6 +12,11 @@ const CODE_EXTENSIONS = new Set<string>([
   '.hs', '.ml', '.fs', '.dart', '.lua', '.pl', '.r', '.jl',
 ]);
 
+/** A single identifier token (no spaces, no regex metacharacters). */
+const IDENT = /^[A-Za-z_][A-Za-z0-9_]*$/;
+/** Regex metacharacters — their presence means a literal/regex scan, not a symbol lookup. */
+const REGEX_METACHAR = /[.*+?^${}()|[\]\\/]/;
+
 export interface DivertDecision {
   /** 'outline' = big-file structural read; 'symbol' = identifier search. */
   shape: 'outline' | 'symbol';
@@ -40,7 +45,13 @@ function parse(command: string): { binary: string; positional: string[]; flags: 
   return {
     binary: tokens[0] ?? '',
     positional: tokens.slice(1).filter(t => !t.startsWith('-')),
-    flags: new Set(tokens.slice(1).filter(t => t.startsWith('-')).map(t => t.replace(/=.*$/, ''))),
+    // Long options keep their name (--foo, --foo=bar); short-option clusters
+    // like `-rl` decompose into `-r` and `-l` so individual flags are detectable.
+    flags: new Set(tokens.slice(1).flatMap(t => {
+      if (!t.startsWith('-')) return [];
+      if (t.startsWith('--')) return [t.replace(/=.*$/, '')];
+      return t.slice(1).split('').map(ch => '-' + ch);
+    })),
   };
 }
 
@@ -49,11 +60,11 @@ function parse(command: string): { binary: string; positional: string[]; flags: 
  * Returns a DivertDecision for a recognized high-value shape, or null to let
  * the caller fall through to rtk (Step 3 of the router).
  *
- * Shape A (big-file `cat` outline) is implemented here; Shape B (identifier
- * grep/rg symbol search) is added alongside in a later task.
+ * Shape A: big-file `cat` → get_file_outline.
+ * Shape B: single-identifier `grep`/`rg` → search_symbols.
  */
 export function scoreJcodemunchValue(command: string, opts: DivertOptions): DivertDecision | null {
-  const { binary, positional } = parse(command);
+  const { binary, positional, flags } = parse(command);
 
   // Shape A — big-file structural read (`cat` only).
   // `head`/`tail` are excluded: they imply the agent wants a slice (top/bottom),
@@ -71,6 +82,42 @@ export function scoreJcodemunchValue(command: string, opts: DivertOptions): Dive
       jmTool: 'mcp__jcodemunch__get_file_outline',
       target,
       reason: `${target} is large; the outline gives its structure for far fewer tokens than reading the whole file (rtk would still return every line).`,
+    };
+  }
+
+  // Shape B — symbol-shaped search (grep / rg, single identifier token).
+  // Diverts only when exactly one pattern is given and it looks like a real
+  // symbol name: identifier-shaped, no regex metacharacters, and containing a
+  // lowercase letter (filters all-caps literal-scan markers like TODO/FIXME and
+  // constants in favor of CamelCase / snake_case names search_symbols handles).
+  if (binary === 'grep' || binary === 'rg' || binary === 'greprx') {
+    if (flags.has('-l') || flags.has('--files-with-matches')) return null;
+    // Collect every pattern source: space form (-e P / --regexp P) and the
+    // attached `=` form (--regexp=P). Multiple patterns form an OR query that
+    // search_symbols can't express → stay rtk (no divert).
+    const tokens = command.trim().split(/\s+/);
+    const patterns: string[] = [];
+    for (let i = 1; i < tokens.length; i++) {
+      const t = tokens[i];
+      if (t === '-e' || t === '--regexp') {
+        const v = tokens[i + 1];
+        if (v !== undefined && !v.startsWith('-')) patterns.push(v);
+      } else if (t.startsWith('--regexp=')) {
+        patterns.push(t.slice('--regexp='.length));
+      }
+    }
+    const pattern = patterns.length === 1
+      ? patterns[0]
+      : (patterns.length === 0 ? positional[0] : undefined);
+    if (!pattern) return null;                        // multi-pattern OR, or none → rtk
+    if (REGEX_METACHAR.test(pattern)) return null;    // regex/literal scan → rtk
+    if (!IDENT.test(pattern)) return null;            // multi-token / phrase → rtk
+    if (!/[a-z]/.test(pattern)) return null;          // all-caps (TODO/FIXME/CONST) → rtk
+    return {
+      shape: 'symbol',
+      jmTool: 'mcp__jcodemunch__search_symbols',
+      target: pattern,
+      reason: `${pattern} looks like a symbol; mcp__jcodemunch__search_symbols ranks definitions/references better than a text grep.`,
     };
   }
 

--- a/src/router/jcodemunch-value.ts
+++ b/src/router/jcodemunch-value.ts
@@ -9,7 +9,7 @@ const CODE_EXTENSIONS = new Set<string>([
   '.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.py', '.go', '.rs', '.java',
   '.kt', '.scala', '.rb', '.php', '.cs', '.c', '.cc', '.cpp', '.h', '.hpp',
   '.swift', '.vue', '.svelte', '.elixir', '.ex', '.exs', '.clj', '.cljs',
-  '.hs', '.ml', '.fs', '.dart', '.lua', '.pl', '.r', '.jl',
+  '.hs', '.ml', '.fs', '.dart', '.lua', '.pl', '.r', '.jl', '.erl',
 ]);
 
 /** A single identifier token (no spaces, no regex metacharacters). */
@@ -90,7 +90,7 @@ export function scoreJcodemunchValue(command: string, opts: DivertOptions): Dive
   // symbol name: identifier-shaped, no regex metacharacters, and containing a
   // lowercase letter (filters all-caps literal-scan markers like TODO/FIXME and
   // constants in favor of CamelCase / snake_case names search_symbols handles).
-  if (binary === 'grep' || binary === 'rg' || binary === 'greprx') {
+  if (binary === 'grep' || binary === 'rg') {
     if (flags.has('-l') || flags.has('--files-with-matches')) return null;
     // One pass collects explicit pattern sources (-e / --regexp, including the
     // `--regexp=PATTERN` form) and the remaining positional args, SKIPPING the

--- a/src/session/cache.ts
+++ b/src/session/cache.ts
@@ -12,6 +12,14 @@ const ENV_TTL_MS = 4 * 60 * 60 * 1000; // 4 hours
  */
 export const ADVISORY_READVISE_PERIOD = 10;
 
+/**
+ * Divert advisory re-advisory cycle length. Divert advisories surface more
+ * often than generic ones (every 3rd suppressed vs every 10th) because a
+ * high-value jcodemunch opportunity is worth re-surfacing through a session.
+ * Callers pass this as the second arg to shouldAdvise().
+ */
+export const DIVERT_READVISE_PERIOD = 3;
+
 export function sessionCachePath(cwd: string, sessionId?: string): string {
   // Canonicalize the cwd so callers that pass an unresolved path (e.g. macOS
   // /var/folders/... which resolves to /private/var/folders/...) hash to the
@@ -244,7 +252,7 @@ export class SessionCache {
    * is already marked, whereas calling shouldAdvise() first would advance
    * the cycle on paths that never advise.
    */
-  shouldAdvise(intent: string): boolean {
+  shouldAdvise(intent: string, period: number = ADVISORY_READVISE_PERIOD): boolean {
     if (!this.advisedIntents.has(intent)) {
       // No counter seed needed: a missing key reads as 0 via `?? 0` below,
       // which is also the state markAdvised() leaves behind.
@@ -253,7 +261,7 @@ export class SessionCache {
       return true;
     }
     const suppressed = (this.advisorySuppressCounts.get(intent) ?? 0) + 1;
-    if (suppressed >= ADVISORY_READVISE_PERIOD) {
+    if (suppressed >= period) {
       // Final suppressed occurrence of the cycle — re-advise and restart.
       this.advisorySuppressCounts.set(intent, 0);
       this.save();

--- a/src/types.ts
+++ b/src/types.ts
@@ -214,6 +214,8 @@ export interface ToolRoutingRules {
   rtk_cat_code?: EnforcementLevel;
   scout_explore?: EnforcementLevel;
   read_line_threshold?: number;
+  jcodemunch_divert?: EnforcementLevel;
+  jcodemunch_divert_outline_bytes?: number;
 }
 
 export interface ConstitutionalRules {

--- a/tests/cli/init.test.ts
+++ b/tests/cli/init.test.ts
@@ -86,6 +86,8 @@ describe('initCommand', () => {
     expect(content).toContain('tool_routing');
     expect(content).toContain('constitutional');
     expect(content).toContain('stale_tests');
+    expect(content).toContain('jcodemunch_divert:');
+    expect(content).toContain('jcodemunch_divert_outline_bytes:');
   });
 
   it('creates graphify-out directory but no placeholder graph.json', async () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -27,6 +27,20 @@ describe('config', () => {
       expect(DEFAULT_CONFIG.rules.tool_routing.rtk_cat_code).toBe('block');
       expect(DEFAULT_CONFIG.rules.tool_routing.read_line_threshold).toBe(100);
     });
+
+    it('has jcodemunch divert config keys', () => {
+      expect(DEFAULT_CONFIG.rules.tool_routing.jcodemunch_divert).toBe('advise');
+      expect(DEFAULT_CONFIG.rules.tool_routing.jcodemunch_divert_outline_bytes).toBe(8192);
+    });
+  });
+
+  it('mergeConfigs preserves unspecified tool_routing keys (jcodemunch_divert)', () => {
+    const base = structuredClone(DEFAULT_CONFIG);
+    const override = structuredClone(DEFAULT_CONFIG);
+    override.rules.tool_routing.jcodemunch_divert = 'block';
+    const merged = mergeConfigs(base, override);
+    expect(merged.rules.tool_routing.jcodemunch_divert).toBe('block');
+    expect(merged.rules.tool_routing.jcodemunch_divert_outline_bytes).toBe(8192);
   });
 
   describe('loadConfig', () => {

--- a/tests/evals/grade.test.ts
+++ b/tests/evals/grade.test.ts
@@ -6,6 +6,8 @@ import {
   matchLoopOptIn,
   matchSectionsPresent,
   judgeNegative,
+  extractToolUseNames,
+  matchJcodemunchUsed,
 } from '../../evals/grade.js';
 
 const fx = (name: string) => readFileSync(join(process.cwd(), 'evals/fixtures', name), 'utf-8');
@@ -57,5 +59,32 @@ describe('grade: confined judge fallback (fail-closed)', () => {
   });
   it('accepts the natural "PASSED" wording', async () => {
     expect(await judgeNegative('...', async () => 'PASSED')).toBe(true);
+  });
+});
+
+describe('grade: tool-use extraction (jcodemunch-followed detection)', () => {
+  // Minimal stream-json: an assistant turn with a text block + a jcodemunch tool_use.
+  const jmTranscript = [
+    '{"type":"assistant","message":{"content":[{"type":"text","text":"Looking up the symbol..."},{"type":"tool_use","name":"mcp__jcodemunch__search_symbols","input":{"query":"routeRequest"}}]}}',
+    '{"type":"result","result":"found"}',
+  ].join('\n');
+  // Same shape but the agent fell back to raw Bash instead of following the divert.
+  const bashTranscript =
+    '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"grep -r routeRequest src/"}},{"type":"tool_use","name":"Read","input":{"file_path":"src/router.ts"}}]}}';
+
+  it('extracts tool_use names from assistant content blocks', () => {
+    expect(extractToolUseNames(jmTranscript)).toEqual(['mcp__jcodemunch__search_symbols']);
+  });
+  it('ignores text blocks and non-assistant lines', () => {
+    const names = extractToolUseNames(bashTranscript);
+    expect(names).toEqual(['Bash', 'Read']);
+    expect(names).not.toContain('mcp__jcodemunch__search_symbols');
+  });
+  it('matchJcodemunchUsed is true when a jcodemunch tool was invoked', () => {
+    expect(matchJcodemunchUsed(extractToolUseNames(jmTranscript))).toBe(true);
+  });
+  it('matchJcodemunchUsed is false when only non-jcodemunch tools ran', () => {
+    expect(matchJcodemunchUsed(extractToolUseNames(bashTranscript))).toBe(false);
+    expect(matchJcodemunchUsed([])).toBe(false);
   });
 });

--- a/tests/evals/runner.test.ts
+++ b/tests/evals/runner.test.ts
@@ -41,6 +41,31 @@ describe('runner: gradeTranscript dispatch by invariant', () => {
   });
 });
 
+describe('runner: jcodemunch-tool-used dispatch (divert-followed)', () => {
+  // Canned stream-json: an assistant turn whose tool calls are the grading surface.
+  const JM =
+    '{"type":"assistant","message":{"content":[{"type":"text","text":"Using indexed search."},' +
+    '{"type":"tool_use","name":"mcp__jcodemunch__search_symbols","input":{"query":"routeRequest"}}]}}';
+  const BASH =
+    '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"grep -r routeRequest ."}}]}}';
+
+  it('passes when the agent followed the divert (jcodemunch tool_use present)', async () => {
+    const r = await gradeTranscript(get('divert-jcodemunch-used'), JM, judgeAlways(true));
+    expect(r.pass).toBe(true);
+    expect(r.observed).toContain('search_symbols');
+  });
+  it('fails when the agent ignored the advisory (only raw Bash)', async () => {
+    const r = await gradeTranscript(get('divert-jcodemunch-used'), BASH, judgeAlways(true));
+    expect(r.pass).toBe(false);
+    expect(r.observed).toContain('no mcp__jcodemunch__');
+  });
+  it('the divert scenario is registered with its fixture code file', () => {
+    const s = get('divert-jcodemunch-used');
+    expect(s.invariants[0].kind).toBe('jcodemunch-tool-used');
+    expect(s.projectFiles?.some((f) => f.dest === 'src/router.ts')).toBe(true);
+  });
+});
+
 describe('runner: runScenario with injected driver', () => {
   it('runs N times and reduces by majority', async () => {
     const driveSession = vi.fn(async () => POS);

--- a/tests/evals/scenarios.test.ts
+++ b/tests/evals/scenarios.test.ts
@@ -4,9 +4,9 @@ import { join } from 'path';
 import { SCENARIOS } from '../../evals/scenarios.js';
 
 describe('scenarios: v1 set', () => {
-  it('defines the three v1 scenarios', () => {
+  it('defines the known v1 scenarios', () => {
     expect(SCENARIOS.map((s) => s.id).sort()).toEqual(
-      ['loop-fit-negative', 'loop-fit-positive', 'loop-optin-sections'],
+      ['divert-jcodemunch-used', 'loop-fit-negative', 'loop-fit-positive', 'loop-optin-sections'],
     );
   });
   it('each scenario resolves a brief file, a prompt, and >=1 invariant', () => {
@@ -14,6 +14,9 @@ describe('scenarios: v1 set', () => {
       expect(existsSync(join(process.cwd(), s.briefFile)), s.briefFile).toBe(true);
       expect(s.prompt.length).toBeGreaterThan(20);
       expect(s.invariants.length).toBeGreaterThanOrEqual(1);
+      for (const f of s.projectFiles ?? []) {
+        expect(existsSync(join(process.cwd(), f.src)), f.src).toBe(true);
+      }
     }
   });
   it('the negative scenario asserts opt-in ABSENCE', () => {

--- a/tests/evals/session-driver.test.ts
+++ b/tests/evals/session-driver.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { buildClaudeArgs, sessionFragmentOwnedBy } from '../../evals/session-driver.js';
+import { mkdtempSync, rmSync, readFileSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { buildClaudeArgs, sessionFragmentOwnedBy, materializeProjectFiles } from '../../evals/session-driver.js';
 
 describe('drive: claude args', () => {
   it('builds headless stream-json args with model and permission bypass', () => {
@@ -32,5 +35,33 @@ describe('drive: session-fragment ownership (data-loss guard)', () => {
   });
   it('fail-safe on malformed JSON (does not track)', () => {
     expect(sessionFragmentOwnedBy('{not json', [TEMP])).toBe(false);
+  });
+});
+
+describe('drive: materializeProjectFiles', () => {
+  it('copies fixture files into the temp project, creating parent dirs', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'rig-eval-files-'));
+    try {
+      materializeProjectFiles(dir, [
+        { dest: 'src/router.ts', src: 'evals/fixtures/divert-project/src/router.ts' },
+        { dest: 'BRIEF.md', src: 'evals/fixtures/divert-positive.md' },
+      ]);
+      expect(existsSync(join(dir, 'src/router.ts'))).toBe(true);
+      expect(existsSync(join(dir, 'BRIEF.md'))).toBe(true);
+      // Content is copied verbatim (the divert target symbol is present).
+      expect(readFileSync(join(dir, 'src/router.ts'), 'utf-8')).toContain('routeRequest');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('is a no-op for a scenario with no project files', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'rig-eval-empty-'));
+    try {
+      materializeProjectFiles(dir, []);
+      expect(existsSync(join(dir, 'src/router.ts'))).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/router/hook.test.ts
+++ b/tests/router/hook.test.ts
@@ -518,4 +518,78 @@ describe('handlePreToolUse test-scope check', () => {
     expect(msg(first)).toContain('TEST SCOPE');
     expect(msg(second)).toContain('TEST SCOPE');
   });
+
+  describe('jcodemunch divert (Step 2.5)', () => {
+    const bigExists = (p: string) => p === '/x/big.ts';
+    const bigStat = () => ({ size: 20000, isFile: true });
+    const jmEnv = () => makeEnv({ rtkAvailable: true, rtkPath: '/usr/bin/rtk', jcodemunchAvailable: true, jcodemunchCwdIndexed: true });
+
+    it('diverts a big cat to a jcodemunch advisory and does NOT reach rtk', () => {
+      cache.setEnvironment(jmEnv());
+      const rtkMustNotRun = (): never => { throw new Error('rtk execRewrite must not be called on a divert'); };
+      const result = handlePreToolUse('Bash', { command: 'cat /x/big.ts' }, cache, config, undefined, {
+        execRewrite: rtkMustNotRun, existsCheck: bigExists, statCheck: bigStat,
+      });
+      expect(result).toMatchObject({ level: 'advise' });
+      expect(msg(result)).toContain('mcp__jcodemunch__get_file_outline');
+      expect(msg(result)).toContain('big-file outline');
+    });
+
+    it('falls through to rtk on a suppressed divert turn', () => {
+      cache.setEnvironment(jmEnv());
+      const opts = { execRewrite: () => ({ command: 'rtk cat /x/big.ts', autoAllow: true }), existsCheck: bigExists, statCheck: bigStat };
+      expect(handlePreToolUse('Bash', { command: 'cat /x/big.ts' }, cache, config, undefined, opts)).toMatchObject({ level: 'advise' }); // 1st: divert
+      // 2nd + 3rd suppressed → rtk rewrite returned
+      for (let i = 0; i < 2; i++) {
+        expect(handlePreToolUse('Bash', { command: 'cat /x/big.ts' }, cache, config, undefined, opts)).toMatchObject({ type: 'rewrite' });
+      }
+    });
+
+    it('blocks at jcodemunch_divert: block', () => {
+      cache.setEnvironment(jmEnv());
+      config.rules.tool_routing.jcodemunch_divert = 'block';
+      const result = handlePreToolUse('Bash', { command: 'cat /x/big.ts' }, cache, config, undefined, { existsCheck: bigExists, statCheck: bigStat });
+      expect(result).toMatchObject({ level: 'block' });
+    });
+
+    it('block level is never suppressed (blocks on every call)', () => {
+      cache.setEnvironment(jmEnv());
+      config.rules.tool_routing.jcodemunch_divert = 'block';
+      const first = handlePreToolUse('Bash', { command: 'cat /x/big.ts' }, cache, config, undefined, { existsCheck: bigExists, statCheck: bigStat });
+      const second = handlePreToolUse('Bash', { command: 'cat /x/big.ts' }, cache, config, undefined, { existsCheck: bigExists, statCheck: bigStat });
+      expect(first).toMatchObject({ level: 'block' });
+      expect(second).toMatchObject({ level: 'block' });
+    });
+
+    it('falls through to rtk when jcodemunch_divert is silent', () => {
+      cache.setEnvironment(jmEnv());
+      config.rules.tool_routing.jcodemunch_divert = 'silent';
+      const result = handlePreToolUse('Bash', { command: 'cat /x/big.ts' }, cache, config, undefined, {
+        execRewrite: () => ({ command: 'rtk cat /x/big.ts', autoAllow: true }), existsCheck: bigExists, statCheck: bigStat,
+      });
+      expect(result).toMatchObject({ type: 'rewrite' });
+    });
+
+    it('does not divert when jcodemunch is not ready (rtk runs)', () => {
+      cache.setEnvironment(makeEnv({ rtkAvailable: true, rtkPath: '/usr/bin/rtk', jcodemunchAvailable: true, jcodemunchCwdIndexed: false }));
+      const result = handlePreToolUse('Bash', { command: 'cat /x/big.ts' }, cache, config, undefined, {
+        execRewrite: () => ({ command: 'rtk cat /x/big.ts', autoAllow: true }), existsCheck: bigExists, statCheck: bigStat,
+      });
+      expect(result).toMatchObject({ type: 'rewrite' });
+    });
+
+    it('does not divert a low-value grep (rtk runs)', () => {
+      cache.setEnvironment(jmEnv());
+      const result = handlePreToolUse('Bash', { command: 'grep -r TODO .' }, cache, config, undefined, {
+        execRewrite: () => ({ command: 'rtk grep TODO .', autoAllow: true }),
+      });
+      expect(result).toMatchObject({ type: 'rewrite' });
+    });
+
+    it('does not divert a compound command (Step 2.5 skipped → pass-through)', () => {
+      cache.setEnvironment(jmEnv());
+      const result = handlePreToolUse('Bash', { command: 'cat /x/big.ts && cat /y/big.ts' }, cache, config, undefined, { existsCheck: bigExists, statCheck: bigStat });
+      expect(result).toBeNull();
+    });
+  });
 });

--- a/tests/router/hook.test.ts
+++ b/tests/router/hook.test.ts
@@ -586,6 +586,17 @@ describe('handlePreToolUse test-scope check', () => {
       expect(result).toMatchObject({ type: 'rewrite' });
     });
 
+    it('diverts an identifier grep to search_symbols and does NOT reach rtk', () => {
+      cache.setEnvironment(jmEnv());
+      const rtkMustNotRun = (): never => { throw new Error('rtk execRewrite must not be called on a divert'); };
+      const result = handlePreToolUse('Bash', { command: 'grep -r calculateScore src/' }, cache, config, undefined, {
+        execRewrite: rtkMustNotRun, existsCheck: bigExists, statCheck: bigStat,
+      });
+      expect(result).toMatchObject({ level: 'advise' });
+      expect(msg(result)).toContain('mcp__jcodemunch__search_symbols');
+      expect(msg(result)).toContain('symbol search');
+    });
+
     it('does not divert a compound command (Step 2.5 skipped → pass-through)', () => {
       cache.setEnvironment(jmEnv());
       const result = handlePreToolUse('Bash', { command: 'cat /x/big.ts && cat /y/big.ts' }, cache, config, undefined, { existsCheck: bigExists, statCheck: bigStat });

--- a/tests/router/jcodemunch-value.test.ts
+++ b/tests/router/jcodemunch-value.test.ts
@@ -103,4 +103,13 @@ describe('scoreJcodemunchValue — Shape B (identifier grep symbol search)', () 
   it('does not divert multiple -e patterns (an OR query search_symbols cannot express)', () => {
     expect(scoreJcodemunchValue('grep -e Foo -e Bar baz.ts', opts())).toBeNull();
   });
+
+  it('does not mistake a value-taking flag value for the pattern (rg --type ts "export function")', () => {
+    // `ts` is the --type value, not the search pattern; the real pattern is a phrase.
+    expect(scoreJcodemunchValue('rg --type ts "export function"', opts())).toBeNull();
+  });
+
+  it('still diverts an identifier search that carries a --type/-t filter', () => {
+    expect(scoreJcodemunchValue('rg -t ts calculateScore src/', opts())).toMatchObject({ shape: 'symbol', target: 'calculateScore' });
+  });
 });

--- a/tests/router/jcodemunch-value.test.ts
+++ b/tests/router/jcodemunch-value.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { scoreJcodemunchValue } from '../../src/router/jcodemunch-value.js';
+
+const opts = (overrides: Partial<{ size: number; exists: boolean }> = {}) => ({
+  existsCheck: () => overrides.exists ?? true,
+  statCheck: () => ({ size: overrides.size ?? 20000, isFile: true }),
+  outlineBytes: 8192,
+});
+
+describe('scoreJcodemunchValue — Shape A (cat outline)', () => {
+  it('diverts a big cat of a code file to get_file_outline', () => {
+    const d = scoreJcodemunchValue('cat /x/src/big.ts', opts({ size: 20000 }));
+    expect(d).toMatchObject({ shape: 'outline', jmTool: 'mcp__jcodemunch__get_file_outline', target: '/x/src/big.ts' });
+  });
+
+  it('does not divert a file below the outline byte threshold', () => {
+    expect(scoreJcodemunchValue('cat /x/src/small.ts', opts({ size: 100 }))).toBeNull();
+  });
+
+  it('does not divert a non-code file extension', () => {
+    expect(scoreJcodemunchValue('cat /x/notes.md', opts({ size: 20000 }))).toBeNull();
+  });
+
+  it('does not divert a missing file', () => {
+    expect(scoreJcodemunchValue('cat /x/missing.ts', opts({ exists: false }))).toBeNull();
+  });
+
+  it('does not divert multi-file cat', () => {
+    expect(scoreJcodemunchValue('cat /x/a.ts /x/b.ts', opts({ size: 20000 }))).toBeNull();
+  });
+
+  it('does not divert head or tail (slice reads)', () => {
+    expect(scoreJcodemunchValue('head /x/big.ts', opts({ size: 20000 }))).toBeNull();
+    expect(scoreJcodemunchValue('tail -n 50 /x/big.ts', opts({ size: 20000 }))).toBeNull();
+  });
+
+  it('does not divert a sed -n range print', () => {
+    expect(scoreJcodemunchValue("sed -n '10,20p' /x/big.ts", opts({ size: 20000 }))).toBeNull();
+  });
+
+  it('returns null for unrelated commands', () => {
+    expect(scoreJcodemunchValue('find . -name "*.ts"', opts())).toBeNull();
+    expect(scoreJcodemunchValue('git status', opts())).toBeNull();
+  });
+
+  it('diverts cat -n (line-number flag does not change whole-file semantics)', () => {
+    expect(scoreJcodemunchValue('cat -n /x/big.ts', opts({ size: 20000 }))).toMatchObject({ shape: 'outline' });
+  });
+
+  it('does not divert at exactly the byte threshold (strict >)', () => {
+    expect(scoreJcodemunchValue('cat /x/big.ts', opts({ size: 8192 }))).toBeNull();
+  });
+
+  it('diverts one byte above the threshold', () => {
+    expect(scoreJcodemunchValue('cat /x/big.ts', opts({ size: 8193 }))).toMatchObject({ shape: 'outline' });
+  });
+
+  it('does not divert a quoted path with spaces (quote-naive parse — known v1 limitation)', () => {
+    expect(scoreJcodemunchValue('cat "src/my file.ts"', opts({ size: 20000 }))).toBeNull();
+  });
+});

--- a/tests/router/jcodemunch-value.test.ts
+++ b/tests/router/jcodemunch-value.test.ts
@@ -59,3 +59,48 @@ describe('scoreJcodemunchValue — Shape A (cat outline)', () => {
     expect(scoreJcodemunchValue('cat "src/my file.ts"', opts({ size: 20000 }))).toBeNull();
   });
 });
+
+describe('scoreJcodemunchValue — Shape B (identifier grep symbol search)', () => {
+  it('diverts a single-identifier grep to search_symbols', () => {
+    const d = scoreJcodemunchValue('grep -r calculateScore src/', opts());
+    expect(d).toMatchObject({ shape: 'symbol', jmTool: 'mcp__jcodemunch__search_symbols', target: 'calculateScore' });
+  });
+
+  it('still diverts with --word-regexp (-w)', () => {
+    expect(scoreJcodemunchValue('grep -rw FooBar .', opts())).toMatchObject({ shape: 'symbol' });
+  });
+
+  it('still diverts with rg and case-insensitive (-i)', () => {
+    expect(scoreJcodemunchValue('rg -i MyType src/', opts())).toMatchObject({ shape: 'symbol', target: 'MyType' });
+  });
+
+  it('diverts snake_case identifiers', () => {
+    expect(scoreJcodemunchValue('grep -r parse_header .', opts())).toMatchObject({ shape: 'symbol', target: 'parse_header' });
+  });
+
+  it('does not divert a regex pattern (contains metacharacters)', () => {
+    expect(scoreJcodemunchValue('grep "foo.bar" src/', opts())).toBeNull();
+    expect(scoreJcodemunchValue('grep -r "a|b" .', opts())).toBeNull();
+  });
+
+  it('does not divert a multi-token / quoted phrase pattern', () => {
+    expect(scoreJcodemunchValue('grep "some phrase" .', opts())).toBeNull();
+  });
+
+  it('does not divert all-caps literal-scan markers (TODO/FIXME) — no lowercase letter', () => {
+    expect(scoreJcodemunchValue('grep -r TODO .', opts())).toBeNull();
+    expect(scoreJcodemunchValue('grep -rn FIXME src/', opts())).toBeNull();
+  });
+
+  it('does not divert --files-with-matches (-l)', () => {
+    expect(scoreJcodemunchValue('grep -rl FooBar .', opts())).toBeNull();
+  });
+
+  it('diverts --regexp=PATTERN (the = form)', () => {
+    expect(scoreJcodemunchValue('grep --regexp=FooBar src/', opts())).toMatchObject({ shape: 'symbol', target: 'FooBar' });
+  });
+
+  it('does not divert multiple -e patterns (an OR query search_symbols cannot express)', () => {
+    expect(scoreJcodemunchValue('grep -e Foo -e Bar baz.ts', opts())).toBeNull();
+  });
+});

--- a/tests/session/cache.test.ts
+++ b/tests/session/cache.test.ts
@@ -198,6 +198,29 @@ describe('SessionCache', () => {
     });
   });
 
+  describe('shouldAdvise (divert period)', () => {
+    it('advises on the 1st call, suppresses 2-3, re-advises on the 4th when period=3', () => {
+      expect(cache.shouldAdvise('jm_divert:outline', 3)).toBe(true);   // 1
+      expect(cache.shouldAdvise('jm_divert:outline', 3)).toBe(false);  // 2
+      expect(cache.shouldAdvise('jm_divert:outline', 3)).toBe(false);  // 3
+      expect(cache.shouldAdvise('jm_divert:outline', 3)).toBe(true);   // 4 (re-advise)
+      expect(cache.shouldAdvise('jm_divert:outline', 3)).toBe(false);  // 5
+    });
+
+    it('keeps the default period at 10 when no period is passed', () => {
+      expect(cache.shouldAdvise('native_grep')).toBe(true);            // 1
+      for (let i = 0; i < 9; i++) expect(cache.shouldAdvise('native_grep')).toBe(false);
+      expect(cache.shouldAdvise('native_grep')).toBe(true);            // 11
+    });
+
+    it('tracks divert shape keys independently', () => {
+      expect(cache.shouldAdvise('jm_divert:outline', 3)).toBe(true);
+      expect(cache.shouldAdvise('jm_divert:symbol', 3)).toBe(true);    // independent first call
+      expect(cache.shouldAdvise('jm_divert:outline', 3)).toBe(false);
+      expect(cache.shouldAdvise('jm_divert:symbol', 3)).toBe(false);
+    });
+  });
+
   describe('updateStaleKey (stale-test advisory dedup)', () => {
     it('returns true on the first set and when the set changes, false when unchanged', () => {
       expect(cache.updateStaleKey('a')).toBe(true);   // first non-empty set


### PR DESCRIPTION
## Summary

Adds a router **Step 2.5 jcodemunch divert**: high-value Bash read/search commands divert to a jcodemunch advisory instead of being rewritten to rtk, so jcodemunch's indexed/symbol search actually participates in Bash-heavy sessions where rtk was silently short-circuiting every `grep`/`cat`.

## Why

A `debug+` trace showed `jcodemunch: 0 queries` session after session despite the tool being installed and indexed. Root cause: rtk transparently rewrites every Bash `grep`/`find`/`cat` and **short-circuits** (`src/router/hook.ts` Step 3) before the jcodemunch advisory (Step 5) can fire. The resolver also gives rtk strict priority over jcodemunch for the Bash intents. So jcodemunch was reachable only via the native Read/Grep/Glob tools (first-occurrence suppressed), which a Bash-heavy agent rarely touches. Detection and indexing are healthy — the agent just never reaches jcodemunch.

## What changed

- **`src/router/jcodemunch-value.ts`** (new) — pure heuristic `scoreJcodemunchValue(command, opts)`:
  - **Shape A**: big-file `cat` of a code file above `jcodemunch_divert_outline_bytes` (default 8192 B) → `mcp__jcodemunch__get_file_outline`. `head`/`tail`, multi-file, non-code, below-threshold, and quoted paths stay on rtk.
  - **Shape B**: single-identifier `grep`/`rg` → `mcp__jcodemunch__search_symbols`. Precision rules: must contain a lowercase letter (filters all-caps `TODO`/`FIXME`/constants), no regex metacharacters, not multi-`-e` (OR query), not `-l`. Handles `-e`/`--regexp` space + `--regexp=PATTERN` forms, skips value-taking flags (`--type`/`-t`/`-g`/`-A/-B/-C`…), and decomposes short-flag clusters (`-rl` → `-r`,`-l`).
- **`src/router/hook.ts`** — Step 2.5 between the python-rewrite and the rtk rewrite. Gate: `jcodemunchAvailable && jcodemunchCwdIndexed`. Level follows `tool_routing.jcodemunch_divert` (advise/block/silent); suppressed advise turns and silent fall through to rtk; block always fires (never calls `shouldAdvise`). Returns an `EnforcementViolation`, never a rewrite. `HookOptions` gains an injectable `statCheck`.
- **`src/session/cache.ts`** — `DIVERT_READVISE_PERIOD = 3` (shape-keyed: `jm_divert:outline`/`:symbol`); `shouldAdvise(intent, period = ADVISORY_READVISE_PERIOD)` is backward-compatible (existing callers keep the period-10 cycle).
- **`src/config.ts` + `src/types.ts`** — `tool_routing.jcodemunch_divert` (advise) and `jcodemunch_divert_outline_bytes` (8192); both optional + defaulted, auto-flow into the generated `.harness.yaml`.

## Live-model eval

New `divert-jcodemunch-used` scenario (the first to grade **tool-use structure** rather than assistant text): scaffolds a fixture TypeScript router, invites a symbol grep, and asserts the agent followed the advisory via an `mcp__jcodemunch__` tool_use. Harness gains `extractToolUseNames`/`matchJcodemunchUsed`, the `jcodemunch-tool-used` invariant, and `Scenario.projectFiles`. Unit-tested with canned transcripts; live run is operator-gated:

```
npm run eval -- --scenario divert-jcodemunch-used
```

## Design docs

Spec + plan under `docs/superpowers/`; Step 2.5 documented in `docs/architecture.md` (Layer 1 flow + note), `README.md`, and `evals/README.md`. Originated from `debug+` → `brain+` → `plan+` → `tdd+`; an independent review sub-agent verified spec conformance and returned **READY TO MERGE**.

## Testing

- `npm test`: **1413/1413** (was 1403; +10 harness tests).
- `npm run lint` (`tsc --noEmit`): clean. Coverage ~97%.
- `tests/eval/fuzzy-routing-eval.test.ts`: 100% at every fuzziness level — it caught the value-flag regression (`rg --type ts "export function"`) during development, now fixed.

## Release note

Contains `feat:` commits → release-please will open a release PR bumping **0.8.0 → 0.9.0** (minor) once this merges to `master`. No manual `package.json` edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
