### PR TITLE
docs: dependency-watch/implement automation — design, runbook, gotchas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,5 +63,6 @@ All types in `src/types.ts`. Important ones:
 - @docs/extending.md -- Custom enforcement checks, skills, and agents
 - @docs/skill-wrapping.md -- Wrapping superpowers skills with project-specific enforcement
 - @docs/agent-loops.md -- Loop-centric development: signal stack, opt-in trajectory, maintainer pattern
+- @docs/dependency-watch.md -- Agentic dependency watch/implement workflows, version manifest, gh-aw runbook
 - @docs/troubleshooting.md -- Diagnosing permission prompts, cache, and detection issues
 - @docs/design-process.md -- How rig was built (historical reference)

--- a/README.md
+++ b/README.md
@@ -325,7 +325,21 @@ npm test         # vitest, 1100+ tests (deterministic, model-independent)
 npm run build    # TypeScript compile
 npm run lint     # type-check only
 npm run eval     # behavioral evals — live claude -p runs (see below)
+npm run sync:versions  # regenerate README "Tested against" line from .github/dependency-versions.json
 ```
+
+### Dependency automation
+
+rig's own panel-tool dependencies (rtk, jcodemunch, graphify, headroom,
+superpowers) are watched by two [GitHub Agentic Workflows](https://github.github.com/gh-aw/):
+`dependency-watch` (weekly — probes upstream releases against the
+[version manifest](.github/dependency-versions.json) and files structured
+integration-analysis issues) and `dependency-implement` (`/implement` on
+such an issue — an approved agent run implements it and proposes a PR
+through gh-aw's validated safe-outputs pipeline). Humans keep the two
+gates that matter: run approval and PR merge. See
+[docs/dependency-watch.md](docs/dependency-watch.md) for the design and
+the runbook.
 
 ### Behavioral evals
 

--- a/docs/dependency-watch.md
+++ b/docs/dependency-watch.md
@@ -1,0 +1,122 @@
+# Dependency Watch & Implement
+
+rig's dependency automation: two GitHub Agentic Workflows (gh-aw) that
+detect upstream releases of the panel tools, analyze the integration
+impact, and implement approved integrations as proposed PRs — with a
+human at the two gates that matter (run approval and PR merge).
+
+This is the maintainer-agent trajectory from [agent-loops.md](agent-loops.md),
+materialized: the L1 external-contract signal (upstream releases) is
+watched continuously, and a graduated-autonomy agent acts on it.
+
+## The pieces
+
+| Piece | What it is |
+| ----- | ---------- |
+| `.github/dependency-versions.json` | Machine-checkable source of truth: one entry per panel tool (rtk, jcodemunch, graphify, headroom, superpowers) with `repo` coordinates, `testedVersion`, and integration `notes` |
+| `npm run sync:versions` | Regenerates the README "Tested against" line from the manifest (`scripts/sync-tested-versions.ts` over the pure module `src/dependency-versions.ts`). Never hand-edit the README line |
+| `.github/workflows/dependency-watch.md` | Weekly agentic workflow: probes upstream releases, files structured analysis issues |
+| `.github/workflows/dependency-implement.md` | Slash-command agentic workflow: `/implement` on an issue builds the change and proposes a PR |
+| `dependency-implement` GitHub environment | Required-reviewer approval gate every implement run passes before the agent starts |
+
+## dependency-watch (analysis -> issues)
+
+**Trigger:** fuzzy weekly schedule (`weekly on monday`) + manual dispatch.
+**Engine:** Claude engine against an Anthropic-compatible endpoint
+(`engine.env.ANTHROPIC_BASE_URL`, model passes through verbatim; the host
+must also be in `network.allowed` — engine defaults exempt only
+`api.anthropic.com`). **Writes:** `create-issue` safe-output only, labeled
+`dependency-update`, dedup by exact title, max 5 per run, hard
+`max-ai-credits` cap.
+
+Per release it files one issue with a fixed template — What changed
+(cited from release notes) / Breaking vs additive / Affected rig modules
+(cited file paths) / Proposed integration steps / Verification checklist
+(`npm test`, `npm run lint`, `npm run sync:versions`, operator-gated
+`npm run eval`). Releases inside a tested tilde range (e.g. `~1.108.x`)
+are skipped; quiet weeks emit `noop`, never placeholder issues.
+
+## dependency-implement (issues -> PRs)
+
+**Trigger:** a maintainer comments `/implement` on an issue (`roles:
+[admin, maintainer]`), then approves the run when the
+`dependency-implement` environment pings them.
+**Writes:** `create-pull-request` (label-gated to `dependency-update`
+issues) + `add-comment` back on the issue. Never merges, never closes
+issues, never pushes outside the safe-output pipeline.
+
+The agent executes the issue's checklist in the sandbox: `npm install` +
+build, manifest bump, `npm run sync:versions`, fixture updates. Zero-defect
+gate: the full suite must pass and the verbatim test summary goes in the
+PR body; two fix iterations max — a red suite produces a diagnosis comment
+on the issue, never a PR. `npm run eval` is deliberately not run
+(operator-gated, live model spend) and its checklist box stays unchecked.
+
+## Runbook
+
+### After a watch issue appears
+
+Review the analysis (especially the Breaking vs additive verdict and the
+affected-modules citations). Then either implement it yourself, or comment
+`/implement` and approve the environment ping.
+
+### If a run files a fallback issue instead of a PR
+
+gh-aw's safe-output pipeline can fall back to filing the *intended PR
+content as an issue* when the signed push is refused. Observed cause:
+the default `protected_files` policy (README.md is on the list; the
+top-level-dot-folder rule covers `.github/`) — and this workflow's job is
+editing exactly those files. The fix shipped in #83:
+
+```yaml
+safe-outputs:
+  create-pull-request:
+    protected-files:
+      policy: request_review
+      exclude:
+        - README.md
+        - .github/dependency-versions.json
+        - .github/   # prefix exclude opts out of the dot-folder rule
+```
+
+Diagnose any failure with the run's `safe_outputs` job log
+(`gh run view <id> --log`), or `gh aw audit <id>` for remediation YAML.
+
+### gh-aw knobs learned the hard way
+
+- `allowed-files` on `create-pull-request` is an **exclusive patch
+  allowlist** (every patched file must match), not a protection exemption.
+  Do not reach for it to bypass `protected_files`.
+- The firewall allowlist is baked into the lock file at compile time —
+  `network.allowed` needs literal hosts, and repo variables/secrets cannot
+  serve it. Engine env vars *can* use `${{ secrets.* }}` for keys.
+- `gh aw compile --approve` clears the compiler's security-review gate
+  after a human reviews new secrets/actions in the diff (the review note
+  belongs in the PR description).
+- The compiler suggests fuzzy schedules over fixed cron; adopt them.
+- gh-aw-generated `.github/skills/` is excluded from markdownlint
+  (compiler-managed, regenerated by `gh aw init`).
+
+### Local verification the sandbox cannot do
+
+The implement agent has no rtk/graphify/headroom binaries (they are not
+npm-distributable), so integration tests that need them self-skip. Before
+merging a deps PR, run the skipped contract tests on a machine with the
+new tool version on PATH — e.g.
+`npx vitest run tests/integration/rtk-contract.test.ts` — and check
+`/tmp/rig-rtk-rewrite-failures.log` for out-of-protocol rtk exits.
+
+## History
+
+- Phase 1 (#71): manifest + sync module + watch workflow. First run
+  filed four real issues (#73-#76) with cited, coupling-aware analysis.
+- Phase 2 (#77): implement workflow with approval environment.
+- Fix cycle (#80, #83): protected-files push refusal -> fallback issues
+  (#79, #82) -> correct `protected-files.exclude` knob. First successful
+  loop: rtk 0.46.0 -> #73 -> PR #85.
+
+## Related
+
+- [architecture.md](architecture.md) -- full system design
+- [agent-loops.md](agent-loops.md) -- the maintainer-agent trajectory this implements
+- [gh-aw documentation](https://github.github.com/gh-aw/) -- triggers, safe outputs, engines


### PR DESCRIPTION
Documents the dependency automation built in #71, #77, #80, #83 (loop proven end-to-end by #85):

- `docs/dependency-watch.md` — new: version manifest + `sync:versions` flow, both agentic workflows (triggers, guardrails, safe-outputs), the approval environment, the fallback-issue runbook (why the signed push gets refused and the correct `protected-files.exclude` knob), compile-time firewall invariants, sandbox limitation on non-npm tool contract tests, and a short history
- `CLAUDE.md` — docs list entry (Doc Reachability check)
- `README.md` — `sync:versions` in the Development commands + a Dependency automation subsection pointing at the doc

## Verification

- [x] `npm run lint:md` — 42 files, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)